### PR TITLE
Multi-threaded evaluation in `RowMatrix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `FieldElement::EXTENSION_DEGREE` constant.
 * Added `FieldElement::base_element` and `FieldElement::slice_from_base_elements` methods.
 * [BREAKING] Renamed `FieldElement::as_base_elements` into `FieldElement::slice_as_base_elements`.
+* Added `Matrix::num_base_cols` and `Matrix::get_base_element` methods.
 
 ## 0.5.1 (2023-02-20)
 * Fix no-std build for winter-utils (#153)

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use super::fft_inputs::FftInputs;
 use crate::{
     field::{FieldElement, StarkField},
     utils::log2,
@@ -141,7 +142,7 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
     // apply inner FFTs
     values
         .par_chunks_mut(outer_len)
-        .for_each(|row| super::fft_inputs::fft_in_place(row, &twiddles, stretch, stretch, 0));
+        .for_each(|row| row.fft_in_place_raw(&twiddles, stretch, stretch, 0));
 
     // transpose inner x inner x stretch square matrix
     transpose_square_stretch(values, inner_len, stretch);
@@ -160,7 +161,7 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
                     outer_twiddle = outer_twiddle * inner_twiddle;
                 }
             }
-            super::fft_inputs::fft_in_place(row, &twiddles, 1, 1, 0)
+            row.fft_in_place(&twiddles);
         });
 }
 

--- a/math/src/fft/fft_inputs.rs
+++ b/math/src/fft/fft_inputs.rs
@@ -68,7 +68,7 @@ pub trait FftInputs<E: FieldElement> {
     /// The FFT is applied in place, so the input is replaced with the result of the FFT. The
     /// `twiddles` parameter specifies the twiddle factors to use for the FFT.
     ///
-    /// This is convenience methods equivalent to calling fft_in_place_raw(twiddles, 1, 1, 0).
+    /// This is a convenience method equivalent to calling fft_in_place_raw(twiddles, 1, 1, 0).
     ///
     /// # Panics
     /// Panics if length of the `twiddles` parameter is not self.len() / 2.
@@ -146,7 +146,7 @@ impl<E: FieldElement> FftInputs<E> for [E] {
 // SLICE OF ARRAYS IMPLEMENTATION
 // ================================================================================================
 
-/// Implements FftInputs for a slice of field element arrays.
+/// Implements [FftInputs] for a slice of field element arrays.
 #[allow(clippy::needless_range_loop)]
 impl<E: FieldElement, const N: usize> FftInputs<E> for [[E; N]] {
     fn len(&self) -> usize {

--- a/math/src/fft/fft_inputs.rs
+++ b/math/src/fft/fft_inputs.rs
@@ -68,10 +68,29 @@ pub trait FftInputs<E: FieldElement> {
     /// The FFT is applied in place, so the input is replaced with the result of the FFT. The
     /// `twiddles` parameter specifies the twiddle factors to use for the FFT.
     ///
+    /// This is convenience methods equivalent to calling fft_in_place_raw(twiddles, 1, 1, 0).
+    ///
     /// # Panics
     /// Panics if length of the `twiddles` parameter is not self.len() / 2.
     fn fft_in_place(&mut self, twiddles: &[E::BaseField]) {
         fft_in_place(self, twiddles, 1, 1, 0);
+    }
+
+    /// Applies the FFT to this input.
+    ///
+    /// The FFT is applied in place, so the input is replaced with the result of the FFT. The
+    /// `twiddles` parameter specifies the twiddle factors to use for the FFT.
+    ///
+    /// # Panics
+    /// Panics if length of the `twiddles` parameter is not self.len() / 2.
+    fn fft_in_place_raw(
+        &mut self,
+        twiddles: &[E::BaseField],
+        count: usize,
+        stride: usize,
+        offset: usize,
+    ) {
+        fft_in_place(self, twiddles, count, stride, offset)
     }
 }
 
@@ -193,7 +212,7 @@ impl<E: FieldElement, const N: usize> FftInputs<E> for [[E; N]] {
 /// In-place recursive FFT with permuted output.
 ///
 /// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
-pub(super) fn fft_in_place<E, I>(
+fn fft_in_place<E, I>(
     values: &mut I,
     twiddles: &[E::BaseField],
     count: usize,

--- a/math/src/fft/fft_inputs.rs
+++ b/math/src/fft/fft_inputs.rs
@@ -128,11 +128,13 @@ impl<E: FieldElement> FftInputs<E> for [E] {
 // ================================================================================================
 
 /// Implements FftInputs for a slice of field element arrays.
+#[allow(clippy::needless_range_loop)]
 impl<E: FieldElement, const N: usize> FftInputs<E> for [[E; N]] {
     fn len(&self) -> usize {
         self.len()
     }
 
+    #[inline(always)]
     fn butterfly(&mut self, offset: usize, stride: usize) {
         let i = offset;
         let j = offset + stride;
@@ -144,6 +146,7 @@ impl<E: FieldElement, const N: usize> FftInputs<E> for [[E; N]] {
         }
     }
 
+    #[inline(always)]
     fn butterfly_twiddle(&mut self, twiddle: E::BaseField, offset: usize, stride: usize) {
         let i = offset;
         let j = offset + stride;

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -18,9 +18,7 @@ use crate::{
 };
 
 pub mod fft_inputs;
-
 pub mod real_u64;
-
 mod serial;
 
 #[cfg(feature = "concurrent")]
@@ -33,7 +31,6 @@ mod tests;
 
 // CONSTANTS
 // ================================================================================================
-const USIZE_BITS: usize = 0_usize.count_zeros() as usize;
 const MIN_CONCURRENT_SIZE: usize = 1024;
 
 // POLYNOMIAL EVALUATION
@@ -586,8 +583,21 @@ where
     super::polynom::degree_of(&poly)
 }
 
-// HELPER FUNCTIONS
+// PERMUTATIONS
 // ================================================================================================
+
+/// Computes bit reverse of the specified index in the domain of the specified size.
+///
+/// Domain size is assumed to be a power of two and index must be smaller than domain size.
+pub fn permute_index(size: usize, index: usize) -> usize {
+    const USIZE_BITS: u32 = 0_usize.count_zeros();
+
+    debug_assert!(index < size);
+    debug_assert!(size.is_power_of_two());
+
+    let bits = size.trailing_zeros();
+    index.reverse_bits().wrapping_shr(USIZE_BITS - bits)
+}
 
 fn permute<E: FieldElement>(v: &mut [E]) {
     if cfg!(feature = "concurrent") && v.len() >= MIN_CONCURRENT_SIZE {
@@ -596,14 +606,4 @@ fn permute<E: FieldElement>(v: &mut [E]) {
     } else {
         FftInputs::permute(v);
     }
-}
-
-fn permute_index(size: usize, index: usize) -> usize {
-    debug_assert!(index < size);
-    if size == 1 {
-        return 0;
-    }
-    debug_assert!(size.is_power_of_two());
-    let bits = size.trailing_zeros() as usize;
-    index.reverse_bits() >> (USIZE_BITS - bits)
 }

--- a/prover/benches/row_matrix.rs
+++ b/prover/benches/row_matrix.rs
@@ -57,7 +57,7 @@ fn evaluate_matrix(c: &mut Criterion) {
             };
             group.bench_function(BenchmarkId::new(SIZE.to_string(), params), |bench| {
                 bench.iter_with_large_drop(|| {
-                    RowMatrix::transpose_and_extend(&column_matrix, blowup_factor);
+                    RowMatrix::evaluate_polys::<8>(&column_matrix, blowup_factor);
                 });
             });
         }

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -89,6 +89,27 @@ impl<E: FieldElement> Matrix<E> {
         self.columns[col_idx][row_idx]
     }
 
+    /// Returns base field elements located at the specified column and row indexes in this matrix.
+    ///
+    /// For STARK fields, `base_col_idx` is the same as `col_idx` used in `Self::get` method. For
+    /// extension fields, each column in the matrix is viewed as 2 or more columns in the base
+    /// field.
+    ///
+    /// Thus, for example, if we are in a degree 2 extension field, `base_col_idx = 0` would refer
+    /// to the first base element of the first column, `base_col_idx = 1` would refer to the second
+    /// base element of the first column, `base_col_idx = 2` would refer to the first base element
+    /// of the second column etc.
+    ///
+    /// # Panics
+    /// Panics if either `base_col_idx` or `row_idx` are out of bounds for this matrix.
+    pub fn get_base_element(&self, base_col_idx: usize, row_idx: usize) -> E::BaseField {
+        let (col_idx, elem_idx) = (
+            base_col_idx / E::EXTENSION_DEGREE,
+            base_col_idx % E::EXTENSION_DEGREE,
+        );
+        self.columns[col_idx][row_idx].base_element(elem_idx)
+    }
+
     /// Set the cell in this matrix at the specified column and row indexes to the provided value.
     ///
     /// # Panics

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -76,6 +76,14 @@ impl<E: FieldElement> Matrix<E> {
         self.columns.len()
     }
 
+    /// Returns the number of base field columns in this matrix.
+    ///
+    /// The number of base field columns is defined as the number of columns multiplied by the
+    /// extension degree of field elements contained in this matrix.
+    pub fn num_base_cols(&self) -> usize {
+        self.num_cols() * E::EXTENSION_DEGREE
+    }
+
     /// Returns the number of rows in this matrix.
     pub fn num_rows(&self) -> usize {
         self.columns[0].len()

--- a/prover/src/matrix/mod.rs
+++ b/prover/src/matrix/mod.rs
@@ -10,7 +10,7 @@ mod col_matrix;
 pub use col_matrix::{ColumnIter, Matrix, MultiColumnIter};
 
 mod segments;
-use segments::{Segment, SEGMENT_WIDTH};
+use segments::Segment;
 
 #[cfg(test)]
 mod tests;

--- a/prover/src/matrix/mod.rs
+++ b/prover/src/matrix/mod.rs
@@ -4,13 +4,13 @@
 // LICENSE file in the root directory of this source tree.
 
 mod row_matrix;
-pub use row_matrix::*;
+pub use row_matrix::RowMatrix;
 
 mod col_matrix;
-pub use col_matrix::*;
+pub use col_matrix::{ColumnIter, Matrix, MultiColumnIter};
 
 mod segments;
-use segments::*;
+use segments::{Segment, SEGMENT_WIDTH};
 
 #[cfg(test)]
 mod tests;

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -3,11 +3,13 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::segments::Segment;
-use crate::{matrix::ARR_SIZE, Matrix};
+use super::{Matrix, Segment, SEGMENT_WIDTH};
 use math::{fft, log2, FieldElement, StarkField};
 use utils::collections::Vec;
 use utils::{flatten_vector_elements, uninit_vector};
+
+#[cfg(feature = "concurrent")]
+use utils::iterators::*;
 
 // ROW-MAJOR MATRIX
 // ================================================================================================
@@ -42,7 +44,7 @@ where
     /// - if the specified data is empty.
     pub fn new(data: Vec<E>, row_len: usize) -> Self {
         assert!(data.len() % row_len == 0);
-        assert!(row_len % ARR_SIZE == 0);
+        assert!(row_len % SEGMENT_WIDTH == 0);
         assert!(!data.is_empty());
 
         Self { data, row_len }
@@ -52,7 +54,7 @@ where
     /// a shifted domain offset.
     pub fn transpose_and_extend(polys: &Matrix<E>, blowup_factor: usize) -> Self {
         let poly_size = polys.num_rows();
-        let num_segments = polys.num_cols() / ARR_SIZE;
+        let num_segments = polys.num_cols() / SEGMENT_WIDTH;
 
         // compute twiddles for polynomial evaluation
         let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows());
@@ -62,7 +64,7 @@ where
 
         // build matrix segments by evaluating all polynomials
         let segments = (0..num_segments)
-            .map(|i| Segment::new(polys, i * ARR_SIZE, &offsets, &twiddles))
+            .map(|i| Segment::new(polys, i * SEGMENT_WIDTH, &offsets, &twiddles))
             .collect::<Vec<_>>();
 
         // transpose data in individual segments into a single row-major matrix
@@ -71,31 +73,21 @@ where
 
     /// Converts a collection of segments into a row-major matrix.
     pub fn from_segments(segments: Vec<Segment<E>>) -> Self {
-        // get the number of rows and segments.
-        let num_rows = segments[0].num_rows();
-        let num_segs = segments.len();
+        // compute the size of each row
+        let row_len = segments.len() * SEGMENT_WIDTH;
 
-        // create a vector of arrays to hold the result.
-        // TODO: use a more efficient way so that we don't have to allocate a vector of arrays here.
-        let mut result = unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * num_segs) };
+        // transpose the segments into a single vector of arrays
+        let result = transpose(segments);
 
-        // transpose the segments into a row matrix.
-        for i in 0..num_rows {
-            for j in 0..num_segs {
-                let v = &segments[j].as_data()[i];
-                result[i * num_segs + j].copy_from_slice(v);
-            }
-        }
-
-        // create a `RowMatrix` object from the result.
+        // flatten the result to be a simple vector of elements and return
         RowMatrix {
             data: flatten_vector_elements(result),
-            row_len: num_segs * ARR_SIZE,
+            row_len,
         }
     }
 
     // PUBLIC ACCESSORS
-    // ---------------------------------------------------------------------------------------------
+    // --------------------------------------------------------------------------------------------
 
     /// Returns the number of rows in this matrix.
     pub fn num_rows(&self) -> usize {
@@ -123,42 +115,104 @@ where
 
 /// Returns a vector of offsets for an evaluation defined by the specified polynomial size, blowup
 /// factor and domain offset.
+///
+/// When `concurrent` feature is enabled, offsets are computed in multiple threads.
 fn get_offsets<E: FieldElement>(
     poly_size: usize,
     blowup_factor: usize,
     domain_offset: E::BaseField,
 ) -> Vec<E::BaseField> {
     let domain_size = poly_size * blowup_factor;
-
     let g = E::BaseField::get_root_of_unity(log2(domain_size));
 
-    // create a vector to hold the offsets.
+    // allocate memory to hold the offsets
     let mut offsets = unsafe { uninit_vector(domain_size) };
 
+    // define a closure to compute offsets for a given chunk of the result; the number of chunks
+    // is defined by the blowup factor. for example, for blowup factor = 2, the number of chunks
+    // will be 2, for blowup factor = 8, the number of chunks will be 8 etc.
+    let compute_offsets = |(chunk_idx, chunk): (usize, &mut [E::BaseField])| {
+        let idx = fft::permute_index(blowup_factor, chunk_idx) as u64;
+        let offset = g.exp_vartime(idx.into()) * domain_offset;
+        let mut factor = E::BaseField::ONE;
+        for res in chunk.iter_mut() {
+            *res = factor;
+            factor *= offset;
+        }
+    };
+
+    // compute offsets for each chunk using either parallel or regular iterators
+
+    #[cfg(not(feature = "concurrent"))]
     offsets
         .chunks_mut(poly_size)
         .enumerate()
-        .for_each(|(i, chunk)| {
-            let idx = permute_index(blowup_factor, i) as u64;
-            let offset = g.exp_vartime(idx.into()) * domain_offset;
-            let mut factor = E::BaseField::ONE;
-            for res in chunk.iter_mut() {
-                *res = factor;
-                factor *= offset;
-            }
-        });
+        .for_each(compute_offsets);
+
+    #[cfg(feature = "concurrent")]
+    offsets
+        .par_chunks_mut(poly_size)
+        .enumerate()
+        .for_each(compute_offsets);
 
     offsets
 }
 
-fn permute_index(size: usize, index: usize) -> usize {
-    const USIZE_BITS: usize = 0_usize.count_zeros() as usize;
+/// Transposes a vector of segments into a single vector of fixed-size arrays.
+///
+/// When `concurrent` feature is enabled, transposition is performed in multiple threads.
+fn transpose<E: FieldElement>(segments: Vec<Segment<E>>) -> Vec<[E; SEGMENT_WIDTH]> {
+    let num_rows = segments[0].num_rows();
+    let num_segs = segments.len();
+    let result_len = num_rows * num_segs;
 
-    debug_assert!(index < size);
-    if size == 1 {
-        return 0;
+    // allocate memory to hold the transposed result;
+    // TODO: investigate transposing in-place
+    let mut result = unsafe { uninit_vector::<[E; SEGMENT_WIDTH]>(result_len) };
+
+    // determine number of batches in which transposition will be preformed; if `concurrent`
+    // feature is not enabled, the number of batches will always be 1
+    let num_batches = get_num_batches(result_len);
+    let rows_per_batch = num_rows / num_batches;
+
+    // define a closure for transposing a given batch
+    let transpose_batch = |(batch_idx, batch): (usize, &mut [[E; SEGMENT_WIDTH]])| {
+        let row_offset = batch_idx * rows_per_batch;
+        for i in 0..rows_per_batch {
+            let row_idx = i + row_offset;
+            for j in 0..num_segs {
+                let v = &segments[j].data()[row_idx];
+                batch[i * num_segs + j].copy_from_slice(v);
+            }
+        }
+    };
+
+    // call the closure either once (for single-threaded transposition) or in a parallel
+    // iterator (for multi-threaded transposition)
+
+    #[cfg(not(feature = "concurrent"))]
+    transpose_batch((0, &mut result));
+
+    #[cfg(feature = "concurrent")]
+    result
+        .par_chunks_mut(result_len / num_batches)
+        .enumerate()
+        .for_each(transpose_batch);
+
+    result
+}
+
+#[cfg(not(feature = "concurrent"))]
+fn get_num_batches(_input_size: usize) -> usize {
+    1
+}
+
+#[cfg(feature = "concurrent")]
+fn get_num_batches(input_size: usize) -> usize {
+    if input_size < 1024 {
+        return 1;
     }
-    debug_assert!(size.is_power_of_two());
-    let bits = size.trailing_zeros() as usize;
-    index.reverse_bits() >> (USIZE_BITS - bits)
+
+    use utils::rayon;
+    rayon::current_num_threads().next_power_of_two() * 2
 }

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -49,7 +49,7 @@ impl<E: FieldElement> RowMatrix<E> {
     /// in the `polys` matrix) and the `blowup_factor`.
     ///
     /// To improve performance, polynomials are evaluated in batches specified by the `N` type
-    /// parameter. Minimum batch size is 0.
+    /// parameter. Minimum batch size is 1.
     pub fn evaluate_polys<const N: usize>(polys: &Matrix<E>, blowup_factor: usize) -> Self {
         assert!(N > 0, "batch size N must be greater than zero");
         let poly_size = polys.num_rows();

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -9,7 +9,7 @@ use math::{fft, FieldElement, StarkField};
 use utils::collections::Vec;
 use utils::{flatten_vector_elements, uninit_vector};
 
-// ROWMAJOR MATRIX
+// ROW-MAJOR MATRIX
 // ================================================================================================
 
 /// A row-major matrix of field elements. The matrix is represented as a single vector of field
@@ -58,10 +58,10 @@ where
         // get the twiddles for the segment.
         let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows() * blowup_factor);
 
-        // precompute offsets for each row.
+        // pre-compute offsets for each row.
         let offsets = get_offsets::<E>(num_rows, E::BaseField::GENERATOR);
 
-        // create a vector of uninitialised segments to hold the result.
+        // create a vector of uninitialized segments to hold the result.
         let mut segments = allocate_segments::<E>(num_rows, row_width, blowup_factor);
 
         // create segments.
@@ -152,9 +152,9 @@ where
     offsets
 }
 
-/// Creates a vector of uninitialised segments to hold the result. The number of segments is
+/// Creates a vector of uninitialized segments to hold the result. The number of segments is
 /// equal to the number of columns in the matrix divided by the ARR_SIZE. Each segment is
-/// initialised with a vector of uninitialised arrays of length `num_rows * blowup_factor`.
+/// initialized with a vector of uninitialized arrays of length `num_rows * blowup_factor`.
 ///
 /// # Panics
 /// Panics if the number of columns in the matrix is not a multiple of ARR_SIZE.
@@ -168,10 +168,10 @@ where
     );
     let outer_vec_len = row_width / ARR_SIZE;
 
-    // create a vector of uninitialised segments to hold the result.
-    // SAFETY: we are creating a vector of uninitialised segments, and each segment is
-    // initialised with a vector of uninitialised arrays of length `num_rows * blowup_factor`.
-    // This is safe because we are not reading from the vectors, and we will initialise
+    // create a vector of uninitialized segments to hold the result.
+    // SAFETY: we are creating a vector of uninitialized segments, and each segment is
+    // initialized with a vector of uninitialized arrays of length `num_rows * blowup_factor`.
+    // This is safe because we are not reading from the vectors, and we will initialize
     // the vectors before reading from them.
     let outer_vec: Vec<Segment<E>> = (0..outer_vec_len)
         .map(|_| Segment::new(unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * blowup_factor) }))

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -5,7 +5,7 @@
 
 use super::segments::Segment;
 use crate::{matrix::ARR_SIZE, Matrix};
-use math::{fft, FieldElement, StarkField};
+use math::{fft, log2, FieldElement, StarkField};
 use utils::collections::Vec;
 use utils::{flatten_vector_elements, uninit_vector};
 
@@ -51,37 +51,26 @@ where
     /// Converts a column-major matrix of polynomials `Matrix<E>` into a RowMatrix evaluated at
     /// a shifted domain offset.
     pub fn transpose_and_extend(polys: &Matrix<E>, blowup_factor: usize) -> Self {
-        // get the number of rows and columns in the polys.
-        let row_width = polys.num_cols();
-        let num_rows = polys.num_rows();
+        let poly_size = polys.num_rows();
+        let num_segments = polys.num_cols() / ARR_SIZE;
 
-        // get the twiddles for the segment.
-        let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows() * blowup_factor);
+        // compute twiddles for polynomial evaluation
+        let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows());
 
-        // pre-compute offsets for each row.
-        let offsets = get_offsets::<E>(num_rows, E::BaseField::GENERATOR);
+        // pre-compute offsets for each row
+        let offsets = get_offsets::<E>(poly_size, blowup_factor, E::BaseField::GENERATOR);
 
-        // create a vector of uninitialized segments to hold the result.
-        let mut segments = allocate_segments::<E>(num_rows, row_width, blowup_factor);
+        // build matrix segments by evaluating all polynomials
+        let segments = (0..num_segments)
+            .map(|i| Segment::new(polys, i * ARR_SIZE, &offsets, &twiddles))
+            .collect::<Vec<_>>();
 
-        // create segments.
-        segments
-            .iter_mut()
-            .enumerate()
-            .for_each(|(seg_idx, segment)| {
-                // prepare the segment.
-                prepare_segment(segment, polys, seg_idx, &offsets);
-
-                // evaluate the segment at the shifted domain offset.
-                segment.evaluate_poly(&twiddles);
-            });
-
-        // create a `RowMatrix` object from the segments.
+        // transpose data in individual segments into a single row-major matrix
         Self::from_segments(segments)
     }
 
     /// Converts a collection of segments into a row-major matrix.
-    fn from_segments(segments: Vec<Segment<E>>) -> Self {
+    pub fn from_segments(segments: Vec<Segment<E>>) -> Self {
         // get the number of rows and segments.
         let num_rows = segments[0].num_rows();
         let num_segs = segments.len();
@@ -132,70 +121,44 @@ where
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Returns a vector of offsets for the specified number of rows. The offsets are computed as
-/// `domain_offset^i` for `i` in `[0, num_rows)`. The first offset is always 1.
-fn get_offsets<E>(num_rows: usize, domain_offset: E::BaseField) -> Vec<E::BaseField>
-where
-    E: FieldElement,
-{
+/// Returns a vector of offsets for an evaluation defined by the specified polynomial size, blowup
+/// factor and domain offset.
+fn get_offsets<E: FieldElement>(
+    poly_size: usize,
+    blowup_factor: usize,
+    domain_offset: E::BaseField,
+) -> Vec<E::BaseField> {
+    let domain_size = poly_size * blowup_factor;
+
+    let g = E::BaseField::get_root_of_unity(log2(domain_size));
+
     // create a vector to hold the offsets.
-    let mut offsets = Vec::with_capacity(num_rows);
+    let mut offsets = unsafe { uninit_vector(domain_size) };
 
-    // the first offset is always 1.
-    offsets.push(E::BaseField::ONE);
-
-    // compute the remaining offsets.
-    for i in 1..num_rows {
-        offsets.push(offsets[i - 1] * domain_offset);
-    }
+    offsets
+        .chunks_mut(poly_size)
+        .enumerate()
+        .for_each(|(i, chunk)| {
+            let idx = permute_index(blowup_factor, i) as u64;
+            let offset = g.exp_vartime(idx.into()) * domain_offset;
+            let mut factor = E::BaseField::ONE;
+            for res in chunk.iter_mut() {
+                *res = factor;
+                factor *= offset;
+            }
+        });
 
     offsets
 }
 
-/// Creates a vector of uninitialized segments to hold the result. The number of segments is
-/// equal to the number of columns in the matrix divided by the ARR_SIZE. Each segment is
-/// initialized with a vector of uninitialized arrays of length `num_rows * blowup_factor`.
-///
-/// # Panics
-/// Panics if the number of columns in the matrix is not a multiple of ARR_SIZE.
-fn allocate_segments<E>(num_rows: usize, row_width: usize, blowup_factor: usize) -> Vec<Segment<E>>
-where
-    E: FieldElement,
-{
-    assert!(
-        row_width % ARR_SIZE == 0,
-        "number of columns must be a multiple of ARR_SIZE"
-    );
-    let outer_vec_len = row_width / ARR_SIZE;
+fn permute_index(size: usize, index: usize) -> usize {
+    const USIZE_BITS: usize = 0_usize.count_zeros() as usize;
 
-    // create a vector of uninitialized segments to hold the result.
-    // SAFETY: we are creating a vector of uninitialized segments, and each segment is
-    // initialized with a vector of uninitialized arrays of length `num_rows * blowup_factor`.
-    // This is safe because we are not reading from the vectors, and we will initialize
-    // the vectors before reading from them.
-    let outer_vec: Vec<Segment<E>> = (0..outer_vec_len)
-        .map(|_| Segment::new(unsafe { uninit_vector::<[E; ARR_SIZE]>(num_rows * blowup_factor) }))
-        .collect();
-
-    outer_vec
-}
-
-/// Prepares a segment for evaluation by multiplying each element in the segment by the
-/// corresponding offset.
-fn prepare_segment<E>(
-    segment: &mut Segment<E>,
-    polys: &Matrix<E>,
-    seg_idx: usize,
-    offsets: &[E::BaseField],
-) where
-    E: FieldElement,
-{
-    (seg_idx * ARR_SIZE..(seg_idx + 1) * ARR_SIZE).for_each(|col_idx| {
-        // get the column from the polys matrix.
-        let col = polys.get_column(col_idx);
-        col.iter().enumerate().for_each(|(row_idx, elem)| {
-            segment.as_mut_data()[row_idx][col_idx - seg_idx * ARR_SIZE] =
-                elem.mul_base(offsets[row_idx]);
-        });
-    });
+    debug_assert!(index < size);
+    if size == 1 {
+        return 0;
+    }
+    debug_assert!(size.is_power_of_two());
+    let bits = size.trailing_zeros() as usize;
+    index.reverse_bits() >> (USIZE_BITS - bits)
 }

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -7,10 +7,17 @@ use super::Matrix;
 use math::{fft::fft_inputs::FftInputs, FieldElement};
 use utils::{collections::Vec, uninit_vector};
 
+#[cfg(feature = "concurrent")]
+use utils::iterators::*;
+
 // CONSTANTS
 // ================================================================================================
 
-pub const ARR_SIZE: usize = 8;
+/// Number of elements in row of a segment.
+pub const SEGMENT_WIDTH: usize = 8;
+
+/// Segments with domain sizes under this number will be evaluated in a single thread.
+const MIN_CONCURRENT_SIZE: usize = 1024;
 
 // SEGMENT OF ROW-MAJOR MATRIX
 // ================================================================================================
@@ -40,7 +47,7 @@ pub const ARR_SIZE: usize = 8;
 /// It is arranged in a way that allows for efficient FFT operations.
 #[derive(Clone, Debug)]
 pub struct Segment<E: FieldElement> {
-    data: Vec<[E; ARR_SIZE]>,
+    data: Vec<[E; SEGMENT_WIDTH]>,
 }
 
 impl<E: FieldElement> Segment<E> {
@@ -70,40 +77,191 @@ impl<E: FieldElement> Segment<E> {
         debug_assert_eq!(poly_size, twiddles.len() * 2);
 
         // allocate uninitialized memory for the segment
-        let mut data = unsafe { uninit_vector::<[E; ARR_SIZE]>(domain_size) };
+        let mut data = unsafe { uninit_vector::<[E; SEGMENT_WIDTH]>(domain_size) };
 
-        // prepare the segment for FFT algorithm; this involves copying the polynomial coefficients
-        // into the segment and applying the specified offsets.
-        for i in 0..ARR_SIZE {
-            let p = polys.get_column(poly_offset + i);
+        // evaluate the polynomials either in a single thread or multiple threads, depending
+        // on whether `concurrent` feature is enabled and domain size is greater than 1024;
+
+        if cfg!(feature = "concurrent") && domain_size >= MIN_CONCURRENT_SIZE {
+            #[cfg(feature = "concurrent")]
+            data.par_chunks_mut(poly_size)
+                .zip(offsets.par_chunks(poly_size))
+                .for_each(|(d_chunk, o_chunk)| {
+                    for row_idx in 0..poly_size {
+                        for i in 0..SEGMENT_WIDTH {
+                            let coeff = polys.get(poly_offset + i, row_idx);
+                            d_chunk[row_idx][i] = coeff.mul_base(o_chunk[row_idx]);
+                        }
+                    }
+                    concurrent::split_radix_fft(d_chunk, twiddles);
+                });
+            #[cfg(feature = "concurrent")]
+            concurrent::permute(&mut data);
+        } else {
             data.chunks_mut(poly_size)
                 .zip(offsets.chunks(poly_size))
                 .for_each(|(d_chunk, o_chunk)| {
                     for row_idx in 0..poly_size {
-                        d_chunk[row_idx][i] = p[row_idx].mul_base(o_chunk[row_idx])
+                        for i in 0..SEGMENT_WIDTH {
+                            let coeff = polys.get(poly_offset + i, row_idx);
+                            d_chunk[row_idx][i] = coeff.mul_base(o_chunk[row_idx]);
+                        }
                     }
+                    d_chunk.fft_in_place(twiddles);
                 });
+            data.permute();
         }
 
-        // run FFT algorithm and then permute the result
-        data.chunks_mut(poly_size).for_each(|chunk| {
-            chunk.fft_in_place(twiddles);
-        });
-        data.permute();
-
-        Self { data }
+        Segment { data }
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the number of rows in this matrix.
+    /// Returns the number of rows in this segment.
     pub fn num_rows(&self) -> usize {
         self.data.len()
     }
 
-    /// Returns the data in this matrix as a slice of arrays.
-    pub fn as_data(&self) -> &[[E; ARR_SIZE]] {
+    /// Returns the data in this segment as a slice of arrays.
+    pub fn data(&self) -> &[[E; SEGMENT_WIDTH]] {
         &self.data
+    }
+}
+
+// CONCURRENT FFT IMPLEMENTATION
+// ================================================================================================
+
+/// Multi-threaded implementations of FFT and permutation algorithms. These are very similar to
+/// the functions implemented in `winter-math::fft::concurrent` module, but are adapted to work
+/// with slices of element arrays.
+#[cfg(feature = "concurrent")]
+mod concurrent {
+    use super::{FftInputs, FieldElement, SEGMENT_WIDTH};
+    use math::fft::permute_index;
+    use utils::{iterators::*, rayon};
+
+    /// In-place recursive FFT with permuted output.
+    /// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
+    pub fn split_radix_fft<E: FieldElement>(
+        data: &mut [[E; SEGMENT_WIDTH]],
+        twiddles: &[E::BaseField],
+    ) {
+        // generator of the domain should be in the middle of twiddles
+        let n = data.len();
+        let g = twiddles[twiddles.len() / 2];
+        debug_assert_eq!(g.exp((n as u32).into()), E::BaseField::ONE);
+
+        let inner_len = 1_usize << (n.ilog2() / 2);
+        let outer_len = n / inner_len;
+        let stretch = outer_len / inner_len;
+        debug_assert!(outer_len == inner_len || outer_len == 2 * inner_len);
+        debug_assert_eq!(outer_len * inner_len, n);
+
+        // transpose inner x inner x stretch square matrix
+        transpose_square_stretch(data, inner_len, stretch);
+
+        // apply inner FFTs
+        data.par_chunks_mut(outer_len)
+            .for_each(|row| row.fft_in_place_raw(&twiddles, stretch, stretch, 0));
+
+        // transpose inner x inner x stretch square matrix
+        transpose_square_stretch(data, inner_len, stretch);
+
+        // apply outer FFTs
+        data.par_chunks_mut(outer_len)
+            .enumerate()
+            .for_each(|(i, row)| {
+                if i > 0 {
+                    let i = permute_index(inner_len, i);
+                    let inner_twiddle = g.exp_vartime((i as u32).into());
+                    let mut outer_twiddle = inner_twiddle;
+                    for element in row.iter_mut().skip(1) {
+                        for col_idx in 0..SEGMENT_WIDTH {
+                            element[col_idx] = element[col_idx].mul_base(outer_twiddle);
+                        }
+                        outer_twiddle = outer_twiddle * inner_twiddle;
+                    }
+                }
+                row.fft_in_place(&twiddles)
+            });
+    }
+
+    // PERMUTATIONS
+    // --------------------------------------------------------------------------------------------
+
+    pub fn permute<E: FieldElement>(v: &mut [[E; SEGMENT_WIDTH]]) {
+        let n = v.len();
+        let num_batches = rayon::current_num_threads().next_power_of_two() * 2;
+        let batch_size = n / num_batches;
+        rayon::scope(|s| {
+            for batch_idx in 0..num_batches {
+                // create another mutable reference to the slice of values to use in a new thread;
+                // this is OK because we never write the same positions in the slice from different
+                // threads
+                let values = unsafe { &mut *(&mut v[..] as *mut [[E; SEGMENT_WIDTH]]) };
+                s.spawn(move |_| {
+                    let batch_start = batch_idx * batch_size;
+                    let batch_end = batch_start + batch_size;
+                    for i in batch_start..batch_end {
+                        let j = permute_index(n, i);
+                        if j > i {
+                            values.swap(i, j);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    // TRANSPOSING
+    // --------------------------------------------------------------------------------------------
+
+    fn transpose_square_stretch<E: FieldElement>(
+        data: &mut [[E; SEGMENT_WIDTH]],
+        size: usize,
+        stretch: usize,
+    ) {
+        assert_eq!(data.len(), size * size * stretch);
+        match stretch {
+            1 => transpose_square_1(data, size),
+            2 => transpose_square_2(data, size),
+            _ => unimplemented!("only stretch sizes 1 and 2 are supported"),
+        }
+    }
+
+    fn transpose_square_1<E: FieldElement>(data: &mut [[E; SEGMENT_WIDTH]], size: usize) {
+        debug_assert_eq!(data.len(), size * size);
+        debug_assert_eq!(size % 2, 0, "odd sizes are not supported");
+
+        // iterate over upper-left triangle, working in 2x2 blocks
+        // TODO: investigate concurrent implementation
+        for row in (0..size).step_by(2) {
+            let i = row * size + row;
+            data.swap(i + 1, i + size);
+            for col in (row..size).step_by(2).skip(1) {
+                let i = row * size + col;
+                let j = col * size + row;
+                data.swap(i, j);
+                data.swap(i + 1, j + size);
+                data.swap(i + size, j + 1);
+                data.swap(i + size + 1, j + size + 1);
+            }
+        }
+    }
+
+    fn transpose_square_2<E: FieldElement>(data: &mut [[E; SEGMENT_WIDTH]], size: usize) {
+        debug_assert_eq!(data.len(), 2 * size * size);
+
+        // iterate over upper-left triangle, working in 1x2 blocks
+        // TODO: investigate concurrent implementation
+        for row in 0..size {
+            for col in (row..size).skip(1) {
+                let i = (row * size + col) * 2;
+                let j = (col * size + row) * 2;
+                data.swap(i, j);
+                data.swap(i + 1, j + 1);
+            }
+        }
     }
 }

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -11,7 +11,7 @@ use utils::collections::Vec;
 
 pub const ARR_SIZE: usize = 8;
 
-// SEGMENT OF ROWMAJOR MATRIX
+// SEGMENT OF ROW-MAJOR MATRIX
 // ================================================================================================
 
 /// A segment of a row-major matrix of field elements. The segment is represented as a single vector
@@ -38,17 +38,11 @@ pub const ARR_SIZE: usize = 8;
 ///
 /// It is arranged in a way that allows for efficient FFT operations.
 #[derive(Clone, Debug)]
-pub struct Segment<E>
-where
-    E: FieldElement,
-{
+pub struct Segment<E: FieldElement> {
     data: Vec<[E; ARR_SIZE]>,
 }
 
-impl<E> Segment<E>
-where
-    E: FieldElement,
-{
+impl<E: FieldElement> Segment<E> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 
@@ -81,143 +75,7 @@ where
     where
         E: FieldElement,
     {
-        self.fft_in_place(twiddles);
-        self.permute()
-    }
-}
-
-/// Implementation of `FftInputs` for `Segment`.
-impl<E> FftInputs<E> for Segment<E>
-where
-    E: FieldElement,
-{
-    fn len(&self) -> usize {
-        self.num_rows()
-    }
-
-    #[inline(always)]
-    fn butterfly(&mut self, offset: usize, stride: usize) {
-        let i = offset;
-        let j = offset + stride;
-
-        let temp = self.data[i];
-
-        //  apply on 1st element of the array.
-        self.data[i][0] = temp[0] + self.data[j][0];
-        self.data[j][0] = temp[0] - self.data[j][0];
-
-        // apply on 2nd element of the array.
-        self.data[i][1] = temp[1] + self.data[j][1];
-        self.data[j][1] = temp[1] - self.data[j][1];
-
-        // apply on 3rd element of the array.
-        self.data[i][2] = temp[2] + self.data[j][2];
-        self.data[j][2] = temp[2] - self.data[j][2];
-
-        // apply on 4th element of the array.
-        self.data[i][3] = temp[3] + self.data[j][3];
-        self.data[j][3] = temp[3] - self.data[j][3];
-
-        // apply on 5th element of the array.
-        self.data[i][4] = temp[4] + self.data[j][4];
-        self.data[j][4] = temp[4] - self.data[j][4];
-
-        // apply on 6th element of the array.
-        self.data[i][5] = temp[5] + self.data[j][5];
-        self.data[j][5] = temp[5] - self.data[j][5];
-
-        // apply on 7th element of the array.
-        self.data[i][6] = temp[6] + self.data[j][6];
-        self.data[j][6] = temp[6] - self.data[j][6];
-
-        // apply on 8th element of the array.
-        self.data[i][7] = temp[7] + self.data[j][7];
-        self.data[j][7] = temp[7] - self.data[j][7];
-    }
-
-    #[inline(always)]
-    fn butterfly_twiddle(&mut self, twiddle: E::BaseField, offset: usize, stride: usize) {
-        let i = offset;
-        let j = offset + stride;
-
-        let twiddle = E::from(twiddle);
-        let temp = self.data[i];
-
-        // apply of index 0 of twiddle.
-        self.data[j][0] *= twiddle;
-        self.data[i][0] = temp[0] + self.data[j][0];
-        self.data[j][0] = temp[0] - self.data[j][0];
-
-        // apply of index 1 of twiddle.
-        self.data[j][1] *= twiddle;
-        self.data[i][1] = temp[1] + self.data[j][1];
-        self.data[j][1] = temp[1] - self.data[j][1];
-
-        // apply of index 2 of twiddle.
-        self.data[j][2] *= twiddle;
-        self.data[i][2] = temp[2] + self.data[j][2];
-        self.data[j][2] = temp[2] - self.data[j][2];
-
-        // apply of index 3 of twiddle.
-        self.data[j][3] *= twiddle;
-        self.data[i][3] = temp[3] + self.data[j][3];
-        self.data[j][3] = temp[3] - self.data[j][3];
-
-        // apply of index 4 of twiddle.
-        self.data[j][4] *= twiddle;
-        self.data[i][4] = temp[4] + self.data[j][4];
-        self.data[j][4] = temp[4] - self.data[j][4];
-
-        // apply of index 5 of twiddle.
-        self.data[j][5] *= twiddle;
-        self.data[i][5] = temp[5] + self.data[j][5];
-        self.data[j][5] = temp[5] - self.data[j][5];
-
-        // apply of index 6 of twiddle.
-        self.data[j][6] *= twiddle;
-        self.data[i][6] = temp[6] + self.data[j][6];
-        self.data[j][6] = temp[6] - self.data[j][6];
-
-        // apply of index 7 of twiddle.
-        self.data[j][7] *= twiddle;
-        self.data[i][7] = temp[7] + self.data[j][7];
-        self.data[j][7] = temp[7] - self.data[j][7];
-    }
-
-    fn swap(&mut self, i: usize, j: usize) {
-        self.data.swap(i, j);
-    }
-
-    fn shift_by_series(&mut self, offset: E::BaseField, increment: E::BaseField) {
-        let increment = E::from(increment);
-        let mut offset = E::from(offset);
-
-        for row_idx in 0..self.len() {
-            self.data[row_idx][0] *= offset;
-            self.data[row_idx][1] *= offset;
-            self.data[row_idx][2] *= offset;
-            self.data[row_idx][3] *= offset;
-            self.data[row_idx][4] *= offset;
-            self.data[row_idx][5] *= offset;
-            self.data[row_idx][6] *= offset;
-            self.data[row_idx][7] *= offset;
-
-            offset *= increment;
-        }
-    }
-
-    fn shift_by(&mut self, offset: E::BaseField) {
-        let offset = E::from(offset);
-
-        for row_idx in 0..self.len() {
-            self.data[row_idx][0] *= offset;
-            self.data[row_idx][1] *= offset;
-            self.data[row_idx][2] *= offset;
-            self.data[row_idx][3] *= offset;
-            self.data[row_idx][4] *= offset;
-            self.data[row_idx][5] *= offset;
-            self.data[row_idx][6] *= offset;
-            self.data[row_idx][7] *= offset;
-        }
+        self.data.fft_in_place(twiddles);
+        self.data.permute()
     }
 }

--- a/prover/src/matrix/tests.rs
+++ b/prover/src/matrix/tests.rs
@@ -20,7 +20,7 @@ fn test_eval_poly_with_offset_matrix() {
     let mut columns: Vec<Vec<BaseElement>> = (0..num_polys).map(|_| rand_vector(n)).collect();
 
     // evaluate columns using the row matrix implementation.
-    let row_matrix = RowMatrix::transpose_and_extend(&Matrix::new(columns.clone()), blowup_factor);
+    let row_matrix = RowMatrix::evaluate_polys::<8>(&Matrix::new(columns.clone()), blowup_factor);
 
     // evaluate columns using the using the polynomial evaluation implementation.
     let offset = BaseElement::GENERATOR;
@@ -32,7 +32,7 @@ fn test_eval_poly_with_offset_matrix() {
 
     // compare the results of the two implementations row by row.
     for row in 0..n * blowup_factor {
-        let row_matrix_row = row_matrix.get_row(row);
+        let row_matrix_row = row_matrix.row(row);
         let eval_col_row = get_row(&columns, row);
         assert_eq!(row_matrix_row, eval_col_row);
     }


### PR DESCRIPTION
This PR implements multi-threaded polynomial evaluation (using FFT) for `RowMatrix` struct and also refactors/improves single-threaded evaluation

Benchmarking this on Apple M1 Pro for `f64` field, 64-column matrix, and $2^{20} \rightarrow 2^{23}$ extension, I get the following results:

- Single-threaded evaluation: ~40% faster than using column-based approach.
- Multi-threaded evaluation: ~37% faster than using column-based approach.

Unfortunately, this PR also results in some code duplication. Specifically, `split_radix_fft` methods had to be duplicated for `RowMatrix` almost entirely. But overall, I think it is worth it.