### PR TITLE
[DRAFT]Custom evaluation frame

### DIFF
--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 use crate::{AuxTraceRandElements, FieldExtension};
@@ -254,6 +254,8 @@ impl MockAir {
 impl Air for MockAir {
     type BaseField = BaseElement;
     type PublicInputs = ();
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     fn new(trace_info: TraceInfo, _pub_inputs: (), _options: ProofOptions) -> Self {
         let num_assertions = trace_info.meta()[0] as usize;
@@ -279,7 +281,7 @@ impl Air for MockAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        _frame: &EvaluationFrame<E>,
+        _frame: &Self::Frame<E>,
         _periodic_values: &[E],
         _result: &mut [E],
     ) {

--- a/air/src/air/transition/frame.rs
+++ b/air/src/air/transition/frame.rs
@@ -3,54 +3,63 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{FieldElement, Vec};
+use super::{super::Air, FieldElement, Vec};
+use utils::TableReader;
 
-// EVALUATION FRAME
+// EVALUATION FRAME TRAIT
 // ================================================================================================
-/// A set of execution trace rows required for evaluation of transition constraints.
+/// Defines a frame for evaluation of transition constraints.
 ///
-/// In the current implementation, an evaluation frame always contains two consecutive rows of the
-/// execution trace. It is passed in as one of the parameters into
+/// It is passed in as one of the parameters into
 /// [Air::evaluate_transition()](crate::Air::evaluate_transition) function.
+pub trait EvaluationFrame<E: FieldElement> {
+    /// Creates an empty frame.
+    fn new<A: Air>(air: &A) -> Self;
+
+    /// Reads selected trace rows from the supplied data into the frame.
+    fn read_from<R: TableReader<E>>(&mut self, data: R, step: usize, offset: usize, blowup: usize);
+
+    /// Creates a new frame instantiated from the provided row-major list of 2 consecutive rows.
+    fn from_table(table: &[Vec<E>; 2]) -> Self;
+
+    /// Convert frame to a row-major list of 2 consecutive rows.
+    fn to_table(&self) -> [Vec<E>; 2];
+
+    /// Returns the current frame row.
+    fn current(&self) -> &[E];
+
+    /// Returns the next frame row.
+    fn next(&self) -> &[E];
+}
+
+/// Default implementation of the Evaluation Frame trait, which contains two consecutive rows of
+/// the execution trace.
 #[derive(Debug, Clone)]
-pub struct EvaluationFrame<E: FieldElement> {
+pub struct DefaultEvaluationFrame<E: FieldElement> {
     current: Vec<E>,
     next: Vec<E>,
 }
 
-impl<E: FieldElement> EvaluationFrame<E> {
+impl<E: FieldElement> EvaluationFrame<E> for DefaultEvaluationFrame<E> {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a new evaluation frame instantiated with the specified number of columns.
-    ///
-    /// # Panics
-    /// Panics if `num_columns` is zero.
-    pub fn new(num_columns: usize) -> Self {
-        assert!(
-            num_columns > 0,
-            "number of columns must be greater than zero"
-        );
-        EvaluationFrame {
-            current: E::zeroed_vector(num_columns),
-            next: E::zeroed_vector(num_columns),
+    /// Returns a new evaluation frame instantiated from an instance of AIR.
+    fn new<A: Air>(air: &A) -> Self {
+        let num_cols = air.trace_layout().main_trace_width();
+        DefaultEvaluationFrame {
+            current: E::zeroed_vector(num_cols),
+            next: E::zeroed_vector(num_cols),
         }
     }
 
-    /// Returns a new evaluation frame instantiated from the provided rows.
-    ///
-    /// # Panics
-    /// Panics if:
-    /// * Lengths of the provided rows are zero.
-    /// * Lengths of the provided rows are not the same.
-    pub fn from_rows(current: Vec<E>, next: Vec<E>) -> Self {
-        assert!(!current.is_empty(), "a row must contain at least one value");
-        assert_eq!(
-            current.len(),
-            next.len(),
-            "number of values in the rows must be the same"
-        );
-        Self { current, next }
+    /// Reads the values of current and next row from data.
+    fn read_from<R: TableReader<E>>(&mut self, data: R, step: usize, offset: usize, blowup: usize) {
+        let trace_len = data.num_rows();
+        for col_idx in 0..data.num_cols() {
+            self.current[col_idx + offset] = data.get(col_idx, step % trace_len);
+            self.next[col_idx + offset] = data.get(col_idx, (step + blowup) % trace_len);
+        }
     }
 
     // ROW ACCESSORS
@@ -58,20 +67,41 @@ impl<E: FieldElement> EvaluationFrame<E> {
 
     /// Returns a reference to the current row.
     #[inline(always)]
-    pub fn current(&self) -> &[E] {
+    fn current(&self) -> &[E] {
         &self.current
-    }
-
-    /// Returns a mutable reference to the current row.
-    #[inline(always)]
-    pub fn current_mut(&mut self) -> &mut [E] {
-        &mut self.current
     }
 
     /// Returns a reference to the next row.
     #[inline(always)]
-    pub fn next(&self) -> &[E] {
+    fn next(&self) -> &[E] {
         &self.next
+    }
+
+    /// Generates current and next row from the provided row-major list of 2 consecutive rows.
+    fn from_table(table: &[Vec<E>; 2]) -> Self {
+        Self {
+            current: table
+                .first()
+                .expect("Failed to fetch the first element")
+                .to_vec(),
+            next: table
+                .last()
+                .expect("Failed to fetch the last element")
+                .to_vec(),
+        }
+    }
+
+    /// Convert current and next row to a row-major list of 2 consecutive rows.
+    fn to_table(&self) -> [Vec<E>; 2] {
+        [self.current().to_vec(), self.next().to_vec()]
+    }
+}
+
+impl<E: FieldElement> DefaultEvaluationFrame<E> {
+    /// Returns a mutable reference to the current row.
+    #[inline(always)]
+    pub fn current_mut(&mut self) -> &mut [E] {
+        &mut self.current
     }
 
     /// Returns a mutable reference to the next row.

--- a/air/src/air/transition/mod.rs
+++ b/air/src/air/transition/mod.rs
@@ -6,7 +6,7 @@
 use super::{AirContext, BTreeMap, ConstraintDivisor, ExtensionOf, FieldElement, Vec};
 
 mod frame;
-pub use frame::EvaluationFrame;
+pub use frame::{DefaultEvaluationFrame, EvaluationFrame};
 
 mod degree;
 pub use degree::TransitionConstraintDegree;

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -45,6 +45,6 @@ mod air;
 pub use air::{
     Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint, BoundaryConstraintGroup,
     BoundaryConstraints, ConstraintCompositionCoefficients, ConstraintDivisor,
-    DeepCompositionCoefficients, EvaluationFrame, TraceInfo, TraceLayout,
+    DeepCompositionCoefficients, DefaultEvaluationFrame, EvaluationFrame, TraceInfo, TraceLayout,
     TransitionConstraintDegree, TransitionConstraintGroup, TransitionConstraints,
 };

--- a/air/src/proof/ood_frame.rs
+++ b/air/src/proof/ood_frame.rs
@@ -13,7 +13,7 @@ use utils::{
 // TYPE ALIASES
 // ================================================================================================
 
-type ParsedOodFrame<E> = (EvaluationFrame<E>, Option<EvaluationFrame<E>>, Vec<E>);
+type ParsedOodFrame<E, F1, F2> = (F1, Option<F2>, Vec<E>);
 
 // OUT-OF-DOMAIN FRAME
 // ================================================================================================
@@ -85,12 +85,12 @@ impl OodFrame {
     /// * A vector of evaluations specified by `num_evaluations` could not be parsed from the
     ///   internal bytes.
     /// * Any unconsumed bytes remained after the parsing was complete.
-    pub fn parse<E: FieldElement>(
+    pub fn parse<E: FieldElement, F1: EvaluationFrame<E>, F2: EvaluationFrame<E>>(
         self,
         main_trace_width: usize,
         aux_trace_width: usize,
         num_evaluations: usize,
-    ) -> Result<ParsedOodFrame<E>, DeserializationError> {
+    ) -> Result<ParsedOodFrame<E, F1, F2>, DeserializationError> {
         assert!(main_trace_width > 0, "trace width cannot be zero");
         assert!(num_evaluations > 0, "number of evaluations cannot be zero");
 
@@ -105,9 +105,9 @@ impl OodFrame {
         }
 
         // instantiate the frames from the parsed rows
-        let main_frame = EvaluationFrame::from_rows(current, next);
+        let main_frame = F1::from_table(&[current, next]);
         let aux_frame = if aux_trace_width > 0 {
-            Some(EvaluationFrame::from_rows(current_aux, next_aux))
+            Some(F2::from_table(&[current_aux, next_aux]))
         } else {
             None
         };

--- a/examples/src/fibonacci/fib2/air.rs
+++ b/examples/src/fibonacci/fib2/air.rs
@@ -6,7 +6,8 @@
 use super::{BaseElement, FieldElement, ProofOptions, TRACE_WIDTH};
 use crate::utils::are_equal;
 use winterfell::{
-    Air, AirContext, Assertion, EvaluationFrame, TraceInfo, TransitionConstraintDegree,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, EvaluationFrame, TraceInfo,
+    TransitionConstraintDegree,
 };
 
 // FIBONACCI AIR
@@ -20,6 +21,8 @@ pub struct FibAir {
 impl Air for FibAir {
     type BaseField = BaseElement;
     type PublicInputs = BaseElement;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -41,7 +44,7 @@ impl Air for FibAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/fibonacci/fib8/air.rs
+++ b/examples/src/fibonacci/fib8/air.rs
@@ -6,7 +6,7 @@
 use super::{BaseElement, FieldElement, TRACE_WIDTH};
 use crate::utils::are_equal;
 use winterfell::{
-    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -21,6 +21,8 @@ pub struct Fib8Air {
 impl Air for Fib8Air {
     type BaseField = BaseElement;
     type PublicInputs = BaseElement;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -42,7 +44,7 @@ impl Air for Fib8Air {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/fibonacci/fib_small/air.rs
+++ b/examples/src/fibonacci/fib_small/air.rs
@@ -6,7 +6,8 @@
 use super::{BaseElement, FieldElement, ProofOptions, TRACE_WIDTH};
 use crate::utils::are_equal;
 use winterfell::{
-    Air, AirContext, Assertion, EvaluationFrame, TraceInfo, TransitionConstraintDegree,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, EvaluationFrame, TraceInfo,
+    TransitionConstraintDegree,
 };
 
 // FIBONACCI AIR
@@ -20,6 +21,8 @@ pub struct FibSmall {
 impl Air for FibSmall {
     type BaseField = BaseElement;
     type PublicInputs = BaseElement;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -41,7 +44,7 @@ impl Air for FibSmall {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/fibonacci/mulfib2/air.rs
+++ b/examples/src/fibonacci/mulfib2/air.rs
@@ -6,7 +6,7 @@
 use crate::utils::are_equal;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -23,6 +23,8 @@ pub struct MulFib2Air {
 impl Air for MulFib2Air {
     type BaseField = BaseElement;
     type PublicInputs = BaseElement;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -44,7 +46,7 @@ impl Air for MulFib2Air {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/fibonacci/mulfib8/air.rs
+++ b/examples/src/fibonacci/mulfib8/air.rs
@@ -6,7 +6,7 @@
 use crate::utils::are_equal;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -23,6 +23,8 @@ pub struct MulFib8Air {
 impl Air for MulFib8Air {
     type BaseField = BaseElement;
     type PublicInputs = BaseElement;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -50,7 +52,7 @@ impl Air for MulFib8Air {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/lamport/aggregate/air.rs
+++ b/examples/src/lamport/aggregate/air.rs
@@ -9,8 +9,8 @@ use super::{
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, DefaultEvaluationFrame, EvaluationFrame, ProofOptions,
+    Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -42,6 +42,8 @@ pub struct LamportAggregateAir {
 impl Air for LamportAggregateAir {
     type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -94,7 +96,7 @@ impl Air for LamportAggregateAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -10,8 +10,8 @@ use super::{
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
     math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, DefaultEvaluationFrame, EvaluationFrame, ProofOptions,
+    Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -49,6 +49,8 @@ pub struct LamportThresholdAir {
 impl Air for LamportThresholdAir {
     type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -105,7 +107,7 @@ impl Air for LamportThresholdAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/merkle/air.rs
+++ b/examples/src/merkle/air.rs
@@ -6,8 +6,8 @@
 use super::{rescue, BaseElement, FieldElement, HASH_CYCLE_LEN, HASH_STATE_WIDTH, TRACE_WIDTH};
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, DefaultEvaluationFrame, EvaluationFrame, ProofOptions,
+    Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
 // MERKLE PATH VERIFICATION AIR
@@ -31,6 +31,8 @@ pub struct MerkleAir {
 impl Air for MerkleAir {
     type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -57,7 +59,7 @@ impl Air for MerkleAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/rescue/air.rs
+++ b/examples/src/rescue/air.rs
@@ -6,8 +6,8 @@
 use super::{rescue, BaseElement, FieldElement, ProofOptions, CYCLE_LENGTH, TRACE_WIDTH};
 use crate::utils::{are_equal, is_zero, not, EvaluationResult};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, DefaultEvaluationFrame, EvaluationFrame, Serializable,
+    TraceInfo, TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -57,6 +57,8 @@ pub struct RescueAir {
 impl Air for RescueAir {
     type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -81,7 +83,7 @@ impl Air for RescueAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/rescue_raps/air.rs
+++ b/examples/src/rescue_raps/air.rs
@@ -9,8 +9,8 @@ use super::{
 };
 use crate::utils::{are_equal, not, EvaluationResult};
 use winterfell::{
-    Air, AirContext, Assertion, AuxTraceRandElements, ByteWriter, EvaluationFrame, Serializable,
-    TraceInfo, TransitionConstraintDegree,
+    Air, AirContext, Assertion, AuxTraceRandElements, ByteWriter, DefaultEvaluationFrame,
+    EvaluationFrame, Serializable, TraceInfo, TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -57,6 +57,8 @@ pub struct RescueRapsAir {
 impl Air for RescueRapsAir {
     type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -88,7 +90,7 @@ impl Air for RescueRapsAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         periodic_values: &[E],
         result: &mut [E],
     ) {
@@ -154,8 +156,8 @@ impl Air for RescueRapsAir {
 
     fn evaluate_aux_transition<F, E>(
         &self,
-        main_frame: &EvaluationFrame<F>,
-        aux_frame: &EvaluationFrame<E>,
+        main_frame: &Self::Frame<F>,
+        aux_frame: &Self::AuxFrame<E>,
         periodic_values: &[F],
         aux_rand_elements: &AuxTraceRandElements<E>,
         result: &mut [E],

--- a/examples/src/rescue_raps/custom_trace_table.rs
+++ b/examples/src/rescue_raps/custom_trace_table.rs
@@ -6,7 +6,7 @@
 use core_utils::{collections::Vec, uninit_vector};
 use winterfell::{
     math::{log2, FieldElement, StarkField},
-    EvaluationFrame, Matrix, Trace, TraceInfo, TraceLayout,
+    Matrix, Trace, TraceInfo, TraceLayout,
 };
 
 // RAP TRACE TABLE
@@ -174,12 +174,6 @@ impl<B: StarkField> Trace for RapTraceTable<B> {
 
     fn meta(&self) -> &[u8] {
         &self.meta
-    }
-
-    fn read_main_frame(&self, row_idx: usize, frame: &mut EvaluationFrame<Self::BaseField>) {
-        let next_row_idx = (row_idx + 1) % self.length();
-        self.trace.read_row_into(row_idx, frame.current_mut());
-        self.trace.read_row_into(next_row_idx, frame.next_mut());
     }
 
     fn main_segment(&self) -> &Matrix<B> {

--- a/examples/src/vdf/exempt/air.rs
+++ b/examples/src/vdf/exempt/air.rs
@@ -5,8 +5,8 @@
 
 use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, DefaultEvaluationFrame, EvaluationFrame, Serializable,
+    TraceInfo, TransitionConstraintDegree,
 };
 
 // PUBLIC INPUTS
@@ -37,6 +37,8 @@ pub struct VdfAir {
 impl Air for VdfAir {
     type BaseField = BaseElement;
     type PublicInputs = VdfInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     fn new(trace_info: TraceInfo, pub_inputs: VdfInputs, options: ProofOptions) -> Self {
         let degrees = vec![TransitionConstraintDegree::new(3)];
@@ -53,7 +55,7 @@ impl Air for VdfAir {
 
     fn evaluate_transition<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/examples/src/vdf/regular/air.rs
+++ b/examples/src/vdf/regular/air.rs
@@ -5,8 +5,8 @@
 
 use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, ByteWriter, DefaultEvaluationFrame, EvaluationFrame, Serializable,
+    TraceInfo, TransitionConstraintDegree,
 };
 
 // PUBLIC INPUTS
@@ -37,6 +37,8 @@ pub struct VdfAir {
 impl Air for VdfAir {
     type BaseField = BaseElement;
     type PublicInputs = VdfInputs;
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     fn new(trace_info: TraceInfo, pub_inputs: VdfInputs, options: ProofOptions) -> Self {
         let degrees = vec![TransitionConstraintDegree::new(3)];
@@ -49,7 +51,7 @@ impl Air for VdfAir {
 
     fn evaluate_transition<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
-        frame: &EvaluationFrame<E>,
+        frame: &Self::Frame<E>,
         _periodic_values: &[E],
         result: &mut [E],
     ) {

--- a/prover/src/constraints/evaluator.rs
+++ b/prover/src/constraints/evaluator.rs
@@ -144,7 +144,7 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> ConstraintEvaluator<
         fragment: &mut EvaluationTableFragment<E>,
     ) {
         // initialize buffers to hold trace values and evaluation results at each step;
-        let mut main_frame = EvaluationFrame::new(trace.main_trace_width());
+        let mut main_frame = A::Frame::new(self.air);
         let mut evaluations = vec![E::ZERO; fragment.num_columns()];
         let mut t_evaluations = vec![E::BaseField::ZERO; self.num_main_transition_constraints()];
 
@@ -199,8 +199,8 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> ConstraintEvaluator<
         fragment: &mut EvaluationTableFragment<E>,
     ) {
         // initialize buffers to hold trace values and evaluation results at each step
-        let mut main_frame = EvaluationFrame::new(trace.main_trace_width());
-        let mut aux_frame = EvaluationFrame::new(trace.aux_trace_width());
+        let mut main_frame = A::Frame::new(self.air);
+        let mut aux_frame = A::AuxFrame::new(self.air);
         let mut tm_evaluations = vec![E::BaseField::ZERO; self.num_main_transition_constraints()];
         let mut ta_evaluations = vec![E::ZERO; self.num_aux_transition_constraints()];
         let mut evaluations = vec![E::ZERO; fragment.num_columns()];
@@ -263,7 +263,7 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> ConstraintEvaluator<
     #[rustfmt::skip]
     fn evaluate_main_transition(
         &self,
-        main_frame: &EvaluationFrame<E::BaseField>,
+        main_frame: &A::Frame<E::BaseField>,
         x: E::BaseField,
         step: usize,
         evaluations: &mut [E::BaseField],
@@ -293,8 +293,8 @@ impl<'a, A: Air, E: FieldElement<BaseField = A::BaseField>> ConstraintEvaluator<
     #[rustfmt::skip]
     fn evaluate_aux_transition(
         &self,
-        main_frame: &EvaluationFrame<E::BaseField>,
-        aux_frame: &EvaluationFrame<E>,
+        main_frame: &A::Frame<E::BaseField>,
+        aux_frame: &A::AuxFrame<E>,
         x: E::BaseField,
         step: usize,
         evaluations: &mut [E],

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -46,8 +46,8 @@ extern crate alloc;
 pub use air::{
     proof::StarkProof, Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint,
     BoundaryConstraintGroup, ConstraintCompositionCoefficients, ConstraintDivisor,
-    DeepCompositionCoefficients, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
-    TraceLayout, TransitionConstraintDegree, TransitionConstraintGroup,
+    DeepCompositionCoefficients, DefaultEvaluationFrame, EvaluationFrame, FieldExtension,
+    ProofOptions, TraceInfo, TraceLayout, TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use utils::{
     iterators, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,

--- a/prover/src/matrix.rs
+++ b/prover/src/matrix.rs
@@ -2,7 +2,7 @@ use super::StarkDomain;
 use core::{iter::FusedIterator, slice};
 use crypto::{ElementHasher, MerkleTree};
 use math::{fft, polynom, FieldElement};
-use utils::{batch_iter_mut, collections::Vec, iter, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, collections::Vec, iter, iter_mut, uninit_vector, TableReader};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;
@@ -24,7 +24,7 @@ use utils::iterators::*;
 /// - Number of rows must be a power of two.
 #[derive(Debug, Clone)]
 pub struct Matrix<E: FieldElement> {
-    columns: Vec<Vec<E>>,
+    pub columns: Vec<Vec<E>>,
 }
 
 impl<E: FieldElement> Matrix<E> {
@@ -97,7 +97,7 @@ impl<E: FieldElement> Matrix<E> {
         &self.columns[col_idx]
     }
 
-    /// Returns a reference to the column at the specified index.
+    /// Returns a mutable reference to the column at the specified index.
     pub fn get_column_mut(&mut self, col_idx: usize) -> &mut [E] {
         &mut self.columns[col_idx]
     }
@@ -253,6 +253,19 @@ impl<E: FieldElement> Matrix<E> {
     /// TODO: replace this with an iterator.
     pub fn into_columns(self) -> Vec<Vec<E>> {
         self.columns
+    }
+}
+
+impl<E: FieldElement> TableReader<E> for &Matrix<E> {
+    fn num_cols(&self) -> usize {
+        Matrix::num_cols(self)
+    }
+    fn num_rows(&self) -> usize {
+        Matrix::num_rows(self)
+    }
+
+    fn get(&self, col_idx: usize, row_idx: usize) -> E {
+        self.columns[col_idx][row_idx]
     }
 }
 

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::TraceTable;
 use air::{
-    Air, AirContext, Assertion, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
+    Air, AirContext, Assertion, DefaultEvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 use math::{fields::f128::BaseElement, FieldElement, StarkField};
@@ -73,6 +73,8 @@ impl MockAir {
 impl Air for MockAir {
     type BaseField = BaseElement;
     type PublicInputs = ();
+    type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+    type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 
     fn new(trace_info: TraceInfo, _pub_inputs: (), _options: ProofOptions) -> Self {
         let context = build_context(trace_info, 8, 1);
@@ -89,7 +91,7 @@ impl Air for MockAir {
 
     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
-        _frame: &EvaluationFrame<E>,
+        _frame: &Self::Frame<E>,
         _periodic_values: &[E],
         _result: &mut [E],
     ) {

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{matrix::MultiColumnIter, Matrix};
+use super::Matrix;
 use air::{Air, AuxTraceRandElements, EvaluationFrame, TraceInfo, TraceLayout};
 use math::{polynom, FieldElement, StarkField};
 
@@ -71,9 +71,6 @@ pub trait Trace: Sized {
         aux_segments: &[Matrix<E>],
         rand_elements: &[E],
     ) -> Option<Matrix<E>>;
-
-    /// Reads an evaluation frame from the main trace segment at the specified row.
-    fn read_main_frame(&self, row_idx: usize, frame: &mut EvaluationFrame<Self::BaseField>);
 
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
@@ -167,9 +164,9 @@ pub trait Trace: Sized {
 
         // initialize buffers to hold evaluation frames and results of constraint evaluations
         let mut x = Self::BaseField::ONE;
-        let mut main_frame = EvaluationFrame::new(self.main_trace_width());
+        let mut main_frame = A::Frame::new(air);
         let mut aux_frame = if air.trace_info().is_multi_segment() {
-            Some(EvaluationFrame::<E>::new(self.aux_trace_width()))
+            Some(A::AuxFrame::<E>::new(air))
         } else {
             None
         };
@@ -189,7 +186,7 @@ pub trait Trace: Sized {
 
             // evaluate transition constraints for the main trace segment and make sure they all
             // evaluate to zeros
-            self.read_main_frame(step, &mut main_frame);
+            main_frame.read_from(self.main_segment(), step, 0, 1);
             air.evaluate_transition(&main_frame, &periodic_values, &mut main_evaluations);
             for (i, &evaluation) in main_evaluations.iter().enumerate() {
                 assert!(
@@ -203,7 +200,11 @@ pub trait Trace: Sized {
             // evaluate transition constraints for auxiliary trace segments (if any) and make
             // sure they all evaluate to zeros
             if let Some(ref mut aux_frame) = aux_frame {
-                read_aux_frame(aux_segments, step, aux_frame);
+                let mut offset = 0;
+                for aux_segment in aux_segments {
+                    aux_frame.read_from(aux_segment, step, offset, 1);
+                    offset += aux_segment.num_cols();
+                }
                 air.evaluate_aux_transition(
                     &main_frame,
                     aux_frame,
@@ -224,28 +225,5 @@ pub trait Trace: Sized {
             // update x coordinate of the domain
             x *= g;
         }
-    }
-}
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-/// Reads an evaluation frame from the set of provided auxiliary segments. This expects that
-/// `aux_segments` contains at least one entry.
-///
-/// This is probably not the most efficient implementation, but since we call this function only
-/// for trace validation purposes (which is done in debug mode only), we don't care all that much
-/// about its performance.
-fn read_aux_frame<E>(aux_segments: &[Matrix<E>], row_idx: usize, frame: &mut EvaluationFrame<E>)
-where
-    E: FieldElement,
-{
-    for (column, current_value) in MultiColumnIter::new(aux_segments).zip(frame.current_mut()) {
-        *current_value = column[row_idx];
-    }
-
-    let next_row_idx = (row_idx + 1) % aux_segments[0].num_rows();
-    for (column, next_value) in MultiColumnIter::new(aux_segments).zip(frame.next_mut()) {
-        *next_value = column[next_row_idx];
     }
 }

--- a/prover/src/trace/poly_table.rs
+++ b/prover/src/trace/poly_table.rs
@@ -93,6 +93,6 @@ impl<E: FieldElement> TracePolyTable<E> {
     /// Returns a polynomial from the main segment of the trace at the specified index.
     #[cfg(test)]
     pub fn get_main_trace_poly(&self, idx: usize) -> &[E::BaseField] {
-        &self.main_segment_polys.get_column(idx)
+        self.main_segment_polys.get_column(idx)
     }
 }

--- a/prover/src/trace/trace_lde.rs
+++ b/prover/src/trace/trace_lde.rs
@@ -68,31 +68,21 @@ impl<E: FieldElement> TraceLde<E> {
     }
 
     /// Reads current and next rows from the main trace segment into the specified frame.
-    pub fn read_main_trace_frame_into(
+    pub fn read_main_trace_frame_into<F: EvaluationFrame<E::BaseField>>(
         &self,
         lde_step: usize,
-        frame: &mut EvaluationFrame<E::BaseField>,
+        frame: &mut F,
     ) {
-        // at the end of the trace, next state wraps around and we read the first step again
-        let next_lde_step = (lde_step + self.blowup()) % self.trace_len();
-
         // copy main trace segment values into the frame
-        self.main_segment_lde
-            .read_row_into(lde_step, frame.current_mut());
-        self.main_segment_lde
-            .read_row_into(next_lde_step, frame.next_mut());
+        frame.read_from(&self.main_segment_lde, lde_step, 0, self.blowup());
     }
 
     /// Reads current and next rows from the auxiliary trace segment into the specified frame.
-    pub fn read_aux_trace_frame_into(&self, lde_step: usize, frame: &mut EvaluationFrame<E>) {
-        // at the end of the trace, next state wraps around and we read the first step again
-        let next_lde_step = (lde_step + self.blowup()) % self.trace_len();
-
+    pub fn read_aux_trace_frame_into<F: EvaluationFrame<E>>(&self, lde_step: usize, frame: &mut F) {
         //copy auxiliary trace segment values into the frame
         let mut offset = 0;
         for segment in self.aux_segment_ldes.iter() {
-            segment.read_row_into(lde_step, &mut frame.current_mut()[offset..]);
-            segment.read_row_into(next_lde_step, &mut frame.next_mut()[offset..]);
+            frame.read_from(segment, lde_step, offset, self.blowup());
             offset += segment.num_cols();
         }
     }

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{Matrix, Trace};
-use air::{EvaluationFrame, TraceInfo, TraceLayout};
+use air::{TraceInfo, TraceLayout};
 use math::{log2, FieldElement, StarkField};
 use utils::{collections::Vec, uninit_vector};
 
@@ -358,12 +358,6 @@ impl<B: StarkField> Trace for TraceTable<B> {
 
     fn meta(&self) -> &[u8] {
         &self.meta
-    }
-
-    fn read_main_frame(&self, row_idx: usize, frame: &mut EvaluationFrame<Self::BaseField>) {
-        let next_row_idx = (row_idx + 1) % self.length();
-        self.trace.read_row_into(row_idx, frame.current_mut());
-        self.trace.read_row_into(next_row_idx, frame.next_mut());
     }
 
     fn main_segment(&self) -> &Matrix<B> {

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -645,3 +645,10 @@ impl Randomizable for u8 {
         Some(source[0])
     }
 }
+
+pub trait TableReader<E> {
+    fn num_cols(&self) -> usize;
+    fn num_rows(&self) -> usize;
+
+    fn get(&self, col_idx: usize, row_idx: usize) -> E;
+}

--- a/verifier/src/composer.rs
+++ b/verifier/src/composer.rs
@@ -58,12 +58,12 @@ impl<E: FieldElement> DeepComposer<E> {
     ///
     /// Note that values of T_i(z) and T_i(z * g) are received from the prover and passed into
     /// this function via the `ood_frame` parameter.
-    pub fn compose_trace_columns(
+    pub fn compose_trace_columns<F1: EvaluationFrame<E>, F2: EvaluationFrame<E>>(
         &self,
         queried_main_trace_states: Table<E::BaseField>,
         queried_aux_trace_states: Option<Table<E>>,
-        ood_main_frame: EvaluationFrame<E>,
-        ood_aux_frame: Option<EvaluationFrame<E>>,
+        ood_main_frame: F1,
+        ood_aux_frame: Option<F2>,
     ) -> Vec<E> {
         let ood_main_trace_states = [ood_main_frame.current(), ood_main_frame.next()];
 
@@ -73,7 +73,7 @@ impl<E: FieldElement> DeepComposer<E> {
         let conjugate_values =
             get_conjugate_values(self.field_extension, ood_main_trace_states[0], self.z[0]);
 
-        // compose columns of of the main trace segment
+        // compose columns of the main trace segment
         let mut result = E::zeroed_vector(queried_main_trace_states.num_rows());
         for ((result, row), &x) in result
             .iter_mut()
@@ -142,7 +142,7 @@ impl<E: FieldElement> DeepComposer<E> {
     ///   all i, where cc_i is the coefficient for the random linear combination drawn from the
     ///   public coin.
     ///
-    /// Note that values of H_i(z^m)are received from teh prover and passed into this function
+    /// Note that values of H_i(z^m)are received from the prover and passed into this function
     /// via the `ood_evaluations` parameter.
     pub fn compose_constraint_evaluations(
         &self,

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -14,8 +14,8 @@ use utils::collections::Vec;
 pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
     air: &A,
     composition_coefficients: ConstraintCompositionCoefficients<E>,
-    main_trace_frame: &EvaluationFrame<E>,
-    aux_trace_frame: &Option<EvaluationFrame<E>>,
+    main_trace_frame: &A::Frame<E>,
+    aux_trace_frame: &Option<A::AuxFrame<E>>,
     aux_rand_elements: AuxTraceRandElements<E>,
     x: E,
 ) -> E {

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -128,7 +128,7 @@ pub fn verify<AIR: Air, HashFn: ElementHasher<BaseField = AIR::BaseField>>(
 /// attests to a correct execution of the computation specified by the provided `air`.
 fn perform_verification<A, E, H>(
     air: A,
-    mut channel: VerifierChannel<E, H>,
+    mut channel: VerifierChannel<E, H, A::Frame<E>, A::AuxFrame<E>>,
     mut public_coin: RandomCoin<A::BaseField, H>,
 ) -> Result<(), VerifierError>
 where

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -151,7 +151,7 @@
 //! use winterfell::{
 //!     math::{fields::f128::BaseElement, FieldElement},
 //!     Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable,
-//!     TraceInfo, TransitionConstraintDegree, crypto::hashers::Blake3_256,
+//!     TraceInfo, TransitionConstraintDegree, crypto::hashers::Blake3_256, DefaultEvaluationFrame,
 //! };
 //!
 //! // Public inputs for our computation will consist of the starting value and the end result.
@@ -182,6 +182,8 @@
 //!     // the public inputs must look like.
 //!     type BaseField = BaseElement;
 //!     type PublicInputs = PublicInputs;
+//!     type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+//!     type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 //!
 //!     // Here, we'll construct a new instance of our computation which is defined by 3
 //!     // parameters: starting value, number of steps, and the end result. Another way to
@@ -216,7 +218,7 @@
 //!     // value. The `frame` parameter will contain current and next states of the computation.
 //!     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
 //!         &self,
-//!         frame: &EvaluationFrame<E>,
+//!         frame: &Self::Frame<E>,
 //!         _periodic_values: &[E],
 //!         result: &mut [E],
 //!     ) {
@@ -262,7 +264,7 @@
 //!
 //! # use winterfell::{
 //! #   Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
-//! #   TraceInfo, TransitionConstraintDegree,
+//! #   TraceInfo, TransitionConstraintDegree, DefaultEvaluationFrame,
 //! # };
 //! #
 //! # pub struct PublicInputs {
@@ -286,6 +288,8 @@
 //! # impl Air for WorkAir {
 //! #     type BaseField = BaseElement;
 //! #     type PublicInputs = PublicInputs;
+//! #     type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+//! #     type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 //! #
 //! #     fn new(trace_info: TraceInfo, pub_inputs: PublicInputs, options: ProofOptions) -> Self {
 //! #         assert_eq!(1, trace_info.width());
@@ -299,7 +303,7 @@
 //! #
 //! #     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
 //! #         &self,
-//! #         frame: &EvaluationFrame<E>,
+//! #         frame: &Self::Frame<E>,
 //! #         _periodic_values: &[E],
 //! #         result: &mut [E],
 //! #     ) {
@@ -370,6 +374,7 @@
 //! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
 //! #    TraceInfo, TransitionConstraintDegree, TraceTable, FieldExtension,
 //! #    Prover, ProofOptions, StarkProof, Trace, crypto::hashers::Blake3_256,
+//! #    DefaultEvaluationFrame,
 //! # };
 //! #
 //! # pub fn build_do_work_trace(start: BaseElement, n: usize) -> TraceTable<BaseElement> {
@@ -408,6 +413,8 @@
 //! # impl Air for WorkAir {
 //! #     type BaseField = BaseElement;
 //! #     type PublicInputs = PublicInputs;
+//! #     type Frame<E: FieldElement> = DefaultEvaluationFrame<E>;
+//! #     type AuxFrame<E: FieldElement> = DefaultEvaluationFrame<E>;
 //! #
 //! #     fn new(trace_info: TraceInfo, pub_inputs: PublicInputs, options: ProofOptions) -> Self {
 //! #         assert_eq!(1, trace_info.width());
@@ -421,7 +428,7 @@
 //! #
 //! #     fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
 //! #         &self,
-//! #         frame: &EvaluationFrame<E>,
+//! #         frame: &Self::Frame<E>,
 //! #         _periodic_values: &[E],
 //! #         result: &mut [E],
 //! #     ) {
@@ -529,9 +536,9 @@
 pub use prover::{
     crypto, iterators, math, Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint,
     BoundaryConstraintGroup, ByteReader, ByteWriter, ConstraintCompositionCoefficients,
-    ConstraintDivisor, DeepCompositionCoefficients, Deserializable, DeserializationError,
-    EvaluationFrame, FieldExtension, Matrix, ProofOptions, Prover, ProverError, Serializable,
-    SliceReader, StarkProof, Trace, TraceInfo, TraceLayout, TraceTable, TraceTableFragment,
-    TransitionConstraintDegree, TransitionConstraintGroup,
+    ConstraintDivisor, DeepCompositionCoefficients, DefaultEvaluationFrame, Deserializable,
+    DeserializationError, EvaluationFrame, FieldExtension, Matrix, ProofOptions, Prover,
+    ProverError, Serializable, SliceReader, StarkProof, Trace, TraceInfo, TraceLayout, TraceTable,
+    TraceTableFragment, TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use verifier::{verify, VerifierError};


### PR DESCRIPTION
This PR continues the work done in PR #91 and partially addresses #80. This PR defines an evaluation frame trait with a 2-row consecutive frame instead of a multi-row frame. The latter will be tackled in future PRs.