### PR TITLE
Optimized methods for squaring in extension fields of degree 2 & 3

### DIFF
--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -70,6 +70,12 @@ impl<B: ExtensibleField<3>> FieldElement for CubeExtension<B> {
     }
 
     #[inline]
+    fn square(self) -> Self {
+        let a = <B as ExtensibleField<3>>::square([self.0, self.1, self.2]);
+        Self(a[0], a[1], a[2])
+    }
+
+    #[inline]
     fn inv(self) -> Self {
         if self == Self::ZERO {
             return self;

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -70,6 +70,12 @@ impl<B: ExtensibleField<2>> FieldElement for QuadExtension<B> {
     }
 
     #[inline]
+    fn square(self) -> Self {
+        let a = <B as ExtensibleField<2>>::square([self.0, self.1]);
+        Self(a[0], a[1])
+    }
+
+    #[inline]
     fn inv(self) -> Self {
         if self == Self::ZERO {
             return self;

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -85,6 +85,17 @@ fn mul() {
 }
 
 #[test]
+fn mul_small() {
+    // test overflow
+    let m = BaseElement::MODULUS;
+    let t = BaseElement::from(m - 1);
+    let a = u32::MAX;
+    let expected = BaseElement::new(a as u64) * t;
+
+    assert_eq!(expected, t.mul_small(a));
+}
+
+#[test]
 fn exp() {
     let a = BaseElement::ZERO;
     assert_eq!(a.exp(0), BaseElement::ONE);
@@ -422,6 +433,16 @@ proptest! {
     }
 
     #[test]
+    fn mul_small_proptest(a in any::<u64>(), b in any::<u32>()) {
+        let v1 = BaseElement::from(a);
+        let v2 = b;
+        let result = v1.mul_small(v2);
+
+        let expected = (((a as u128) * (b as u128)) % super::M as u128) as u64;
+        prop_assert_eq!(expected, result.as_int());
+    }
+
+    #[test]
     fn double_proptest(x in any::<u64>()) {
         let v = BaseElement::from(x);
         let result = v.double();
@@ -476,6 +497,14 @@ proptest! {
         prop_assert_eq!(expected, a * b);
     }
 
+    #[test]
+    fn quad_square_proptest(a0 in any::<u64>(), a1 in any::<u64>()) {
+        let a = QuadExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1));
+        let expected = a * a;
+
+        prop_assert_eq!(expected, a.square());
+    }
+
     // CUBIC EXTENSION
     // --------------------------------------------------------------------------------------------
     #[test]
@@ -489,5 +518,13 @@ proptest! {
             CubeExtension::<BaseElement>::ONE
         };
         prop_assert_eq!(expected, a * b);
+    }
+
+    #[test]
+    fn cube_square_proptest(a0 in any::<u64>(), a1 in any::<u64>(), a2 in any::<u64>()) {
+        let a = CubeExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1), BaseElement::from(a2));
+        let expected = a * a;
+
+        prop_assert_eq!(expected, a.square());
     }
 }

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -254,6 +254,11 @@ pub trait ExtensibleField<const N: usize>: StarkField {
     /// Returns a product of `a` and `b` in the field defined by this extension.
     fn mul(a: [Self; N], b: [Self; N]) -> [Self; N];
 
+    /// Returns the square of `a` in the field defined by this extension.
+    fn square(a: [Self; N]) -> [Self; N] {
+        <Self as ExtensibleField<N>>::mul(a, a)
+    }
+
     /// Returns a product of `a` and `b` in the field defined by this extension. `b` represents
     /// an element in the base field.
     fn mul_base(a: [Self; N], b: Self) -> [Self; N];


### PR DESCRIPTION
This PR implements more optimized methods for computing squares in the degrees 2 and 3 extension fields. This is in contrast to the old way of squaring which was using a generic multiplication.
Also included, is a method for multiplying field elements in 64-bit field with constants smaller than $2^{32}$. This will be useful for extension fields that are defined by irreducible polynomials of the form $X^d - \omega$ where $d$ is the degree of the extension and $\omega$ is a field element. In the case of such extension fields, reduction modulo $X^d - \omega$ becomes just a multiplication by $\omega$ and thus a method for multiplying with small constants will be useful.