### PR TITLE
Fix as_int() non-canonical output

### DIFF
--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -245,9 +245,11 @@ impl StarkField for BaseElement {
     #[inline]
     fn as_int(&self) -> Self::PositiveInteger {
         let x = self.0;
-        let (r, c) = x.overflowing_add(x << 32);
-        let res = r.wrapping_sub(r >> 32).wrapping_sub(c as u64);
-        M - res
+        let (a, e) = x.overflowing_add(x << 32);
+        let b = a.wrapping_sub(a >> 32).wrapping_sub(e as u64);
+
+        let (r, c) = 0u64.overflowing_sub(b);
+        r.wrapping_sub(0u32.wrapping_sub(c as u32) as u64)
     }
 }
 

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -125,6 +125,11 @@ fn element_as_int() {
     let v = u64::MAX;
     let e = BaseElement::new(v);
     assert_eq!(v % super::M, e.as_int());
+
+    let e1 = BaseElement::new(0);
+    let e2 = BaseElement::new(M);
+    assert_eq!(e1.as_int(), e2.as_int());
+    assert_eq!(e1.as_int(), 0);
 }
 
 #[test]


### PR DESCRIPTION
This change fixes the non-canonical conversion of 0 from its Montgomery form equivalent in `f64.`

closes #145 