### PR TITLE
Prepare v0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.0 (2023-02-20)
+* [BREAKING]: Refactored prover/verifier to take hash function as a generic parameter (#111).
+* Introduced `FftInputs` trait (#124).
+* Optimized `as_int()` method for `f64` field (#127, #146).
+* Improved FRI remainder commitment methodology (#128).
+* Added new arithmetization-friendly hash functions: Griffin and Rescue Prime Jive (#129).
+* Fixed panic in prover when debugging with concurrent feature enabled (#130, #132).
+* Added variable-time exponentiation option to `f64` field (#134).
+* Optimized squaring for degree 2 and 3 extension fields of `f64` field (#138).
+* Simplified conversion to base elements for degree 2 and 3 extension field elements (#147).
+* Made closure types less restrictive for `TraceTable::fill()` (#149).
+* [BREAKING] Refactored serialization/deserialization traits (#150).
+
 ## 0.4.2 (2022-11-14)
 * Removed most exponentiations from the constraint evaluation step for the Prover.
 

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-air"
-version = "0.4.2"
+version = "0.5.0"
 description = "AIR components for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-air/0.4.2"
+documentation = "https://docs.rs/winter-air/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "arithmetization", "air"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -20,13 +20,13 @@ default = ["std"]
 std = ["crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.4.2", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.4.2", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.4.2", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.5", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-crypto"
-version = "0.4.2"
+version = "0.5.0"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-crypto/0.4.2"
+documentation = "https://docs.rs/winter-crypto/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -30,12 +30,12 @@ concurrent = ["utils/concurrent", "std"]
 std = ["blake3/std", "math/std", "sha3/std", "utils/std"]
 
 [dependencies]
-blake3 = { version = "1.0", default-features = false }
-math = { version = "0.4.2", path = "../math", package = "winter-math", default-features = false }
+blake3 = { version = "1.3", default-features = false }
+math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
-proptest = "1.0"
-rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils" }
+proptest = "1.1"
+rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.4.2"
+version = "0.5.0"
 description = "Examples of using Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
 categories = ["cryptography"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -26,13 +26,13 @@ default = ["std"]
 std = ["hex/std", "winterfell/std", "core-utils/std", "rand-utils"]
 
 [dependencies]
-winterfell = { version="0.4.2", path = "../winterfell", default-features = false }
-core-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
-rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils", optional = true }
+winterfell = { version="0.5", path = "../winterfell", default-features = false }
+core-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils", optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
-blake3 = { version = "1.0", default-features = false }
-env_logger = { version = "0.9", default-features = false }
+blake3 = { version = "1.3", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 structopt = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-fri"
-version = "0.4.2"
+version = "0.5.0"
 description = "Implementation of FRI protocol for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-fri/0.4.2"
+documentation = "https://docs.rs/winter-fri/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "polynomial", "commitments"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -29,10 +29,10 @@ default = ["std"]
 std = ["crypto/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.4.2", path = "../crypto", package = "winter-crypto", default-features = false }
-math = { version = "0.4.2", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
+math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
-rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-math"
-version = "0.4.2"
+version = "0.5.0"
 description = "Math library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-math/0.4.2"
+documentation = "https://docs.rs/winter-math/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "finite-fields", "polynomials", "fft"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -33,13 +33,13 @@ default = ["std"]
 std = ["utils/std"]
 
 [dependencies]
-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
 num-bigint = "0.4"
-proptest = "1.0"
-rand-utils = { version = "0.4.2", path = "../utils/rand", package = "winter-rand-utils" }
+proptest = "1.1"
+rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-prover"
-version = "0.4.2"
+version = "0.5.0"
 description = "Winterfell STARK prover"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-prover/0.4.2"
+documentation = "https://docs.rs/winter-prover/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -21,12 +21,12 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.4.2", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.4.2", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.4.2", path = '../fri', package = "winter-fri", default-features = false }
+air = { version = "0.5", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.5", path = '../fri', package = "winter-fri", default-features = false }
 log = { version = "0.4", default-features = false }
-math = { version = "0.4.2", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
+math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-utils"
-version = "0.4.2"
+version = "0.5.0"
 description = "Utilities for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-utils/0.4.2"
+documentation = "https://docs.rs/winter-utils/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["serialization", "transmute"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -21,4 +21,4 @@ default = ["std"]
 std = []
 
 [dependencies]
-rayon = { version = "1.5", optional = true }
+rayon = { version = "1.6", optional = true }

--- a/utils/rand/Cargo.toml
+++ b/utils/rand/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "winter-rand-utils"
-version = "0.4.2"
+version = "0.5.0"
 description = "Random value generation utilities for Winterfell crates"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-rand-utils/0.4.2"
+documentation = "https://docs.rs/winter-rand-utils/0.5.0"
 categories = ["cryptography"]
 keywords = ["rand"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
 
 [dependencies]
-utils = { version = "0.4.2", path = "../core", package = "winter-utils" }
+utils = { version = "0.5", path = "../core", package = "winter-utils" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rand =  { version = "0.8" }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winter-verifier"
-version = "0.4.2"
+version = "0.5.0"
 description = "Winterfell STARK verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-verifier/0.4.2"
+documentation = "https://docs.rs/winter-verifier/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "verifier"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -20,11 +20,11 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.4.2", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.4.2", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.4.2", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.4.2", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.4.2", path = "../utils/core", package = "winter-utils", default-features = false }
+air = { version = "0.5", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.5", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/winterfell/Cargo.toml
+++ b/winterfell/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "winterfell"
-version = "0.4.2"
+version = "0.5.0"
 description = "Winterfell STARK prover and verifier"
 authors = ["winterfell contributors"]
 readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winterfell/0.4.2"
+documentation = "https://docs.rs/winterfell/0.5.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover", "verifier"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.67"
 
 [lib]
 bench = false
@@ -21,8 +21,8 @@ default = ["std"]
 std = ["prover/std", "verifier/std"]
 
 [dependencies]
-prover = { version = "0.4.2", path = "../prover", package = "winter-prover", default-features = false }
-verifier = { version = "0.4.2", path = "../verifier", package = "winter-verifier", default-features = false }
+prover = { version = "0.5", path = "../prover", package = "winter-prover", default-features = false }
+verifier = { version = "0.5", path = "../verifier", package = "winter-verifier", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR prepares the crates for v0.5 release. Specifically:

- Updates versions of all crates to v0.5.
- Updates versions of outdated dependences (there were a couple).
- Updates minimum required Rust version to v1.67.
- Updates the CHANGELOG.