### PR TITLE
Add exp_vartime method for FieldElement trait

### DIFF
--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -235,7 +235,7 @@ where
         let folding_roots = (0..N)
             .map(|i| {
                 self.domain_generator
-                    .exp(((self.domain_size / N * i) as u64).into())
+                    .exp_vartime(((self.domain_size / N * i) as u64).into())
             })
             .collect::<Vec<_>>();
 
@@ -270,7 +270,7 @@ where
             // build a set of x coordinates for each row polynomial
             #[rustfmt::skip]
             let xs = folded_positions.iter().map(|&i| {
-                let xe = domain_generator.exp((i as u64).into()) * self.options.domain_offset();
+                let xe = domain_generator.exp_vartime((i as u64).into()) * self.options.domain_offset();
                 folding_roots.iter()
                     .map(|&r| E::from(xe * r))
                     .collect::<Vec<_>>().try_into().unwrap()
@@ -297,7 +297,7 @@ where
             }
 
             // update variables for the next iteration of the loop
-            domain_generator = domain_generator.exp((N as u32).into());
+            domain_generator = domain_generator.exp_vartime((N as u32).into());
             max_degree_plus_1 /= N;
             domain_size /= N;
             mem::swap(&mut positions, &mut folded_positions);

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -114,6 +114,13 @@ pub trait FieldElement:
     /// Exponentiates this field element by `power` parameter.
     #[must_use]
     fn exp(self, power: Self::PositiveInteger) -> Self {
+        self.exp_vartime(power)
+    }
+
+    /// Exponentiates this field element by `power` parameter.
+    /// This function is expressly variable time, to speed-up verifier computations.
+    #[must_use]
+    fn exp_vartime(self, power: Self::PositiveInteger) -> Self {
         let mut r = Self::ONE;
         let mut b = self;
         let mut p = power;

--- a/verifier/src/composer.rs
+++ b/verifier/src/composer.rs
@@ -30,7 +30,7 @@ impl<E: FieldElement> DeepComposer<E> {
         let domain_offset = air.domain_offset();
         let x_coordinates: Vec<E> = query_positions
             .iter()
-            .map(|&p| E::from(g_lde.exp((p as u64).into()) * domain_offset))
+            .map(|&p| E::from(g_lde.exp_vartime((p as u64).into()) * domain_offset))
             .collect();
 
         DeepComposer {
@@ -155,7 +155,7 @@ impl<E: FieldElement> DeepComposer<E> {
 
         // compute z^m
         let num_evaluation_columns = ood_evaluations.len() as u32;
-        let z_m = self.z[0].exp(num_evaluation_columns.into());
+        let z_m = self.z[0].exp_vartime(num_evaluation_columns.into());
 
         for (query_values, &x) in queried_evaluations.rows().zip(&self.x_coordinates) {
             let mut composition = E::ZERO;

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -30,7 +30,7 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
         .iter()
         .map(|poly| {
             let num_cycles = air.trace_length() / poly.len();
-            let x = x.exp((num_cycles as u32).into());
+            let x = x.exp_vartime((num_cycles as u32).into());
             polynom::eval(poly, x)
         })
         .collect::<Vec<_>>();
@@ -64,7 +64,7 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
 
     // cache power of x here so that we only re-compute it when degree_adjustment changes
     let mut degree_adjustment = b_constraints.main_constraints()[0].degree_adjustment();
-    let mut xp = x.exp(degree_adjustment.into());
+    let mut xp = x.exp_vartime(degree_adjustment.into());
 
     // iterate over boundary constraint groups for the main trace segment (each group has a
     // distinct divisor), evaluate constraints in each group and add their combination to the
@@ -74,7 +74,7 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
         // previous value; otherwise, compute new `xp`
         if group.degree_adjustment() != degree_adjustment {
             degree_adjustment = group.degree_adjustment();
-            xp = x.exp(degree_adjustment.into());
+            xp = x.exp_vartime(degree_adjustment.into());
         }
         // evaluate all constraints in the group, and add the evaluation to the result
         result += group.evaluate_at(main_trace_frame.current(), x, xp);
@@ -89,7 +89,7 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
             // previous value; otherwise, compute new `xp`
             if group.degree_adjustment() != degree_adjustment {
                 degree_adjustment = group.degree_adjustment();
-                xp = x.exp(degree_adjustment.into());
+                xp = x.exp_vartime(degree_adjustment.into());
             }
             // evaluate all constraints in the group, and add the evaluation to the result
             result += group.evaluate_at(aux_trace_frame.current(), x, xp);

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -220,7 +220,7 @@ where
         .iter()
         .enumerate()
         .fold(E::ZERO, |result, (i, &value)| {
-            result + z.exp((i as u32).into()) * value
+            result + z.exp_vartime((i as u32).into()) * value
         });
     public_coin.reseed(H::hash_elements(&ood_constraint_evaluations));
 


### PR DESCRIPTION
Add `exp_vartime` method to the `FieldElement` trait to speed-up verifier exponentiations.
This is currently useful only for `f64` which implements by default constant-time operations (`exp_vartime` there is about 40% faster than its constant-time counterpart), but could be useful if we were to implement constant-time operations by default for all other supported fields.
For the fib-small example over f64, the verifier speed-up is measured at around 8% on my machine.