### PR TITLE
`ProofOptions` Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ Now, we are finally ready to generate a STARK proof. The function below, will ex
 ```Rust
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    FieldExtension, HashFunction, ProofOptions, StarkProof,
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, HashFunction, ProofOptions, ProofOptionError, StarkProof,
 };
 
-pub fn prove_work() -> (BaseElement, StarkProof) {
+pub fn prove_work() -> Result<(BaseElement, StarkProof), ProofOptionError> {
     // We'll just hard-code the parameters here for this example.
     let start = BaseElement::new(3);
     let n = 1_048_576;
@@ -296,18 +296,18 @@ pub fn prove_work() -> (BaseElement, StarkProof) {
     // Define proof options; these will be enough for ~96-bit security level.
     let options = ProofOptions::new(
         32, // number of queries
-        8,  // blowup factor
+        BlowupFactor::Third,  // blowup factor
         0,  // grinding factor
         FieldExtension::None,
-        8,   // FRI folding factor
-        128, // FRI max remainder length
-    );
+        FriFoldingFactor::Third,   // FRI folding factor
+        FriMaximumRemainderSize::Fourth, // FRI max remainder length
+    )?;
 
     // Instantiate the prover and generate the proof.
     let prover = WorkProver::new(options);
     let proof = prover.prove(trace).unwrap();
 
-    (result, proof)
+    Ok((result, proof))
 }
 ```
 

