### PR TITLE
Rowmatrix for NTT

### DIFF
--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     utils::{get_power_series, log2},
 };
 
-mod fft_inputs;
+pub mod fft_inputs;
 
 pub mod real_u64;
 

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -34,7 +34,7 @@ utils = { version = "0.5", path = "../utils/core", package = "winter-utils", def
 
 [dev-dependencies]
 criterion = "0.4"
-rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -15,6 +15,10 @@ rust-version = "1.67"
 [lib]
 bench = false
 
+[[bench]]
+name = "row_matrix"
+harness = false
+
 [features]
 concurrent = ["crypto/concurrent", "math/concurrent", "fri/concurrent", "utils/concurrent", "std"]
 default = ["std"]
@@ -27,6 +31,10 @@ fri = { version = "0.5", path = '../fri', package = "winter-fri", default-featur
 log = { version = "0.4", default-features = false }
 math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
 utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+
+[dev-dependencies]
+criterion = "0.4"
+rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/prover/benches/row_matrix.rs
+++ b/prover/benches/row_matrix.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use math::{fft, fields::f64::BaseElement, StarkField};
+use rand_utils::rand_vector;
+use std::time::Duration;
+use winter_prover::{Matrix, RowMatrix, StarkDomain};
+
+// CONSTANTS
+// ================================================================================================
+
+const SIZE: usize = 524_288;
+const BLOWUP_FACTOR: usize = 8;
+const NUM_POLYS: [usize; 4] = [16, 32, 64, 96];
+
+fn evaluate_columns(c: &mut Criterion) {
+    let mut group = c.benchmark_group("matrix_evaluate_columns");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    for &num_poly in NUM_POLYS.iter() {
+        let columns: Vec<Vec<BaseElement>> = (0..num_poly).map(|_| rand_vector(SIZE)).collect();
+        let column_matrix = Matrix::new(columns);
+        group.bench_function(BenchmarkId::new("with_offset", num_poly), |bench| {
+            bench.iter_with_large_drop(|| {
+                let twiddles = fft::get_twiddles::<BaseElement>(SIZE);
+                let stark_domain = StarkDomain::from_custom_inputs(
+                    twiddles,
+                    BLOWUP_FACTOR,
+                    BaseElement::GENERATOR,
+                );
+                column_matrix.evaluate_columns_over(&stark_domain)
+            });
+        });
+    }
+    group.finish();
+}
+
+fn evaluate_matrix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("matrix_evaluate_matrix");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    for &num_poly in NUM_POLYS.iter() {
+        let columns: Vec<Vec<BaseElement>> = (0..num_poly).map(|_| rand_vector(SIZE)).collect();
+        let column_matrix = Matrix::new(columns);
+        group.bench_function(BenchmarkId::new("with_offset", num_poly), |bench| {
+            bench.iter_with_large_drop(|| {
+                RowMatrix::from_polys(&column_matrix, BLOWUP_FACTOR);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(matrix_group, evaluate_matrix, evaluate_columns,);
+criterion_main!(matrix_group);

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -52,19 +52,25 @@ impl<B: StarkField> StarkDomain<B> {
     }
 
     /// Returns a new STARK domain initialized with the provided custom inputs.
-    pub fn from_custom_inputs(
-        trace_twiddles: Vec<B>,
-        blowup_factor: usize,
-        domain_offset: B,
-    ) -> Self {
-        let ce_domain_size = trace_twiddles.len() * 2;
+    pub fn from_twiddles(trace_twiddles: Vec<B>, blowup_factor: usize, domain_offset: B) -> Self {
+        // both `trace_twiddles` length and `blowup_factor` must be a power of two.
+        assert!(
+            trace_twiddles.len().is_power_of_two(),
+            "the length of trace twiddles must be a power of 2"
+        );
+        assert!(
+            blowup_factor.is_power_of_two(),
+            "blowup factor must be a power of 2"
+        );
+
+        let ce_domain_size = trace_twiddles.len() * blowup_factor * 2;
         let domain_gen = B::get_root_of_unity(log2(ce_domain_size));
         let ce_domain = get_power_series(domain_gen, ce_domain_size);
 
         StarkDomain {
             trace_twiddles,
             ce_domain,
-            ce_to_lde_blowup: blowup_factor,
+            ce_to_lde_blowup: 1,
             ce_domain_mod_mask: ce_domain_size - 1,
             domain_offset,
         }

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -51,6 +51,25 @@ impl<B: StarkField> StarkDomain<B> {
         }
     }
 
+    /// Returns a new STARK domain initialized with the provided custom inputs.
+    pub fn from_custom_inputs(
+        trace_twiddles: Vec<B>,
+        blowup_factor: usize,
+        domain_offset: B,
+    ) -> Self {
+        let ce_domain_size = trace_twiddles.len() * 2;
+        let domain_gen = B::get_root_of_unity(log2(ce_domain_size));
+        let ce_domain = get_power_series(domain_gen, ce_domain_size);
+
+        StarkDomain {
+            trace_twiddles,
+            ce_domain,
+            ce_to_lde_blowup: blowup_factor,
+            ce_domain_mod_mask: ce_domain_size - 1,
+            domain_offset,
+        }
+    }
+
     // EXECUTION TRACE
     // --------------------------------------------------------------------------------------------
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -78,7 +78,7 @@ mod domain;
 pub use domain::StarkDomain;
 
 mod matrix;
-pub use matrix::Matrix;
+pub use matrix::{Matrix, RowMatrix};
 
 mod constraints;
 use constraints::{CompositionPoly, ConstraintCommitment, ConstraintEvaluator};

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::StarkDomain;
+use crate::StarkDomain;
 use core::{iter::FusedIterator, slice};
 use crypto::{ElementHasher, MerkleTree};
 use math::{fft, polynom, FieldElement};

--- a/prover/src/matrix/mod.rs
+++ b/prover/src/matrix/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+mod row_matrix;
+pub use row_matrix::*;
+
+mod col_matrix;
+pub use col_matrix::*;
+
+mod segments;
+use segments::*;
+
+#[cfg(test)]
+mod tests;

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use super::segments::{Segment, Segments};
+use crate::{matrix::ARR_SIZE, Matrix};
+use math::{fft, FieldElement, StarkField};
+use utils::collections::Vec;
+use utils::{flatten_vector_elements, uninit_vector};
+
+// ROWMAJOR MATRIX
+// ================================================================================================
+
+/// A row-major matrix of field elements. The matrix is represented as a single vector of field
+/// elements, where the first `row_len` elements represent the first row of the matrix, the next
+/// `row_len` elements represent the second row, and so on.
+///
+/// # Note
+/// - The number of rows in the matrix is always a multiple of the ARR_SIZE.
+/// - The number of columns in the matrix is always a multiple of the ARR_SIZE.
+#[derive(Clone, Debug)]
+pub struct RowMatrix<E: FieldElement> {
+    data: Vec<E>,
+    row_len: usize,
+}
+
+impl<E> RowMatrix<E>
+where
+    E: FieldElement,
+{
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new row-major matrix from the specified data and row length. The data must be
+    /// arranged in row-major order, i.e. the first `row_len` elements of the data represent the first
+    /// row of the matrix, the next `row_len` elements represent the second row, and so on.
+    ///
+    /// # Panics
+    /// - if the number of elements in the data is not a multiple of the specified row length;
+    /// - if the specified row length is not a multiple of the ARR_SIZE;
+    /// - if the specified data is empty.
+    pub fn new(data: Vec<E>, row_len: usize) -> Self {
+        assert!(data.len() % row_len == 0);
+        assert!(row_len % ARR_SIZE == 0);
+        assert!(!data.is_empty());
+
+        Self { data, row_len }
+    }
+
+    /// Converts a column-major matrix of polynomials `Matrix<E>` into a RowMatrix evaluated at
+    /// a shifted domain offset.
+    pub fn from_polys(polys: &Matrix<E>, blowup_factor: usize) -> Self {
+        // get the number of rows and columns in the polys.
+        let row_width = polys.num_cols();
+        let num_rows = polys.num_rows();
+
+        // get the twiddles for the segment.
+        let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows() * blowup_factor);
+        let domain_offset = E::BaseField::GENERATOR;
+
+        // get the number of segments in the matrix.
+        let num_of_segments = row_width / ARR_SIZE;
+        let mut segments = Segments::new(Vec::new());
+
+        // precompute offsets for each row.
+        let mut offsets = Vec::with_capacity(num_rows);
+        offsets.push(E::BaseField::ONE);
+        for i in 1..num_rows {
+            offsets.push(offsets[i - 1] * domain_offset);
+        }
+
+        // create segments.
+        (0..num_of_segments).for_each(|i| {
+            // create a vector of arrays to hold the result.
+            let mut result_vec_of_arrays =
+                unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * blowup_factor) };
+
+            // transpose the segment into `Segment` and evaluate the polynomials at the
+            // shifted domain offset.
+            (i * ARR_SIZE..(i + 1) * ARR_SIZE).for_each(|col_idx| {
+                let row = polys.get_column(col_idx);
+                row.iter().enumerate().for_each(|(row_idx, elem)| {
+                    result_vec_of_arrays[row_idx][col_idx - i * ARR_SIZE] =
+                        elem.mul_base(offsets[row_idx]);
+                });
+            });
+
+            // create a `Segment` object from the result.
+            let row_matrix = Segment::new(result_vec_of_arrays);
+            segments.push(row_matrix);
+        });
+
+        // evaluate the polynomials in each segment at the shifted domain offset.
+        for segment in segments.iter_mut() {
+            segment.evaluate_poly(&twiddles);
+        }
+
+        let num_rows = num_rows * blowup_factor;
+
+        // create a vector of arrays to hold the result.
+        let mut result = unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * row_width / ARR_SIZE) };
+
+        // transpose the segments into a row matrix.
+        segments.iter().enumerate().for_each(|(i, segment)| {
+            (segment.as_data()).iter().enumerate().for_each(|(j, row)| {
+                result[j * row_width / ARR_SIZE + i] = *row;
+            })
+        });
+
+        // create a `RowMatrix` object from the result.
+        RowMatrix {
+            data: flatten_vector_elements(result),
+            row_len: row_width,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // ---------------------------------------------------------------------------------------------
+
+    /// Returns the number of rows in this matrix.
+    pub fn num_rows(&self) -> usize {
+        self.data.len() / self.row_len
+    }
+
+    /// Returns the number of columns in this matrix.
+    pub fn num_cols(&self) -> usize {
+        self.row_len
+    }
+
+    /// Returns a reference to a row at the specified index in this matrix.
+    ///
+    /// # Panics
+    /// Panics if the specified row index is out of bounds.
+    pub fn get_row(&self, row_idx: usize) -> &[E] {
+        assert!(row_idx < self.num_rows());
+        let start = row_idx * self.row_len;
+        &self.data[start..start + self.row_len]
+    }
+
+    /// Returns a mutable reference to a row at the specified index in this matrix.
+    ///
+    /// # Panics
+    /// Panics if the specified row index is out of bounds.
+    pub fn get_row_mut(&mut self, row_idx: usize) -> &mut [E] {
+        assert!(row_idx < self.num_rows());
+        let start = row_idx * self.row_len;
+        &mut self.data[start..start + self.row_len]
+    }
+
+    /// Returns the data in this matrix as a slice of field elements.
+    pub fn as_data(&self) -> &[E] {
+        &self.data
+    }
+}

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::segments::{Segment, Segments};
+use super::segments::Segment;
 use crate::{matrix::ARR_SIZE, Matrix};
 use math::{fft, FieldElement, StarkField};
 use utils::collections::Vec;
@@ -17,8 +17,8 @@ use utils::{flatten_vector_elements, uninit_vector};
 /// `row_len` elements represent the second row, and so on.
 ///
 /// # Note
-/// - The number of rows in the matrix is always a multiple of the ARR_SIZE.
-/// - The number of columns in the matrix is always a multiple of the ARR_SIZE.
+/// - The number of rows in the matrix is always a multiple of ARR_SIZE.
+/// - The number of columns in the matrix is always a multiple of ARR_SIZE.
 #[derive(Clone, Debug)]
 pub struct RowMatrix<E: FieldElement> {
     data: Vec<E>,
@@ -38,7 +38,7 @@ where
     ///
     /// # Panics
     /// - if the number of elements in the data is not a multiple of the specified row length;
-    /// - if the specified row length is not a multiple of the ARR_SIZE;
+    /// - if the specified row length is not a multiple of ARR_SIZE;
     /// - if the specified data is empty.
     pub fn new(data: Vec<E>, row_len: usize) -> Self {
         assert!(data.len() % row_len == 0);
@@ -50,68 +50,57 @@ where
 
     /// Converts a column-major matrix of polynomials `Matrix<E>` into a RowMatrix evaluated at
     /// a shifted domain offset.
-    pub fn from_polys(polys: &Matrix<E>, blowup_factor: usize) -> Self {
+    pub fn transpose_and_extend(polys: &Matrix<E>, blowup_factor: usize) -> Self {
         // get the number of rows and columns in the polys.
         let row_width = polys.num_cols();
         let num_rows = polys.num_rows();
 
         // get the twiddles for the segment.
         let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows() * blowup_factor);
-        let domain_offset = E::BaseField::GENERATOR;
-
-        // get the number of segments in the matrix.
-        let num_of_segments = row_width / ARR_SIZE;
-        let mut segments = Segments::new(Vec::new());
 
         // precompute offsets for each row.
-        let mut offsets = Vec::with_capacity(num_rows);
-        offsets.push(E::BaseField::ONE);
-        for i in 1..num_rows {
-            offsets.push(offsets[i - 1] * domain_offset);
-        }
+        let offsets = get_offsets::<E>(num_rows, E::BaseField::GENERATOR);
+
+        // create a vector of uninitialised segments to hold the result.
+        let mut segments = allocate_segments::<E>(num_rows, row_width, blowup_factor);
 
         // create segments.
-        (0..num_of_segments).for_each(|i| {
-            // create a vector of arrays to hold the result.
-            let mut result_vec_of_arrays =
-                unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * blowup_factor) };
+        segments
+            .iter_mut()
+            .enumerate()
+            .for_each(|(seg_idx, segment)| {
+                // prepare the segment.
+                prepare_segment(segment, polys, seg_idx, &offsets);
 
-            // transpose the segment into `Segment` and evaluate the polynomials at the
-            // shifted domain offset.
-            (i * ARR_SIZE..(i + 1) * ARR_SIZE).for_each(|col_idx| {
-                let row = polys.get_column(col_idx);
-                row.iter().enumerate().for_each(|(row_idx, elem)| {
-                    result_vec_of_arrays[row_idx][col_idx - i * ARR_SIZE] =
-                        elem.mul_base(offsets[row_idx]);
-                });
+                // evaluate the segment at the shifted domain offset.
+                segment.evaluate_poly(&twiddles);
             });
 
-            // create a `Segment` object from the result.
-            let row_matrix = Segment::new(result_vec_of_arrays);
-            segments.push(row_matrix);
-        });
+        // create a `RowMatrix` object from the segments.
+        Self::from_segments(segments)
+    }
 
-        // evaluate the polynomials in each segment at the shifted domain offset.
-        for segment in segments.iter_mut() {
-            segment.evaluate_poly(&twiddles);
-        }
-
-        let num_rows = num_rows * blowup_factor;
+    /// Converts a collection of segments into a row-major matrix.
+    fn from_segments(segments: Vec<Segment<E>>) -> Self {
+        // get the number of rows and segments.
+        let num_rows = segments[0].num_rows();
+        let num_segs = segments.len();
 
         // create a vector of arrays to hold the result.
-        let mut result = unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * row_width / ARR_SIZE) };
+        // TODO: use a more efficient way so that we don't have to allocate a vector of arrays here.
+        let mut result = unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * num_segs) };
 
         // transpose the segments into a row matrix.
         segments.iter().enumerate().for_each(|(i, segment)| {
             (segment.as_data()).iter().enumerate().for_each(|(j, row)| {
-                result[j * row_width / ARR_SIZE + i] = *row;
+                result[j * num_segs + i] = *row;
             })
         });
 
         // create a `RowMatrix` object from the result.
         RowMatrix {
             data: flatten_vector_elements(result),
-            row_len: row_width,
+            row_len: num_segs * ARR_SIZE,
         }
     }
 
@@ -121,11 +110,6 @@ where
     /// Returns the number of rows in this matrix.
     pub fn num_rows(&self) -> usize {
         self.data.len() / self.row_len
-    }
-
-    /// Returns the number of columns in this matrix.
-    pub fn num_cols(&self) -> usize {
-        self.row_len
     }
 
     /// Returns a reference to a row at the specified index in this matrix.
@@ -138,18 +122,79 @@ where
         &self.data[start..start + self.row_len]
     }
 
-    /// Returns a mutable reference to a row at the specified index in this matrix.
-    ///
-    /// # Panics
-    /// Panics if the specified row index is out of bounds.
-    pub fn get_row_mut(&mut self, row_idx: usize) -> &mut [E] {
-        assert!(row_idx < self.num_rows());
-        let start = row_idx * self.row_len;
-        &mut self.data[start..start + self.row_len]
-    }
-
     /// Returns the data in this matrix as a slice of field elements.
     pub fn as_data(&self) -> &[E] {
         &self.data
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns a vector of offsets for the specified number of rows. The offsets are computed as
+/// `domain_offset^i` for `i` in `[0, num_rows)`. The first offset is always 1.
+fn get_offsets<E>(num_rows: usize, domain_offset: E::BaseField) -> Vec<E::BaseField>
+where
+    E: FieldElement,
+{
+    // create a vector to hold the offsets.
+    let mut offsets = Vec::with_capacity(num_rows);
+
+    // the first offset is always 1.
+    offsets.push(E::BaseField::ONE);
+
+    // compute the remaining offsets.
+    for i in 1..num_rows {
+        offsets.push(offsets[i - 1] * domain_offset);
+    }
+
+    offsets
+}
+
+/// Creates a vector of uninitialised segments to hold the result. The number of segments is
+/// equal to the number of columns in the matrix divided by the ARR_SIZE. Each segment is
+/// initialised with a vector of uninitialised arrays of length `num_rows * blowup_factor`.
+///
+/// # Panics
+/// Panics if the number of columns in the matrix is not a multiple of ARR_SIZE.
+fn allocate_segments<E>(num_rows: usize, row_width: usize, blowup_factor: usize) -> Vec<Segment<E>>
+where
+    E: FieldElement,
+{
+    assert!(
+        row_width % ARR_SIZE == 0,
+        "number of columns must be a multiple of ARR_SIZE"
+    );
+    let outer_vec_len = row_width / ARR_SIZE;
+
+    // create a vector of uninitialised segments to hold the result.
+    // SAFETY: we are creating a vector of uninitialised segments, and each segment is
+    // initialised with a vector of uninitialised arrays of length `num_rows * blowup_factor`.
+    // This is safe because we are not reading from the vectors, and we will initialise
+    // the vectors before reading from them.
+    let outer_vec: Vec<Segment<E>> = (0..outer_vec_len)
+        .map(|_| Segment::new(unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * blowup_factor) }))
+        .collect();
+
+    outer_vec
+}
+
+/// Prepares a segment for evaluation by multiplying each element in the segment by the
+/// corresponding offset.
+fn prepare_segment<E>(
+    segment: &mut Segment<E>,
+    polys: &Matrix<E>,
+    seg_idx: usize,
+    offsets: &[E::BaseField],
+) where
+    E: FieldElement,
+{
+    (seg_idx * ARR_SIZE..(seg_idx + 1) * ARR_SIZE).for_each(|col_idx| {
+        // get the column from the polys matrix.
+        let col = polys.get_column(col_idx);
+        col.iter().enumerate().for_each(|(row_idx, elem)| {
+            segment.as_mut_data()[row_idx][col_idx - seg_idx * ARR_SIZE] =
+                elem.mul_base(offsets[row_idx]);
+        });
+    });
 }

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -1,0 +1,495 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use core::iter::FusedIterator;
+use math::{fft::fft_inputs::FftInputs, FieldElement};
+use utils::collections::Vec;
+
+// CONSTANTS
+// ================================================================================================
+
+pub const ARR_SIZE: usize = 8;
+
+// SEGMENT OF ROWMAJOR MATRIX
+// ================================================================================================
+
+/// A segment of a row-major matrix of field elements. The segment is represented as a single vector
+/// of field elements, where the first element represent the first row of the segment, the element at
+/// index `i` represents the `i`-th row of the segment, and so on.
+///
+/// Each segment contains only `ARR_SIZE` columns of the matrix. For example, if we have the following
+/// matrix with 8 columns and 2 rows (the matrix is represented as a single vector of field elements
+/// in row-major order) and a ARR_SIZE of 2:
+///
+/// ```text
+/// [ 1  2  3  4  5  6  7  8 ]
+/// [ 9 10 11 12 13 14 15 16 ]
+/// ```
+/// then the first segment of this matrix is represented as a single vector of field elements:
+/// ```text
+/// [[1 2] [9 10]]
+/// ```
+/// and the second segment is represented as:
+/// ```text
+/// [[3 4] [11 12]]
+/// ```
+/// and so on.
+///
+/// It is arranged in a way that allows for efficient FFT operations.
+#[derive(Clone, Debug)]
+pub struct Segment<E>
+where
+    E: FieldElement,
+{
+    data: Vec<[E; ARR_SIZE]>,
+}
+
+#[allow(dead_code)]
+impl<E> Segment<E>
+where
+    E: FieldElement,
+{
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new segment of a row-major matrix from the specified data.
+    pub fn new(data: Vec<[E; ARR_SIZE]>) -> Self {
+        Self { data }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the number of columns in this matrix.
+    pub fn num_cols(&self) -> usize {
+        ARR_SIZE
+    }
+
+    /// Returns the number of rows in this matrix.
+    pub fn num_rows(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns the data in this matrix as a mutable slice of arrays.
+    pub fn as_data_mut(&mut self) -> &mut [[E; ARR_SIZE]] {
+        &mut self.data
+    }
+
+    /// Returns the data in this matrix as a slice of arrays.
+    pub fn as_data(&self) -> &[[E; ARR_SIZE]] {
+        &self.data
+    }
+
+    /// Returns a reference to the row at the specified index.
+    ///
+    /// # Panics
+    /// Panics if the specified row index is out of bounds.
+    pub fn get_row(&self, row_idx: usize) -> &[E; ARR_SIZE] {
+        assert!(row_idx < self.num_rows());
+        &self.data[row_idx]
+    }
+
+    /// Returns a mutable reference to the row at the specified index.
+    ///
+    /// # Panics
+    /// Panics if the specified row index is out of bounds.
+    pub fn get_row_mut(&mut self, row_idx: usize) -> &mut [E; ARR_SIZE] {
+        assert!(row_idx < self.num_rows());
+        &mut self.data[row_idx]
+    }
+
+    /// Evaluates the segment `p` over the domain of length `p.len()` using the FFT algorithm
+    /// and returns the result. The computation is performed in place.
+    pub fn evaluate_poly(&mut self, twiddles: &[E::BaseField])
+    where
+        E: FieldElement,
+    {
+        self.fft_in_place(twiddles);
+        self.permute()
+    }
+}
+
+/// Implementation of `FftInputs` for `Segment`.
+impl<E> FftInputs<E> for Segment<E>
+where
+    E: FieldElement,
+{
+    fn len(&self) -> usize {
+        self.num_rows()
+    }
+
+    #[inline(always)]
+    fn butterfly(&mut self, offset: usize, stride: usize) {
+        let i = offset;
+        let j = offset + stride;
+
+        let temp = self.data[i];
+
+        //  apply on 1st element of the array.
+        self.data[i][0] = temp[0] + self.data[j][0];
+        self.data[j][0] = temp[0] - self.data[j][0];
+
+        // apply on 2nd element of the array.
+        self.data[i][1] = temp[1] + self.data[j][1];
+        self.data[j][1] = temp[1] - self.data[j][1];
+
+        // apply on 3rd element of the array.
+        self.data[i][2] = temp[2] + self.data[j][2];
+        self.data[j][2] = temp[2] - self.data[j][2];
+
+        // apply on 4th element of the array.
+        self.data[i][3] = temp[3] + self.data[j][3];
+        self.data[j][3] = temp[3] - self.data[j][3];
+
+        // apply on 5th element of the array.
+        self.data[i][4] = temp[4] + self.data[j][4];
+        self.data[j][4] = temp[4] - self.data[j][4];
+
+        // apply on 6th element of the array.
+        self.data[i][5] = temp[5] + self.data[j][5];
+        self.data[j][5] = temp[5] - self.data[j][5];
+
+        // apply on 7th element of the array.
+        self.data[i][6] = temp[6] + self.data[j][6];
+        self.data[j][6] = temp[6] - self.data[j][6];
+
+        // apply on 8th element of the array.
+        self.data[i][7] = temp[7] + self.data[j][7];
+        self.data[j][7] = temp[7] - self.data[j][7];
+    }
+
+    #[inline(always)]
+    fn butterfly_twiddle(&mut self, twiddle: E::BaseField, offset: usize, stride: usize) {
+        let i = offset;
+        let j = offset + stride;
+
+        let twiddle = E::from(twiddle);
+        let temp = self.data[i];
+
+        // apply of index 0 of twiddle.
+        self.data[j][0] *= twiddle;
+        self.data[i][0] = temp[0] + self.data[j][0];
+        self.data[j][0] = temp[0] - self.data[j][0];
+
+        // apply of index 1 of twiddle.
+        self.data[j][1] *= twiddle;
+        self.data[i][1] = temp[1] + self.data[j][1];
+        self.data[j][1] = temp[1] - self.data[j][1];
+
+        // apply of index 2 of twiddle.
+        self.data[j][2] *= twiddle;
+        self.data[i][2] = temp[2] + self.data[j][2];
+        self.data[j][2] = temp[2] - self.data[j][2];
+
+        // apply of index 3 of twiddle.
+        self.data[j][3] *= twiddle;
+        self.data[i][3] = temp[3] + self.data[j][3];
+        self.data[j][3] = temp[3] - self.data[j][3];
+
+        // apply of index 4 of twiddle.
+        self.data[j][4] *= twiddle;
+        self.data[i][4] = temp[4] + self.data[j][4];
+        self.data[j][4] = temp[4] - self.data[j][4];
+
+        // apply of index 5 of twiddle.
+        self.data[j][5] *= twiddle;
+        self.data[i][5] = temp[5] + self.data[j][5];
+        self.data[j][5] = temp[5] - self.data[j][5];
+
+        // apply of index 6 of twiddle.
+        self.data[j][6] *= twiddle;
+        self.data[i][6] = temp[6] + self.data[j][6];
+        self.data[j][6] = temp[6] - self.data[j][6];
+
+        // apply of index 7 of twiddle.
+        self.data[j][7] *= twiddle;
+        self.data[i][7] = temp[7] + self.data[j][7];
+        self.data[j][7] = temp[7] - self.data[j][7];
+    }
+
+    fn swap(&mut self, i: usize, j: usize) {
+        self.data.swap(i, j);
+    }
+
+    fn shift_by_series(&mut self, offset: E::BaseField, increment: E::BaseField) {
+        let increment = E::from(increment);
+        let mut offset = E::from(offset);
+        for row_idx in 0..self.len() {
+            // apply on index 0.
+            self.data[row_idx][0] *= offset;
+
+            // apply on index 1.
+            self.data[row_idx][1] *= offset;
+
+            // apply on index 2.
+            self.data[row_idx][2] *= offset;
+
+            // apply on index 3.
+            self.data[row_idx][3] *= offset;
+
+            // apply on index 4.
+            self.data[row_idx][4] *= offset;
+
+            // apply on index 5.
+            self.data[row_idx][5] *= offset;
+
+            // apply on index 6.
+            self.data[row_idx][6] *= offset;
+
+            // apply on index 7.
+            self.data[row_idx][7] *= offset;
+
+            offset *= increment;
+        }
+    }
+
+    fn shift_by(&mut self, offset: E::BaseField) {
+        let offset = E::from(offset);
+
+        for row_idx in 0..self.len() {
+            // apply on index 0.
+            self.data[row_idx][0] *= offset;
+
+            // apply on index 1.
+            self.data[row_idx][1] *= offset;
+
+            // apply on index 2.
+            self.data[row_idx][2] *= offset;
+
+            // apply on index 3.
+            self.data[row_idx][3] *= offset;
+
+            // apply on index 4.
+            self.data[row_idx][4] *= offset;
+
+            // apply on index 5.
+            self.data[row_idx][5] *= offset;
+
+            // apply on index 6.
+            self.data[row_idx][6] *= offset;
+
+            // apply on index 7.
+            self.data[row_idx][7] *= offset;
+        }
+    }
+}
+
+// SEGMENTS
+// ================================================================================================
+
+/// Represents a collection of Segment objects.
+#[derive(Debug, Clone)]
+pub struct Segments<E>
+where
+    E: FieldElement,
+{
+    matrix: Vec<Segment<E>>,
+}
+
+#[allow(dead_code)]
+impl<E> Segments<E>
+where
+    E: FieldElement,
+{
+    /// Create a new segment from a matrix of polynomials.
+    pub fn new(matrix: Vec<Segment<E>>) -> Self {
+        Self { matrix }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a iterator over the segments.
+    pub fn iter(&self) -> SegmentIter<E> {
+        SegmentIter::new(&self.matrix)
+    }
+
+    /// Returns a mutable iterator over the segments.
+    pub fn iter_mut(&mut self) -> SegmentIterMut<E> {
+        SegmentIterMut::new(&mut self.matrix)
+    }
+
+    /// Returns a iterator over the segments.
+    pub fn len(&self) -> usize {
+        self.matrix.len()
+    }
+
+    /// Returns a iterator over the segments.
+    pub fn is_empty(&self) -> bool {
+        self.matrix.is_empty()
+    }
+
+    /// Returns row matrix segment at the given index.
+    ///
+    /// # Panics
+    /// Panics if the index is out of bounds.
+    pub fn get(&self, index: usize) -> Option<&Segment<E>> {
+        self.matrix.get(index)
+    }
+
+    /// Returns mutable row matrix segment at the given index.
+    ///
+    /// # Panics
+    /// Panics if the index is out of bounds.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Segment<E>> {
+        self.matrix.get_mut(index)
+    }
+
+    /// Push a new segment to the end of the segment vector.
+    ///
+    /// # Panics
+    /// Panics if the segment length does not match the length of the other segments.
+    pub fn push(&mut self, segment: Segment<E>) {
+        self.matrix.push(segment);
+    }
+
+    /// Removes the last segment from the segment vector and returns it, or None if it is empty.
+    ///
+    /// # Panics
+    /// Panics if the segment length does not match the length of the other segments.
+    pub fn pop(&mut self) -> Option<Segment<E>> {
+        self.matrix.pop()
+    }
+}
+
+// SECTION: ITERATORS
+// ================================================================================================
+
+// COLUMN ITERATOR
+// ================================================================================================
+
+pub struct SegmentIter<'a, E>
+where
+    E: FieldElement,
+{
+    matrix: &'a [Segment<E>],
+    cursor: usize,
+}
+
+impl<'a, E> SegmentIter<'a, E>
+where
+    E: FieldElement,
+{
+    pub fn new(matrix: &'a Vec<Segment<E>>) -> Self {
+        Self { matrix, cursor: 0 }
+    }
+}
+
+impl<'a, E> Iterator for SegmentIter<'a, E>
+where
+    E: FieldElement,
+{
+    type Item = &'a Segment<E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.matrix.len() - self.cursor {
+            0 => None,
+            _ => {
+                let column = &self.matrix[self.cursor];
+                self.cursor += 1;
+                Some(column)
+            }
+        }
+    }
+}
+
+impl<'a, E> DoubleEndedIterator for SegmentIter<'a, E>
+where
+    E: FieldElement,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.cursor {
+            0 => None,
+            _ => {
+                self.cursor -= 1;
+                Some(&self.matrix[self.cursor])
+            }
+        }
+    }
+}
+
+impl<'a, E> ExactSizeIterator for SegmentIter<'a, E>
+where
+    E: FieldElement,
+{
+    fn len(&self) -> usize {
+        self.matrix.len()
+    }
+}
+
+impl<'a, E> FusedIterator for SegmentIter<'a, E> where E: FieldElement {}
+
+// MUTABLE COLUMN ITERATOR
+// ================================================================================================
+
+pub struct SegmentIterMut<'a, E>
+where
+    E: FieldElement,
+{
+    matrix: &'a mut [Segment<E>],
+    cursor: usize,
+}
+
+impl<'a, E> SegmentIterMut<'a, E>
+where
+    E: FieldElement,
+{
+    pub fn new(matrix: &'a mut Vec<Segment<E>>) -> Self {
+        Self { matrix, cursor: 0 }
+    }
+}
+
+impl<'a, E> Iterator for SegmentIterMut<'a, E>
+where
+    E: FieldElement,
+{
+    type Item = &'a mut Segment<E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.matrix.len() - self.cursor {
+            0 => None,
+            _ => {
+                let segment = &self.matrix[self.cursor];
+                self.cursor += 1;
+
+                // SAFETY: This is safe because the iterator can never yield a reference to the same
+                // segment twice. This is needed to get around mutable iterator lifetime issues.
+                let segment_ptr = segment as *const Segment<E> as *mut Segment<E>;
+                Some(unsafe { &mut *segment_ptr })
+            }
+        }
+    }
+}
+
+impl<'a, E> ExactSizeIterator for SegmentIterMut<'a, E>
+where
+    E: FieldElement,
+{
+    fn len(&self) -> usize {
+        self.matrix.len()
+    }
+}
+
+impl<'a, E> DoubleEndedIterator for SegmentIterMut<'a, E>
+where
+    E: FieldElement,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.cursor {
+            0 => None,
+            _ => {
+                self.cursor -= 1;
+                let segment = &self.matrix[self.cursor];
+
+                // SAFETY: This is safe because the iterator can never yield a reference to the same
+                // segment twice. This is needed to get around mutable iterator lifetime issues.
+                let segment_ptr = segment as *const Segment<E> as *mut Segment<E>;
+                Some(unsafe { &mut *segment_ptr })
+            }
+        }
+    }
+}
+
+impl<'a, E> FusedIterator for SegmentIterMut<'a, E> where E: FieldElement {}

