### PR TITLE
Send remainder polynomial instead of remainder code word

### DIFF
--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -234,7 +234,7 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::with_meta(4, trace_length, vec![1]),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 32),
         );
         result.periodic_columns = column_values;
         result
@@ -244,7 +244,7 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::with_meta(4, trace_length, vec![assertions.len() as u8]),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 32),
         );
         result.assertions = assertions;
         result
@@ -294,7 +294,7 @@ pub fn build_context<B: StarkField>(
     trace_width: usize,
     num_assertions: usize,
 ) -> AirContext<B> {
-    let options = ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 32);
     let t_degrees = vec![TransitionConstraintDegree::new(2)];
     let trace_info = TraceInfo::new(trace_width, trace_length);
     AirContext::new(trace_info, t_degrees, num_assertions, options)

--- a/air/src/proof/commitments.rs
+++ b/air/src/proof/commitments.rs
@@ -75,7 +75,7 @@ impl Commitments {
         // parse constraint evaluation commitment:
         let constraint_commitment = H::Digest::read_from(&mut reader)?;
 
-        // read FRI commitments (+1 is for FRI remainder commitment)
+        // read FRI commitments (+ 1 for remainder polynomial commitment)
         let fri_commitments = H::Digest::read_batch_from(&mut reader, num_fri_layers + 1)?;
 
         // make sure we consumed all available commitment bytes

--- a/examples/src/fibonacci/fib_small/tests.rs
+++ b/examples/src/fibonacci/fib_small/tests.rs
@@ -8,7 +8,7 @@ use super::{super::utils::build_proof_options, Rp64_256};
 #[test]
 fn fib_small_test_basic_proof_verification() {
     let fib = Box::new(super::FibExample::<Rp64_256>::new(
-        16,
+        2048,
         build_proof_options(false),
     ));
     crate::tests::test_basic_proof_verification(fib);

--- a/examples/src/fibonacci/utils.rs
+++ b/examples/src/fibonacci/utils.rs
@@ -38,5 +38,5 @@ pub fn build_proof_options(use_extension_field: bool) -> winterfell::ProofOption
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(28, 8, 0, extension, 4, 8)
 }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -99,7 +99,7 @@ impl ExampleOptions {
                 self.grinding_factor,
                 field_extension,
                 self.folding_factor,
-                256,
+                32,
             ),
             hash_fn,
         )

--- a/examples/src/merkle/tests.rs
+++ b/examples/src/merkle/tests.rs
@@ -39,5 +39,5 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(28, 8, 0, extension, 4, 32)
 }

--- a/examples/src/rescue/tests.rs
+++ b/examples/src/rescue/tests.rs
@@ -39,5 +39,5 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(28, 8, 0, extension, 4, 32)
 }

--- a/examples/src/rescue_raps/tests.rs
+++ b/examples/src/rescue_raps/tests.rs
@@ -39,5 +39,5 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(28, 8, 0, extension, 4, 32)
 }

--- a/examples/src/vdf/exempt/tests.rs
+++ b/examples/src/vdf/exempt/tests.rs
@@ -39,5 +39,5 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(85, 2, 0, extension, 4, 256)
+    ProofOptions::new(85, 2, 0, extension, 4, 32)
 }