--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -7,7 +7,9 @@ use super::{
     Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
-use crate::{AuxTraceRandElements, FieldExtension};
+use crate::{
+    AuxTraceRandElements, BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize,
+};
 use crypto::{hashers::Blake3_256, RandomCoin};
 use math::{fields::f128::BaseElement, get_power_series, log2, polynom, FieldElement, StarkField};
 use utils::collections::{BTreeMap, Vec};
@@ -234,7 +236,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::with_meta(4, trace_length, vec![1]),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.periodic_columns = column_values;
         result
@@ -244,7 +254,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::with_meta(4, trace_length, vec![assertions.len() as u8]),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.assertions = assertions;
         result
@@ -294,7 +312,15 @@ pub fn build_context<B: StarkField>(
     trace_width: usize,
     num_assertions: usize,
 ) -> AirContext<B> {
-    let options = ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        BlowupFactor::Third,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
     let t_degrees = vec![TransitionConstraintDegree::new(2)];
     let trace_info = TraceInfo::new(trace_width, trace_length);
     AirContext::new(trace_info, t_degrees, num_assertions, options)

--- a/air/src/air/transition/degree.rs
+++ b/air/src/air/transition/degree.rs
@@ -120,7 +120,7 @@ impl TransitionConstraintDegree {
         let degree_bound = self.base + self.cycles.len() - 1;
         cmp::max(
             degree_bound.next_power_of_two(),
-            ProofOptions::MIN_BLOWUP_FACTOR,
+            ProofOptions::MIN_BLOWUP_FACTOR.into(),
         )
     }
 }

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -39,7 +39,9 @@ mod errors;
 pub use errors::AssertionError;
 
 mod options;
-pub use options::{FieldExtension, ProofOptions};
+pub use options::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 mod air;
 pub use air::{

--- a/examples/benches/fibonacci.rs
+++ b/examples/benches/fibonacci.rs
@@ -7,7 +7,8 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use examples::{fibonacci, Example};
 use std::time::Duration;
 use winterfell::{
-    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, FieldExtension, ProofOptions,
+    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, BlowupFactor, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
 };
 
 const SIZES: [usize; 3] = [16_384, 65_536, 262_144];
@@ -17,7 +18,15 @@ fn fibonacci(c: &mut Criterion) {
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(20));
 
-    let options = ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        BlowupFactor::Third,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
 
     for &size in SIZES.iter() {
         let fib =

--- a/examples/benches/rescue.rs
+++ b/examples/benches/rescue.rs
@@ -8,7 +8,8 @@ use examples::{rescue, Example};
 
 use std::time::Duration;
 use winterfell::{
-    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, FieldExtension, ProofOptions,
+    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, BlowupFactor, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
 };
 
 const SIZES: [usize; 2] = [256, 512];
@@ -18,7 +19,15 @@ fn rescue(c: &mut Criterion) {
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(25));
 
-    let options = ProofOptions::new(32, 32, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        BlowupFactor::Fifth,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
 
     for &size in SIZES.iter() {
         let resc = rescue::RescueExample::<Blake3_256<BaseElement>>::new(size, options.clone());

--- a/examples/src/fibonacci/utils.rs
+++ b/examples/src/fibonacci/utils.rs
@@ -31,12 +31,22 @@ pub fn compute_mulfib_term(n: usize) -> BaseElement {
 
 #[cfg(test)]
 pub fn build_proof_options(use_extension_field: bool) -> winterfell::ProofOptions {
-    use winterfell::{FieldExtension, ProofOptions};
+    use winterfell::{
+        BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+    };
 
     let extension = if use_extension_field {
         FieldExtension::Quadratic
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/merkle/tests.rs
+++ b/examples/src/merkle/tests.rs
@@ -4,7 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn merkle_test_basic_proof_verification() {
@@ -39,5 +41,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/rescue/tests.rs
+++ b/examples/src/rescue/tests.rs
@@ -4,7 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn rescue_test_basic_proof_verification() {
@@ -39,5 +41,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/rescue_raps/tests.rs
+++ b/examples/src/rescue_raps/tests.rs
@@ -4,7 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn rescue_test_basic_proof_verification() {
@@ -39,5 +41,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/vdf/exempt/tests.rs
+++ b/examples/src/vdf/exempt/tests.rs
@@ -4,7 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn vdf_test_basic_proof_verification() {
@@ -39,5 +41,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(85, 2, 0, extension, 4, 256)
+    ProofOptions::new(
+        85,
+        BlowupFactor::First,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/vdf/regular/tests.rs
+++ b/examples/src/vdf/regular/tests.rs
@@ -4,7 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn vdf_test_basic_proof_verification() {
@@ -39,5 +41,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(85, 2, 0, extension, 4, 256)
+    ProofOptions::new(
+        85,
+        BlowupFactor::First,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -44,10 +44,11 @@
 extern crate alloc;
 
 pub use air::{
-    proof::StarkProof, Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint,
-    BoundaryConstraintGroup, ConstraintCompositionCoefficients, ConstraintDivisor,
-    DeepCompositionCoefficients, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
-    TraceLayout, TransitionConstraintDegree, TransitionConstraintGroup,
+    proof::StarkProof, Air, AirContext, Assertion, AuxTraceRandElements, BlowupFactor,
+    BoundaryConstraint, BoundaryConstraintGroup, ConstraintCompositionCoefficients,
+    ConstraintDivisor, DeepCompositionCoefficients, EvaluationFrame, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions, TraceInfo, TraceLayout,
+    TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use utils::{
     iterators, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::TraceTable;
 use air::{
-    Air, AirContext, Assertion, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, BlowupFactor, EvaluationFrame, FieldExtension, FriFoldingFactor,
+    FriMaximumRemainderSize, ProofOptions, TraceInfo, TransitionConstraintDegree,
 };
 use math::{fields::f128::BaseElement, FieldElement, StarkField};
 use utils::collections::Vec;
@@ -42,7 +42,15 @@ impl MockAir {
         Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         )
     }
 
@@ -53,7 +61,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.periodic_columns = column_values;
         result
@@ -63,7 +79,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.assertions = assertions;
         result
@@ -75,7 +99,7 @@ impl Air for MockAir {
     type PublicInputs = ();
 
     fn new(trace_info: TraceInfo, _pub_inputs: (), _options: ProofOptions) -> Self {
-        let context = build_context(trace_info, 8, 1);
+        let context = build_context(trace_info, BlowupFactor::Third, 1);
         MockAir {
             context,
             assertions: Vec::new(),
@@ -109,10 +133,18 @@ impl Air for MockAir {
 
 fn build_context<B: StarkField>(
     trace_info: TraceInfo,
-    blowup_factor: usize,
+    blowup_factor: BlowupFactor,
     num_assertions: usize,
 ) -> AirContext<B> {
-    let options = ProofOptions::new(32, blowup_factor, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        blowup_factor,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
     let t_degrees = vec![TransitionConstraintDegree::new(2)];
     AirContext::new(trace_info, t_degrees, num_assertions, options)
 }

--- a/utils/core/src/errors.rs
+++ b/utils/core/src/errors.rs
@@ -14,6 +14,8 @@ use core::fmt;
 pub enum DeserializationError {
     /// Bytes in the input do not represent a valid value.
     InvalidValue(String),
+    /// An invalid proof option was chosen
+    ProofOption(ProofOptionError),
     /// An end of input was reached before a valid value could be deserialized.
     UnexpectedEOF,
     /// Deserialization has finished but not all bytes have been consumed.
@@ -29,6 +31,7 @@ impl fmt::Display for DeserializationError {
             Self::InvalidValue(err_msg) => {
                 write!(f, "{err_msg}")
             }
+            Self::ProofOption(error) => error.fmt(f),
             Self::UnexpectedEOF => {
                 write!(f, "unexpected EOF")
             }
@@ -39,5 +42,34 @@ impl fmt::Display for DeserializationError {
                 write!(f, "unknown error: {err_msg}")
             }
         }
+    }
+}
+
+impl From<ProofOptionError> for DeserializationError {
+    fn from(error: ProofOptionError) -> Self {
+        Self::ProofOption(error)
+    }
+}
+
+// PROOF OPTION ERROR
+// ================================================================================================
+
+// Surfaces errors with particular ProofOption values that are requested
+#[derive(Debug, Eq, PartialEq)]
+pub enum ProofOptionError {
+    NumberOfQueries,
+    GrindingFactor,
+}
+
+impl fmt::Display for ProofOptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::NumberOfQueries => "number of queries cannot be greater than 128",
+                Self::GrindingFactor => "grinding factor cannot be greater than 32",
+            }
+        )
     }
 }

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -23,7 +23,7 @@ use string::ToString;
 pub mod iterators;
 
 mod errors;
-pub use errors::DeserializationError;
+pub use errors::{DeserializationError, ProofOptionError};
 
 #[cfg(test)]
 mod tests;

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -367,7 +367,7 @@
 //! ```
 //! # use winterfell::{
 //! #    math::{fields::f128::BaseElement, FieldElement},
-//! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
+//! #    Air, AirContext, Assertion, BlowupFactor, ByteWriter, EvaluationFrame, FriFoldingFactor, FriMaximumRemainderSize, Serializable,
 //! #    TraceInfo, TransitionConstraintDegree, TraceTable, FieldExtension,
 //! #    Prover, ProofOptions, StarkProof, Trace, crypto::hashers::Blake3_256,
 //! # };
@@ -484,11 +484,11 @@
 //! // Define proof options; these will be enough for ~96-bit security level.
 //! let options = ProofOptions::new(
 //!     32, // number of queries
-//!     8,  // blowup factor
+//!     BlowupFactor::Third,  // blowup factor
 //!     0,  // grinding factor
 //!     FieldExtension::None,
-//!     8,   // FRI folding factor
-//!     128, // FRI max remainder length
+//!     FriFoldingFactor::Third,   // FRI folding factor
+//!     FriMaximumRemainderSize::Fourth, // FRI max remainder length
 //! );
 //!
 //! // Instantiate the prover and generate the proof.
@@ -527,11 +527,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use prover::{
-    crypto, iterators, math, Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint,
-    BoundaryConstraintGroup, ByteReader, ByteWriter, ConstraintCompositionCoefficients,
-    ConstraintDivisor, DeepCompositionCoefficients, Deserializable, DeserializationError,
-    EvaluationFrame, FieldExtension, Matrix, ProofOptions, Prover, ProverError, Serializable,
-    SliceReader, StarkProof, Trace, TraceInfo, TraceLayout, TraceTable, TraceTableFragment,
+    crypto, iterators, math, Air, AirContext, Assertion, AuxTraceRandElements, BlowupFactor,
+    BoundaryConstraint, BoundaryConstraintGroup, ByteReader, ByteWriter,
+    ConstraintCompositionCoefficients, ConstraintDivisor, DeepCompositionCoefficients,
+    Deserializable, DeserializationError, EvaluationFrame, FieldExtension, FriFoldingFactor,
+    FriMaximumRemainderSize, Matrix, ProofOptions, Prover, ProverError, Serializable, SliceReader,
+    StarkProof, Trace, TraceInfo, TraceLayout, TraceTable, TraceTableFragment,
     TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use verifier::{verify, VerifierError};


### PR DESCRIPTION
ProofOptions is made pure (returns errors instead of panicking), and is refactored to make it much harder to initialize with invalid options.