### PR TITLE
Update Matrix Transpose Logic

### DIFF
--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -91,11 +91,12 @@ where
         let mut result = unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * num_segs) };
 
         // transpose the segments into a row matrix.
-        segments.iter().enumerate().for_each(|(i, segment)| {
-            (segment.as_data()).iter().enumerate().for_each(|(j, row)| {
-                result[j * num_segs + i] = *row;
-            })
-        });
+        for i in 0..num_rows {
+            for j in 0..num_segs {
+                let v = &segments[j].as_data()[i];
+                result[i * num_segs + j].copy_from_slice(v);
+            }
+        }
 
         // create a `RowMatrix` object from the result.
         RowMatrix {


### PR DESCRIPTION
During transposing a column-major matrix to row-major one, prefer writing to contiguous memory locations. 

> **Note** This change brings ~2-3% performance improvement. 