--- a/examples/src/vdf/regular/tests.rs
+++ b/examples/src/vdf/regular/tests.rs
@@ -39,5 +39,5 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(85, 2, 0, extension, 4, 256)
+    ProofOptions::new(85, 2, 0, extension, 4, 32)
 }

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -20,10 +20,10 @@ use utils::{
 /// of a [FriProver](crate::FriProver), and can be verified by a instance of a
 /// [FriVerifier](crate::FriVerifier) via [VerifierChannel](crate::VerifierChannel) interface.
 ///
-/// A proof consists of zero or more layers and a remainder. Each layer contains a set of
+/// A proof consists of zero or more layers and a remainder polynomial. Each layer contains a set of
 /// polynomial evaluations at positions queried by the verifier as well as Merkle authentication
 /// paths for these evaluations (the Merkle paths are compressed into a batch Merkle proof). The
-/// remainder is a list of field elements.
+/// remainder polynomial is given by its list of coefficients i.e. field elements.
 ///
 /// All values in a proof are stored as vectors of bytes. Thus, the values must be parsed before
 /// they can be returned to the user. To do this, [parse_layers()](FriProof::parse_layers())
@@ -38,7 +38,7 @@ pub struct FriProof {
 impl FriProof {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// Creates a new FRI proof from the provided layers and remainder values.
+    /// Creates a new FRI proof from the provided layers and remainder polynomial.
     ///
     /// # Panics
     /// Panics if:
@@ -139,7 +139,6 @@ impl FriProof {
 
         let mut layer_proofs = Vec::new();
         let mut layer_queries = Vec::new();
-        let num_remainder_elements = self.num_remainder_elements::<E>();
 
         // parse all layers
         for (i, layer) in self.layers.into_iter().enumerate() {
@@ -149,13 +148,6 @@ impl FriProof {
             })?;
             layer_proofs.push(mp);
             layer_queries.push(qv);
-        }
-
-        // make sure the remaining domain size matches remainder length
-        if domain_size != num_remainder_elements {
-            return Err(DeserializationError::InvalidValue(format!(
-                "FRI remainder domain size must be {num_remainder_elements}, but was {domain_size}",
-            )));
         }
 
         Ok((layer_queries, layer_proofs))

--- a/fri/src/verifier/channel.rs
+++ b/fri/src/verifier/channel.rs
@@ -5,7 +5,7 @@
 
 use crate::{FriProof, VerifierError};
 use crypto::{BatchMerkleProof, ElementHasher, Hasher, MerkleTree};
-use math::{polynom, FieldElement};
+use math::FieldElement;
 use utils::{collections::Vec, group_vector_elements, DeserializationError};
 
 // VERIFIER CHANNEL TRAIT
@@ -91,17 +91,8 @@ pub trait VerifierChannel<E: FieldElement> {
     }
 
     /// Returns FRI remainder polynomial read from this channel.
-    ///
-    /// This also checks whether the remainder is valid against the provided maximum expected degree.
-    ///
-    /// # Errors
-    /// Returns an error if:
-    /// - If the degree of the polynomial is greater than the maximum expected degree.
-    fn read_remainder(&mut self, max_degree: usize) -> Result<Vec<E>, VerifierError> {
+    fn read_remainder(&mut self) -> Result<Vec<E>, VerifierError> {
         let remainder = self.take_fri_remainder();
-        if polynom::degree_of(&remainder) > max_degree {
-            return Err(VerifierError::RemainderDegreeMismatch(max_degree));
-        }
 
         Ok(remainder)
     }

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -42,7 +42,7 @@ impl MockAir {
         Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 32),
         )
     }
 
@@ -53,7 +53,7 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 32),
         );
         result.periodic_columns = column_values;
         result
@@ -63,7 +63,7 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 32),
         );
         result.assertions = assertions;
         result
@@ -112,7 +112,7 @@ fn build_context<B: StarkField>(
     blowup_factor: usize,
     num_assertions: usize,
 ) -> AirContext<B> {
-    let options = ProofOptions::new(32, blowup_factor, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(32, blowup_factor, 0, FieldExtension::None, 4, 32);
     let t_degrees = vec![TransitionConstraintDegree::new(2)];
     AirContext::new(trace_info, t_degrees, num_assertions, options)
 }

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -488,7 +488,7 @@
 //!     0,  // grinding factor
 //!     FieldExtension::None,
 //!     8,   // FRI folding factor
-//!     128, // FRI max remainder length
+//!     32, // FRI max remainder polynomial length
 //! );
 //!
 //! // Instantiate the prover and generate the proof.


### PR DESCRIPTION
This PR proposes another method for performing the final check in the FRI query stage. Specifically, in the current implementation the verifier receives a code word from the prover which the latter claims to be consistent with an honest execution of the protocol.
The verifier then checks that the commitment to the received code word matches the one received in the commit phase of the protocol. The verifier then goes on to interpolate the code word in order to find the corresponding remainder polynomial. The verifier concludes by checking whether the degree of this polynomial is less than the expected degree bound (which can be computed from the input polynomial degree bound and the protocol parameters).
The current proposal simplifies things by sending the remainder polynomial directly. Thus the verifier can perform the degree check almost trivially. Moreover, no commitments to the remainder polynomial are needed. 