### PR TITLE
Conversion to base elements for extension field elements

### DIFF
--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -29,7 +29,7 @@ pub struct CubeExtension<B: ExtensibleField<3>>(B, B, B);
 
 impl<B: ExtensibleField<3>> CubeExtension<B> {
     /// Returns a new extension element instantiated from the provided base elements.
-    pub fn new(a: B, b: B, c: B) -> Self {
+    pub const fn new(a: B, b: B, c: B) -> Self {
         Self(a, b, c)
     }
 
@@ -39,8 +39,8 @@ impl<B: ExtensibleField<3>> CubeExtension<B> {
     }
 
     /// Converts a vector of base elements into a vector of elements in a cubic extension field
-    /// by fusing three adjacent base elements together. The output vector is half the length of
-    /// the source vector.
+    /// by fusing three adjacent base elements together. The output vector is one-third the length
+    /// of the source vector.
     fn base_to_cubic_vector(source: Vec<B>) -> Vec<Self> {
         debug_assert!(
             source.len() % 3 == 0,
@@ -52,6 +52,14 @@ impl<B: ExtensibleField<3>> CubeExtension<B> {
         let len = v.len() / 3;
         let cap = v.capacity() / 3;
         unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
+    }
+
+    /// Returns an array of base field elements comprising this extension field element.
+    ///
+    /// The order of abase elements in the returned array is the same as the order in which
+    /// the elements are provided to the [CubeExtension::new()] constructor.
+    pub const fn to_base_elements(self) -> [B; 3] {
+        [self.0, self.1, self.2]
     }
 }
 

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -29,7 +29,7 @@ pub struct QuadExtension<B: ExtensibleField<2>>(B, B);
 
 impl<B: ExtensibleField<2>> QuadExtension<B> {
     /// Returns a new extension element instantiated from the provided base elements.
-    pub fn new(a: B, b: B) -> Self {
+    pub const fn new(a: B, b: B) -> Self {
         Self(a, b)
     }
 
@@ -52,6 +52,14 @@ impl<B: ExtensibleField<2>> QuadExtension<B> {
         let len = v.len() / 2;
         let cap = v.capacity() / 2;
         unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
+    }
+
+    /// Returns an array of base field elements comprising this extension field element.
+    ///
+    /// The order of abase elements in the returned array is the same as the order in which
+    /// the elements are provided to the [QuadExtension::new()] constructor.
+    pub const fn to_base_elements(self) -> [B; 2] {
+        [self.0, self.1]
     }
 }
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -5,7 +5,7 @@
 
 //! An implementation of a 64-bit STARK-friendly prime field with modulus $2^{64} - 2^{32} + 1$
 //! using Montgomery representation.
-//! Our implementation follows https://eprint.iacr.org/2022/274.pdf and is constant-time.
+//! Our implementation follows <https://eprint.iacr.org/2022/274.pdf> and is constant-time.
 //!
 //! This field supports very fast modular arithmetic and has a number of other attractive
 //! properties, including:


### PR DESCRIPTION
This PR adds convenience methods to convert quadratic and cubic extension field elements into corresponding arrays of base field elements.