### PR TITLE
`TraceTable::fill()`: use least restrictive closure type for arguments

### DIFF
--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -227,10 +227,10 @@ impl<B: StarkField> TraceTable<B> {
     ///   - index of the last updated row (starting with 0).
     ///   - a mutable reference to the last updated state; the contents of the state are copied
     ///     into the next row of the trace after the closure returns.
-    pub fn fill<I, U>(&mut self, init: I, update: U)
+    pub fn fill<I, U>(&mut self, init: I, mut update: U)
     where
-        I: Fn(&mut [B]),
-        U: Fn(usize, &mut [B]),
+        I: FnOnce(&mut [B]),
+        U: FnMut(usize, &mut [B]),
     {
         let mut state = vec![B::ZERO; self.main_trace_width()];
         init(&mut state);
@@ -437,10 +437,10 @@ impl<'a, B: StarkField> TraceTableFragment<'a, B> {
     ///   - index of the last updated row (starting with 0).
     ///   - a mutable reference to the last updated state; the contents of the state are copied
     ///     into the next row of the fragment after the closure returns.
-    pub fn fill<I, T>(&mut self, init_state: I, update_state: T)
+    pub fn fill<I, T>(&mut self, init_state: I, mut update_state: T)
     where
-        I: Fn(&mut [B]),
-        T: Fn(usize, &mut [B]),
+        I: FnOnce(&mut [B]),
+        T: FnMut(usize, &mut [B]),
     {
         let mut state = vec![B::ZERO; self.width()];
         init_state(&mut state);


### PR DESCRIPTION
Currently, `TraceTable::fill()` uses `Fn` as the closure type for both its closure arguments. This needlessly restricts the possibilities for the caller. This PR uses the least restrictive closure type for each argument. 

For example, the following is now made possible:

```rust
pub fn build_do_work_trace(start: BaseElement, n: usize) -> TraceTable<BaseElement> {
    let trace_width = 1;
    let mut trace = TraceTable::new(trace_width, n);

    let mut gen = Generator{};

    trace.fill(
        |state| {
            state[0] = start;
        },
        |_, state| {
            // here, `gen` is borrowed mutably by the closure,
            // which is now allowed.
            state[0] = state[0].exp(3u32.into()) + gen.next();
        },
    );

    trace
}

struct Generator;

impl Generator {
    fn next(&mut self) -> BaseElement { ... }
}
```