--- a/prover/src/matrix/tests.rs
+++ b/prover/src/matrix/tests.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use crate::{
+    math::{fields::f64::BaseElement, get_power_series, log2, polynom, StarkField},
+    Matrix, RowMatrix,
+};
+use math::FieldElement;
+use rand_utils::rand_vector;
+use utils::collections::Vec;
+
+#[test]
+fn test_eval_poly_with_offset_matrix() {
+    let n = 256;
+    let num_polys = 64;
+    let blowup_factor = 8;
+
+    // generate random columns. Each column is a polynomial of degree n - 1.
+    let mut columns: Vec<Vec<BaseElement>> = (0..num_polys).map(|_| rand_vector(n)).collect();
+
+    // evaluate columns using the row matrix implementation.
+    let row_matrix = RowMatrix::from_polys(&Matrix::new(columns.clone()), blowup_factor);
+
+    // evaluate columns using the using the polynomial evaluation implementation.
+    let offset = BaseElement::GENERATOR;
+    let domain = build_domain(n * blowup_factor);
+    let shifted_domain = domain.iter().map(|&x| x * offset).collect::<Vec<_>>();
+    for p in columns.iter_mut() {
+        *p = polynom::eval_many(p, &shifted_domain);
+    }
+
+    // transpose the columns back to a row major format.
+    let eval_col = transpose(columns);
+
+    // compare the results
+    assert_eq!(row_matrix.as_data(), eval_col);
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Builds a domain of size `size` using the primitive element of the field.
+fn build_domain(size: usize) -> Vec<BaseElement> {
+    let g = BaseElement::get_root_of_unity(log2(size));
+    get_power_series(g, size)
+}
+
+/// Transposes a matrix stored in a column major format to a row major format.
+fn transpose<E: FieldElement>(matrix: Vec<Vec<E>>) -> Vec<E> {
+    // fetch the number of rows and columns in the column-major matrix.
+    let row_len = matrix.len();
+    let num_rows = matrix[0].len();
+
+    // allocate a vector to store the transposed matrix.
+    let mut result = vec![E::ZERO; num_rows * row_len];
+
+    // transpose the matrix.
+    matrix.iter().enumerate().for_each(|(i, row)| {
+        row.iter().enumerate().for_each(|(j, col)| {
+            result[j * row_len + i] = *col;
+        })
+    });
+
+    result
+}


### PR DESCRIPTION
This Pull Request is a continuation of #124 and partially addresses #93. It introduces a new matrix structure in the `matrix` module of the `prover` crate, which uses a row-major layout.

The following improvements have been made in this PR:

-  Introduction of a [Segment](https://github.com/0xKanekiKen/winterfell/blob/new-rowmatrix/prover/src/matrix/row_matrix.rs#L121-L127) struct that is utilized in processing a `column-major` matrix containing polynomial coefficients. to be evaluated on a larger domain. See [from_polys](https://github.com/0xKanekiKen/winterfell/blob/new-rowmatrix/prover/src/matrix/row_matrix.rs#L380-L428).
-  The new structure provides improved efficiency in NTT computation. The [RowMatrix](https://github.com/0xKanekiKen/winterfell/blob/new-rowmatrix/prover/src/matrix/row_matrix.rs#L29-L33) implementation had decreased performance due to the increased cache miss rate during butterfly operations. After evaluation, the [Segments](https://github.com/0xKanekiKen/winterfell/blob/new-rowmatrix/prover/src/matrix/row_matrix.rs#L362-L367) are [transposed](https://github.com/0xKanekiKen/winterfell/blob/new-rowmatrix/prover/src/matrix/row_matrix.rs#L431-L451) back to a `RowMatrix`.
- Currently, this PR only supports `serial-based execution` (support for `concurrent based execution` will be add later in subsequent PRs) and provides a performance improvement of approximately `33%` compared to the column-based approach. The benchmark was performed on a `M1 Macbook Pro`.

The benchmark results, as depicted in the accompanying snapshot, compare the performance of `matrix_evaluate_columns` (representing the `column-major` matrix) against that of `matrix_evaluate_matrix` (representing the `row-major` matrix). 
<img width="1620" alt="Screenshot 2023-02-12 at 4 13 51 PM" src="https://user-images.githubusercontent.com/100861945/218324525-2c5280d8-3ea8-4b35-9b37-1dc46910231f.png">
