### PR TITLE
New FftInputs trait

### DIFF
--- a/math/src/fft/fft_inputs.rs
+++ b/math/src/fft/fft_inputs.rs
@@ -1,0 +1,81 @@
+use super::StarkField;
+use crate::FieldElement;
+
+// FFTINPUTS TRAIT
+// ================================================================================================
+
+/// Defines the interface that must be implemented by the input to fft_in_place method.
+pub trait FftInputs<B: StarkField> {
+    /// Returns the number of elements in this input.
+    fn len(&self) -> usize;
+
+    /// Combines the result of smaller number theoretic transform into a larger NTT.
+    fn butterfly(&mut self, offset: usize, stride: usize);
+
+    /// Combines the result of smaller number theoretic transform multiplied with a
+    /// twiddle factor into a larger NTT.
+    fn butterfly_twiddle(&mut self, twiddle: B, offset: usize, stride: usize);
+
+    /// Swaps the element at index i with the element at index j.
+    fn swap(&mut self, i: usize, j: usize);
+
+    /// Multiplies every element in this input by a series of increment. Specifically:
+    ///
+    /// elem_i = elem_i * offset * increment^i
+    fn shift_by_series(&mut self, offset: B, increment: B);
+
+    /// Multiplies every element in this input by `offset`. Specifically:
+    ///
+    /// elem_i = elem_i * offset
+    fn shift_by(&mut self, offset: B);
+}
+
+/// Implements FftInputs for a slice of field elements.
+impl<B, E> FftInputs<B> for [E]
+where
+    B: StarkField,
+    E: FieldElement<BaseField = B>,
+{
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline(always)]
+    fn butterfly(&mut self, offset: usize, stride: usize) {
+        let i = offset;
+        let j = offset + stride;
+        let temp = self[i];
+        self[i] = temp + self[j];
+        self[j] = temp - self[j];
+    }
+
+    #[inline(always)]
+    fn butterfly_twiddle(&mut self, twiddle: B, offset: usize, stride: usize) {
+        let i = offset;
+        let j = offset + stride;
+        let temp = self[i];
+        self[j] = self[j].mul_base(twiddle);
+        self[i] = temp + self[j];
+        self[j] = temp - self[j];
+    }
+
+    fn swap(&mut self, i: usize, j: usize) {
+        self.swap(i, j)
+    }
+
+    fn shift_by_series(&mut self, offset: E::BaseField, increment: E::BaseField) {
+        let mut offset = E::from(offset);
+        let increment = E::from(increment);
+        for d in self.iter_mut() {
+            *d *= offset;
+            offset *= increment;
+        }
+    }
+
+    fn shift_by(&mut self, offset: E::BaseField) {
+        let offset = E::from(offset);
+        for d in self.iter_mut() {
+            *d *= offset;
+        }
+    }
+}

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -435,8 +435,8 @@ where
         "multiplicative subgroup of size {} does not exist in the specified base field",
         values.len()
     );
-    FftInputs::fft_in_place(values, twiddles);
-    FftInputs::permute(values);
+    values.fft_in_place(twiddles);
+    values.permute();
 }
 
 // TWIDDLES

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -12,6 +12,7 @@
 //! `n` is the domain size.
 
 use crate::{
+    fft::fft_inputs::FftInputs,
     field::{FieldElement, StarkField},
     utils::{get_power_series, log2},
 };
@@ -434,8 +435,8 @@ where
         "multiplicative subgroup of size {} does not exist in the specified base field",
         values.len()
     );
-    serial::fft_in_place(values, twiddles, 1, 1, 0);
-    serial::permute(values);
+    FftInputs::fft_in_place(values, twiddles);
+    FftInputs::permute(values);
 }
 
 // TWIDDLES
@@ -590,7 +591,7 @@ fn permute<E: FieldElement>(v: &mut [E]) {
         #[cfg(feature = "concurrent")]
         concurrent::permute(v);
     } else {
-        serial::permute(v);
+        FftInputs::permute(v);
     }
 }
 

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::{get_power_series, log2},
 };
 
+mod fft_inputs;
 mod serial;
 
 #[cfg(feature = "concurrent")]

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -17,8 +17,8 @@ where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    FftInputs::fft_in_place(p, twiddles);
-    FftInputs::permute(p);
+    p.fft_in_place(twiddles);
+    p.permute();
 }
 
 /// Evaluates polynomial `p` over the domain of length `p.len()` * `blowup_factor` shifted by
@@ -49,10 +49,10 @@ where
                 *d = (*c).mul_base(factor);
                 factor *= offset;
             }
-            FftInputs::fft_in_place(chunk, twiddles);
+            chunk.fft_in_place(twiddles);
         });
 
-    FftInputs::permute(result.as_mut_slice());
+    result.permute();
     result
 }
 
