### PR TITLE
Fix concurrent fft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     types: [opened, repoened, synchronize]
 
 jobs:
+  check:
+    name: Check with all features
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features
+
   test:
     name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
     runs-on: ${{matrix.os}}-latest

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -141,7 +141,7 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
     // apply inner FFTs
     values
         .par_chunks_mut(outer_len)
-        .for_each(|row| super::serial::fft_in_place(row, &twiddles, stretch, stretch, 0));
+        .for_each(|row| super::fft_inputs::fft_in_place(row, &twiddles, stretch, stretch, 0));
 
     // transpose inner x inner x stretch square matrix
     transpose_square_stretch(values, inner_len, stretch);
@@ -160,7 +160,7 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
                     outer_twiddle = outer_twiddle * inner_twiddle;
                 }
             }
-            super::serial::fft_in_place(row, &twiddles, 1, 1, 0)
+            super::fft_inputs::fft_in_place(row, &twiddles, 1, 1, 0)
         });
 }
 

--- a/math/src/fft/fft_inputs.rs
+++ b/math/src/fft/fft_inputs.rs
@@ -125,8 +125,13 @@ where
 /// In-place recursive FFT with permuted output.
 ///
 /// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
-fn fft_in_place<B, I>(values: &mut I, twiddles: &[B], count: usize, stride: usize, offset: usize)
-where
+pub(super) fn fft_in_place<B, I>(
+    values: &mut I,
+    twiddles: &[B],
+    count: usize,
+    stride: usize,
+    offset: usize,
+) where
     B: StarkField,
     I: FftInputs<B> + ?Sized,
 {


### PR DESCRIPTION
This PR fixes build with `concurrent` feature.
@irakliyk I have included a new CI job checking that we can build with all features activated, to prevent this kind of issue happening in the future. It is only checking the compilation, should it run tests as well instead?

closes #131 