### PR TITLE
Security estimate

### DIFF
--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -108,7 +108,7 @@ impl StarkProof {
             get_conjectured_security(
                 self.context.options(),
                 self.context.num_modulus_bits(),
-                self.lde_domain_size() as u64,
+                self.trace_length() as u64,
                 H::COLLISION_RESISTANCE,
             )
         } else {
@@ -181,12 +181,12 @@ impl StarkProof {
 fn get_conjectured_security(
     options: &ProofOptions,
     base_field_bits: u32,
-    lde_domain_size: u64,
+    trace_domain_size: u64,
     collision_resistance: u32,
 ) -> u32 {
     // compute max security we can get for a given field size
     let field_size = base_field_bits * options.field_extension().degree();
-    let field_security = field_size - lde_domain_size.trailing_zeros();
+    let field_security = field_size - trace_domain_size.trailing_zeros();
 
     // compute security we get by executing multiple query rounds
     let security_per_query = log2(options.blowup_factor());

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -112,8 +112,12 @@ impl StarkProof {
                 H::COLLISION_RESISTANCE,
             )
         } else {
-            // TODO: implement provable security estimation
-            unimplemented!("proven security estimation has not been implement yet")
+            get_proven_security(
+                self.context.options(),
+                self.context.num_modulus_bits(),
+                self.lde_domain_size() as u64,
+                H::COLLISION_RESISTANCE,
+            )
         }
     }
 
@@ -195,6 +199,54 @@ fn get_conjectured_security(
 
     cmp::min(
         cmp::min(field_security, query_security) - 1,
+        collision_resistance,
+    )
+}
+
+/// Estimates proven security level for the specified proof parameters.
+fn get_proven_security(
+    options: &ProofOptions,
+    base_field_bits: u32,
+    lde_domain_size: u64,
+    collision_resistance: u32,
+) -> u32 {
+    let extension_field_bits = (base_field_bits * options.field_extension().degree()) as f64;
+    let blowup_bits = log2(options.blowup_factor()) as f64;
+    let num_fri_queries = options.num_queries() as f64;
+    let lde_size_bits = lde_domain_size.trailing_zeros() as f64;
+
+    // m is a parameter greater or equal to 3.
+    // A larger m gives a worse field security bound but a better query security bound.
+    // An optimal value of m is then a value that would balance field and query security
+    // but there is no simple closed form solution.
+    // This sets m so that field security is equal to the best query security for any value
+    // of m, unless the calculated value is less than 3 in which case it gets rounded up to 3.
+    let mut m = extension_field_bits + 1.0;
+    m -= options.grinding_factor() as f64;
+    m -= (num_fri_queries + 3.0) / 2.0 * blowup_bits;
+    m -= 2.0 * lde_size_bits;
+    m /= 7.0;
+    m = 2.0_f64.powf(m);
+    m -= 0.5;
+    m = m.max(3.0);
+
+    // compute pre-FRI query security
+    // this considers only the third component given in the corresponding part of eq. 20
+    // in https://eprint.iacr.org/2021/582, i.e. (m+1/2)^7.n^2 / (2\rho^1.5.q) as all
+    // other terms are negligible in comparison.
+    let pre_query_security = (extension_field_bits + 1.0
+        - 3.0 / 2.0 * blowup_bits
+        - 2.0 * lde_size_bits
+        - 7.0 * (m + 0.5).log2()) as u32;
+
+    // compute security we get by executing multiple query rounds
+    let security_per_query = 0.5 * blowup_bits - (1.0 + 1.0 / (2.0 * m)).log2();
+    let mut query_security = (security_per_query * num_fri_queries) as u32;
+
+    query_security += options.grinding_factor();
+
+    cmp::min(
+        cmp::min(pre_query_security, query_security) - 1,
         collision_resistance,
     )
 }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -106,14 +106,14 @@ impl ExampleOptions {
     }
 
     /// Returns security level of the input proof in bits.
-    pub fn get_proof_security_level(&self, proof: &StarkProof) -> usize {
+    pub fn get_proof_security_level(&self, proof: &StarkProof, conjectured: bool) -> usize {
         let security_level = match self.hash_fn.as_str() {
-            "blake3_192" => proof.security_level::<Blake3_192>(true),
-            "blake3_256" => proof.security_level::<Blake3_256>(true),
-            "sha3_256" => proof.security_level::<Sha3_256>(true),
-            "rp64_256" => proof.security_level::<Rp64_256>(true),
-            "rp_jive64_256" => proof.security_level::<RpJive64_256>(true),
-            "griffin_jive64_256" => proof.security_level::<GriffinJive64_256>(true),
+            "blake3_192" => proof.security_level::<Blake3_192>(conjectured),
+            "blake3_256" => proof.security_level::<Blake3_256>(conjectured),
+            "sha3_256" => proof.security_level::<Sha3_256>(conjectured),
+            "rp64_256" => proof.security_level::<Rp64_256>(conjectured),
+            "rp_jive64_256" => proof.security_level::<RpJive64_256>(conjectured),
+            "griffin_jive64_256" => proof.security_level::<GriffinJive64_256>(conjectured),
             val => panic!("'{val}' is not a valid hash function option"),
         };
 

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -76,8 +76,12 @@ fn main() {
 
     let proof_bytes = proof.to_bytes();
     debug!("Proof size: {:.1} KB", proof_bytes.len() as f64 / 1024f64);
-    let security_level = options.get_proof_security_level(&proof);
-    debug!("Proof security: {} bits", security_level);
+    let conjectured_security_level = options.get_proof_security_level(&proof, true);
+    let proven_security_level = options.get_proof_security_level(&proof, false);
+    debug!(
+        "Proof security: {} bits ({} proven)",
+        conjectured_security_level, proven_security_level,
+    );
     #[cfg(feature = "std")]
     debug!(
         "Proof hash: {}",


### PR DESCRIPTION
This PR adds proven security level estimate.

Examples now show both conjectured and proven security levels.

The $m$ parameter in the proven security is updated dynamically to optimize the balance between field security and query security. The approach taken is based on the two following assumptions:

- For the "pre-FRI-query err" as mentioned in [ethSTARK paper](https://eprint.iacr.org/2021/582.pdf), only the third (dominant) component, i.e. $\dfrac{(m+\frac{1}{2})^7 \cdot n^2}{2\rho^{3/2}q}$, is considered.
- For the "FRI-query err", the value $\sqrt{\rho} \cdot (1 + \frac{1}{2m})$ is approximated by $\sqrt{\rho}$. The reason for this is that the term $\frac{1}{2m} \leq \frac{1}{6}$ is fairly small, and doubling $m$ removes about 7 bits of security for the pre-FRI-query term.

Based on those two assumptions, we can solve (using the paper notations):
$$-\log_2{\dfrac{(m+\frac{1}{2})^7 \cdot n^2}{2\rho^{3/2}q}} = \zeta - s \cdot \log_2{\sqrt{\rho}}$$ which yields

$$\log_2{(m + \frac{1}{2})} = \dfrac{1 + \log_2{q} + \frac{s+3}{2} \log_2{\rho} - \zeta - 2\log_2{n}}{7} = T$$

$$m = 2^T - \frac{1}{2}$$

with
- $\zeta$ the grinding factor
- $\rho$ the inverse of the blowup factor $b$ (i.e. $\log_2{\rho} = -\log_2{b}$)
- $s$ the number of queries
- $q$ the extended field size
- $n$ the extended trace length