@@ -67,9 +67,9 @@ where
     E: FieldElement<BaseField = B>,
 {
     let inv_length = B::inv((evaluations.len() as u64).into());
-    FftInputs::fft_in_place(evaluations, inv_twiddles);
-    FftInputs::shift_by(evaluations, inv_length);
-    FftInputs::permute(evaluations);
+    evaluations.fft_in_place(inv_twiddles);
+    evaluations.shift_by(inv_length);
+    evaluations.permute();
 }
 
 /// Interpolates `evaluations` over a domain of length `evaluations.len()` and shifted by
@@ -83,11 +83,11 @@ pub fn interpolate_poly_with_offset<B, E>(
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    FftInputs::fft_in_place(evaluations, inv_twiddles);
-    FftInputs::permute(evaluations);
+    evaluations.fft_in_place(inv_twiddles);
+    evaluations.permute();
 
     let domain_offset = B::inv(domain_offset);
     let offset = B::inv((evaluations.len() as u64).into());
 
-    FftInputs::shift_by_series(evaluations, offset, domain_offset);
+    evaluations.shift_by_series(offset, domain_offset);
 }

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -7,10 +7,6 @@ use super::fft_inputs::FftInputs;
 use crate::{field::StarkField, utils::log2, FieldElement};
 use utils::{collections::Vec, uninit_vector};
 
-// CONSTANTS
-// ================================================================================================
-const MAX_LOOP: usize = 256;
-
 // POLYNOMIAL EVALUATION
 // ================================================================================================
 
@@ -21,8 +17,8 @@ where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    fft_in_place(p, twiddles, 1, 1, 0);
-    permute(p);
+    FftInputs::fft_in_place(p, twiddles);
+    FftInputs::permute(p);
 }
 
 /// Evaluates polynomial `p` over the domain of length `p.len()` * `blowup_factor` shifted by
@@ -53,10 +49,10 @@ where
                 *d = (*c).mul_base(factor);
                 factor *= offset;
             }
-            fft_in_place(chunk, twiddles, 1, 1, 0);
+            FftInputs::fft_in_place(chunk, twiddles);
         });
 
-    permute(result.as_mut_slice());
+    FftInputs::permute(result.as_mut_slice());
     result
 }
 
@@ -70,12 +66,10 @@ where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    fft_in_place(evaluations, inv_twiddles, 1, 1, 0);
     let inv_length = B::inv((evaluations.len() as u64).into());
-
-    // Use fftinputs shift_by on evaluations.
+    FftInputs::fft_in_place(evaluations, inv_twiddles);
     FftInputs::shift_by(evaluations, inv_length);
-    permute(evaluations);
+    FftInputs::permute(evaluations);
 }
 
 /// Interpolates `evaluations` over a domain of length `evaluations.len()` and shifted by
@@ -89,76 +83,11 @@ pub fn interpolate_poly_with_offset<B, E>(
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    fft_in_place(evaluations, inv_twiddles, 1, 1, 0);
-    permute(evaluations);
+    FftInputs::fft_in_place(evaluations, inv_twiddles);
+    FftInputs::permute(evaluations);
 
     let domain_offset = B::inv(domain_offset);
     let offset = B::inv((evaluations.len() as u64).into());
 
-    // Use fftinputs's shift_by_series on evaluations.
     FftInputs::shift_by_series(evaluations, offset, domain_offset);
-}
-
-// PERMUTATIONS
-// ================================================================================================
-
-pub fn permute<B, I>(values: &mut I)
-where
-    B: StarkField,
-    I: FftInputs<B> + ?Sized,
-{
-    let n = values.len();
-    for i in 0..n {
-        let j = super::permute_index(n, i);
-        if j > i {
-            values.swap(i, j);
-        }
-    }
-}
-
-// CORE FFT ALGORITHM
-// ================================================================================================
-
-/// In-place recursive FFT with permuted output.
-///
-/// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
-pub(super) fn fft_in_place<B, I>(
-    values: &mut I,
-    twiddles: &[B],
-    count: usize,
-    stride: usize,
-    offset: usize,
-) where
-    B: StarkField,
-    I: FftInputs<B> + ?Sized,
-{
-    let size = values.len() / stride;
-    debug_assert!(size.is_power_of_two());
-    debug_assert!(offset < stride);
-    debug_assert_eq!(values.len() % size, 0);
-
-    // Keep recursing until size is 2
-    if size > 2 {
-        if stride == count && count < MAX_LOOP {
-            fft_in_place(values, twiddles, 2 * count, 2 * stride, offset);
-        } else {
-            fft_in_place(values, twiddles, count, 2 * stride, offset);
-            fft_in_place(values, twiddles, count, 2 * stride, offset + stride);
-        }
-    }
-
-    for offset in offset..(offset + count) {
-        I::butterfly(values, offset, stride);
-    }
-
-    let last_offset = offset + size * stride;
-    for (i, offset) in (offset..last_offset)
-        .step_by(2 * stride)
-        .enumerate()
-        .skip(1)
-    {
-        for j in offset..(offset + count) {
-            I::butterfly_twiddle(values, twiddles[i], j, stride);
-        }
-    }
 }

--- a/math/src/fft/tests.rs
+++ b/math/src/fft/tests.rs
@@ -23,8 +23,8 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let expected = polynom::eval_many(&p, &domain);
     let twiddles = super::get_twiddles::<BaseElement>(n);
-    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
-    super::permute(&mut p);
+    p.fft_in_place(&twiddles);
+    p.permute();
     assert_eq!(expected, p);
 
     // degree 7
@@ -33,8 +33,8 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let twiddles = super::get_twiddles::<BaseElement>(n);
     let expected = polynom::eval_many(&p, &domain);
-    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
-    super::permute(&mut p);
+    p.fft_in_place(&twiddles);
+    p.permute();
     assert_eq!(expected, p);
 
     // degree 15
@@ -43,8 +43,8 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let twiddles = super::get_twiddles::<BaseElement>(16);
     let expected = polynom::eval_many(&p, &domain);
-    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
-    super::permute(&mut p);
+    p.fft_in_place(&twiddles);
+    p.permute();
     assert_eq!(expected, p);
 
     // degree 1023
@@ -53,8 +53,8 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let expected = polynom::eval_many(&p, &domain);
     let twiddles = super::get_twiddles::<BaseElement>(n);
-    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
-    super::permute(&mut p);
+    p.fft_in_place(&twiddles);
+    p.permute();
     assert_eq!(expected, p);
 }
 
@@ -64,7 +64,7 @@ fn fft_get_twiddles() {
     let g = BaseElement::get_root_of_unity(log2(n));
 
     let mut expected = get_power_series(g, n / 2);
-    super::permute(&mut expected);
+    expected.permute();
 
     let twiddles = super::get_twiddles::<BaseElement>(n);
     assert_eq!(expected, twiddles);

--- a/math/src/fft/tests.rs
+++ b/math/src/fft/tests.rs
@@ -22,7 +22,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let expected = polynom::eval_many(&p, &domain);
     let twiddles = super::get_twiddles::<BaseElement>(n);
-    super::serial::fft_in_place(&mut p, &twiddles, 1, 1, 0);
+    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
     super::permute(&mut p);
     assert_eq!(expected, p);
 
@@ -32,7 +32,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let twiddles = super::get_twiddles::<BaseElement>(n);
     let expected = polynom::eval_many(&p, &domain);
-    super::serial::fft_in_place(&mut p, &twiddles, 1, 1, 0);
+    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
     super::permute(&mut p);
     assert_eq!(expected, p);
 
@@ -42,7 +42,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let twiddles = super::get_twiddles::<BaseElement>(16);
     let expected = polynom::eval_many(&p, &domain);
-    super::serial::fft_in_place(&mut p, &twiddles, 1, 1, 0);
+    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
     super::permute(&mut p);
     assert_eq!(expected, p);
 
@@ -52,7 +52,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let expected = polynom::eval_many(&p, &domain);
     let twiddles = super::get_twiddles::<BaseElement>(n);
-    super::serial::fft_in_place(&mut p, &twiddles, 1, 1, 0);
+    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
     super::permute(&mut p);
     assert_eq!(expected, p);
 }

--- a/math/src/fft/tests.rs
+++ b/math/src/fft/tests.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
+    fft::fft_inputs::FftInputs,
     field::{f128::BaseElement, StarkField},
     polynom,
     utils::{get_power_series, log2},
@@ -22,7 +23,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let expected = polynom::eval_many(&p, &domain);
     let twiddles = super::get_twiddles::<BaseElement>(n);
-    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
+    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
     super::permute(&mut p);
     assert_eq!(expected, p);
 
@@ -32,7 +33,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let twiddles = super::get_twiddles::<BaseElement>(n);
     let expected = polynom::eval_many(&p, &domain);
-    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
+    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
     super::permute(&mut p);
     assert_eq!(expected, p);
 
@@ -42,7 +43,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let twiddles = super::get_twiddles::<BaseElement>(16);
     let expected = polynom::eval_many(&p, &domain);
-    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
+    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
     super::permute(&mut p);
     assert_eq!(expected, p);
 
@@ -52,7 +53,7 @@ fn fft_in_place() {
     let domain = build_domain(n);
     let expected = polynom::eval_many(&p, &domain);
     let twiddles = super::get_twiddles::<BaseElement>(n);
-    super::serial::fft_in_place(p.as_mut_slice(), &twiddles, 1, 1, 0);
+    FftInputs::fft_in_place(p.as_mut_slice(), &twiddles);
     super::permute(&mut p);
     assert_eq!(expected, p);
 }


### PR DESCRIPTION
This PR partly addresses #93. It introduces a `FftInput` trait in the `maths` crate, which defines the shape of the input for the FFT computation. This trait is implemented on `[E]`in this PR.