### PR TITLE
refactor: f64 fft inline hotspots

### DIFF
--- a/air/src/air/transition/frame.rs
+++ b/air/src/air/transition/frame.rs
@@ -57,25 +57,21 @@ impl<E: FieldElement> EvaluationFrame<E> {
     // --------------------------------------------------------------------------------------------
 
     /// Returns a reference to the current row.
-    #[inline(always)]
     pub fn current(&self) -> &[E] {
         &self.current
     }
 
     /// Returns a mutable reference to the current row.
-    #[inline(always)]
     pub fn current_mut(&mut self) -> &mut [E] {
         &mut self.current
     }
 
     /// Returns a reference to the next row.
-    #[inline(always)]
     pub fn next(&self) -> &[E] {
         &self.next
     }
 
     /// Returns a mutable reference to the next row.
-    #[inline(always)]
     pub fn next_mut(&mut self) -> &mut [E] {
         &mut self.next
     }

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -7,6 +7,7 @@ use crate::{
     field::{FieldElement, StarkField},
     utils::log2,
 };
+use core::ptr;
 use utils::{collections::Vec, iterators::*, rayon, uninit_vector};
 
 // POLYNOMIAL EVALUATION
@@ -132,19 +133,26 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
     let inner_len = 1_usize << (log2(n) / 2);
     let outer_len = n / inner_len;
     let stretch = outer_len / inner_len;
+    let ptr = values.as_mut_ptr();
     debug_assert!(outer_len == inner_len || outer_len == 2 * inner_len);
     debug_assert_eq!(outer_len * inner_len, n);
+    debug_assert!(stretch == 1 || stretch == 2);
+    debug_assert_eq!(values.len(), stretch * inner_len * inner_len);
+    debug_assert!(
+        stretch == 2 || inner_len & 1 != 1,
+        "odd sizes are not supported"
+    );
 
-    // transpose inner x inner x stretch square matrix
-    transpose_square_stretch(values, inner_len, stretch);
+    // Safety: matrix bounds are checked
+    unsafe { transpose_square_stretch(ptr, inner_len, stretch) };
 
     // apply inner FFTs
     values
         .par_chunks_mut(outer_len)
         .for_each(|row| super::fft_inputs::fft_in_place(row, &twiddles, stretch, stretch, 0));
 
-    // transpose inner x inner x stretch square matrix
-    transpose_square_stretch(values, inner_len, stretch);
+    // Safety: matrix bounds are checked
+    unsafe { transpose_square_stretch(ptr, inner_len, stretch) };
 
     // apply outer FFTs
     values
@@ -155,7 +163,7 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
                 let i = super::permute_index(inner_len, i);
                 let inner_twiddle = g.exp((i as u32).into());
                 let mut outer_twiddle = inner_twiddle;
-                for element in row.iter_mut().skip(1) {
+                for element in (&mut row[1..]).iter_mut() {
                     *element = (*element).mul_base(outer_twiddle);
                     outer_twiddle = outer_twiddle * inner_twiddle;
                 }
@@ -167,46 +175,35 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
 // TRANSPOSING
 // ================================================================================================
 
-fn transpose_square_stretch<T>(matrix: &mut [T], size: usize, stretch: usize) {
-    assert_eq!(matrix.len(), size * size * stretch);
-    match stretch {
-        1 => transpose_square_1(matrix, size),
-        2 => transpose_square_2(matrix, size),
-        _ => unimplemented!("only stretch sizes 1 and 2 are supported"),
-    }
-}
-
-fn transpose_square_1<T>(matrix: &mut [T], size: usize) {
-    debug_assert_eq!(matrix.len(), size * size);
-    if size % 2 != 0 {
-        unimplemented!("odd sizes are not supported");
-    }
-
+/// Transposes inner x inner x stretch square matrix
+#[inline]
+unsafe fn transpose_square_stretch<T>(ptr: *mut T, size: usize, stretch: usize) {
     // iterate over upper-left triangle, working in 2x2 blocks
-    for row in (0..size).step_by(2) {
-        let i = row * size + row;
-        matrix.swap(i + 1, i + size);
-        for col in (row..size).step_by(2).skip(1) {
-            let i = row * size + col;
-            let j = col * size + row;
-            matrix.swap(i, j);
-            matrix.swap(i + 1, j + size);
-            matrix.swap(i + size, j + 1);
-            matrix.swap(i + size + 1, j + size + 1);
+    if stretch == 1 {
+        // Safety: matrix bounds are checked
+        for row in (0..size).step_by(2) {
+            let i = row * size + row;
+            ptr::swap(ptr.add(i + 1), ptr.add(i + size));
+            for col in (row + 2..size).step_by(2) {
+                let i = row * size + col;
+                let j = col * size + row;
+                ptr::swap(ptr.add(i), ptr.add(j));
+                ptr::swap(ptr.add(i + 1), ptr.add(j + size));
+                ptr::swap(ptr.add(i + size), ptr.add(j + 1));
+                ptr::swap(ptr.add(i + size + 1), ptr.add(j + size + 1));
+            }
         }
     }
-}
-
-fn transpose_square_2<T>(matrix: &mut [T], size: usize) {
-    debug_assert_eq!(matrix.len(), 2 * size * size);
 
     // iterate over upper-left triangle, working in 1x2 blocks
-    for row in 0..size {
-        for col in (row..size).skip(1) {
-            let i = (row * size + col) * 2;
-            let j = (col * size + row) * 2;
-            matrix.swap(i, j);
-            matrix.swap(i + 1, j + 1);
+    if stretch == 2 {
+        for row in 0..size {
+            for col in row + 1..size {
+                let i = (row * size + col) * 2;
+                let j = (col * size + row) * 2;
+                ptr::swap(ptr.add(i), ptr.add(j));
+                ptr::swap(ptr.add(i + 1), ptr.add(j + 1));
+            }
         }
     }
 }

--- a/math/src/fft/fft_inputs.rs
+++ b/math/src/fft/fft_inputs.rs
@@ -70,6 +70,7 @@ pub trait FftInputs<E: FieldElement> {
     ///
     /// # Panics
     /// Panics if length of the `twiddles` parameter is not self.len() / 2.
+    #[inline]
     fn fft_in_place(&mut self, twiddles: &[E::BaseField]) {
         fft_in_place(self, twiddles, 1, 1, 0);
     }
@@ -84,7 +85,7 @@ where
         self.len()
     }
 
-    #[inline(always)]
+    #[inline]
     fn butterfly(&mut self, offset: usize, stride: usize) {
         let i = offset;
         let j = offset + stride;
@@ -93,7 +94,7 @@ where
         self[j] = temp - self[j];
     }
 
-    #[inline(always)]
+    #[inline]
     fn butterfly_twiddle(&mut self, twiddle: E::BaseField, offset: usize, stride: usize) {
         let i = offset;
         let j = offset + stride;
@@ -162,13 +163,12 @@ pub(super) fn fft_in_place<E, I>(
 
     // Apply butterfly operations with twiddle factors.
     let last_offset = offset + size * stride;
-    for (i, offset) in (offset..last_offset)
+    for (i, offset) in (offset + 2 * stride..last_offset)
         .step_by(2 * stride)
         .enumerate()
-        .skip(1)
     {
         for j in offset..(offset + count) {
-            I::butterfly_twiddle(values, twiddles[i], j, stride);
+            I::butterfly_twiddle(values, twiddles[i + 1], j, stride);
         }
     }
 }

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -181,27 +181,27 @@ where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    assert!(
+    debug_assert!(
         p.len().is_power_of_two(),
         "number of coefficients must be a power of 2"
     );
-    assert!(
+    debug_assert!(
         blowup_factor.is_power_of_two(),
         "blowup factor must be a power of 2"
     );
-    assert_eq!(
+    debug_assert_eq!(
         p.len(),
         twiddles.len() * 2,
         "invalid number of twiddles: expected {} but received {}",
         p.len() / 2,
         twiddles.len()
     );
-    assert!(
+    debug_assert!(
         log2(p.len() * blowup_factor) <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         p.len() * blowup_factor
     );
-    assert_ne!(domain_offset, B::ZERO, "domain offset cannot be zero");
+    debug_assert_ne!(domain_offset, B::ZERO, "domain offset cannot be zero");
 
     // assign a dummy value here to make the compiler happy
     #[allow(unused_assignments)]
@@ -279,19 +279,19 @@ where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    assert!(
+    debug_assert!(
         evaluations.len().is_power_of_two(),
         "number of evaluations must be a power of 2, but was {}",
         evaluations.len()
     );
-    assert_eq!(
+    debug_assert_eq!(
         evaluations.len(),
         inv_twiddles.len() * 2,
         "invalid number of twiddles: expected {} but received {}",
         evaluations.len() / 2,
         inv_twiddles.len()
     );
-    assert!(
+    debug_assert!(
         log2(evaluations.len()) <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         evaluations.len()
@@ -370,24 +370,24 @@ pub fn interpolate_poly_with_offset<B, E>(
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    assert!(
+    debug_assert!(
         evaluations.len().is_power_of_two(),
         "number of evaluations must be a power of 2, but was {}",
         evaluations.len()
     );
-    assert_eq!(
+    debug_assert_eq!(
         evaluations.len(),
         inv_twiddles.len() * 2,
         "invalid number of twiddles: expected {} but received {}",
         evaluations.len() / 2,
         inv_twiddles.len()
     );
-    assert!(
+    debug_assert!(
         log2(evaluations.len()) <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         evaluations.len()
     );
-    assert_ne!(domain_offset, B::ZERO, "domain offset cannot be zero");
+    debug_assert_ne!(domain_offset, B::ZERO, "domain offset cannot be zero");
 
     // when `concurrent` feature is enabled, run the concurrent version of the function; unless
     // the polynomial is small, then don't bother with the concurrent version
@@ -421,19 +421,19 @@ where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    assert!(
+    debug_assert!(
         values.len().is_power_of_two(),
         "number of values must be a power of 2, but was {}",
         values.len()
     );
-    assert_eq!(
+    debug_assert_eq!(
         values.len(),
         twiddles.len() * 2,
         "invalid number of twiddles: expected {} but received {}",
         values.len() / 2,
         twiddles.len()
     );
-    assert!(
+    debug_assert!(
         log2(values.len()) <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         values.len()
@@ -470,11 +470,11 @@ pub fn get_twiddles<B>(domain_size: usize) -> Vec<B>
 where
     B: StarkField,
 {
-    assert!(
+    debug_assert!(
         domain_size.is_power_of_two(),
         "domain size must be a power of 2"
     );
-    assert!(
+    debug_assert!(
         log2(domain_size) <= B::TWO_ADICITY,
         "multiplicative subgroup of size {domain_size} does not exist in the specified base field"
     );
@@ -598,12 +598,10 @@ fn permute<E: FieldElement>(v: &mut [E]) {
     }
 }
 
+#[inline(always)]
 fn permute_index(size: usize, index: usize) -> usize {
     debug_assert!(index < size);
-    if size == 1 {
-        return 0;
-    }
     debug_assert!(size.is_power_of_two());
     let bits = size.trailing_zeros() as usize;
-    index.reverse_bits() >> (USIZE_BITS - bits)
+    ((size != 1) as usize * index.reverse_bits()) >> (USIZE_BITS - bits).min(USIZE_BITS - 1)
 }

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -74,7 +74,6 @@ impl BaseElement {
 
     /// Computes an exponentiation to the power 7. This is useful for computing Rescue-Prime
     /// S-Box over this field.
-    #[inline(always)]
     pub fn exp7(self) -> Self {
         let x2 = self.square();
         let x4 = x2.square();
@@ -118,7 +117,6 @@ impl FieldElement for BaseElement {
         Self(result.wrapping_sub(M * over))
     }
 
-    #[inline]
     fn exp(self, power: Self::PositiveInteger) -> Self {
         let mut b: Self;
         let mut r = Self::ONE;
@@ -134,7 +132,6 @@ impl FieldElement for BaseElement {
         r
     }
 
-    #[inline]
     #[allow(clippy::many_single_char_names)]
     fn inv(self) -> Self {
         // compute base^(M - 2) using 72 multiplications
@@ -310,7 +307,6 @@ impl Eq for BaseElement {}
 impl Add for BaseElement {
     type Output = Self;
 
-    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, rhs: Self) -> Self {
         // We compute a + b = a - (p - b).
@@ -321,7 +317,6 @@ impl Add for BaseElement {
 }
 
 impl AddAssign for BaseElement {
-    #[inline]
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs
     }
@@ -330,7 +325,6 @@ impl AddAssign for BaseElement {
 impl Sub for BaseElement {
     type Output = Self;
 
-    #[inline]
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, rhs: Self) -> Self {
         let (x1, c1) = self.0.overflowing_sub(rhs.0);
@@ -340,7 +334,6 @@ impl Sub for BaseElement {
 }
 
 impl SubAssign for BaseElement {
-    #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
@@ -356,7 +349,6 @@ impl Mul for BaseElement {
 }
 
 impl MulAssign for BaseElement {
-    #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs
     }
@@ -382,7 +374,6 @@ impl DivAssign for BaseElement {
 impl Neg for BaseElement {
     type Output = Self;
 
-    #[inline]
     fn neg(self) -> Self {
         Self::ZERO - self
     }
@@ -395,7 +386,7 @@ impl Neg for BaseElement {
 /// x + 2. Thus, an extension element is defined as α + β * φ, where φ is a root of this polynomial,
 /// and α and β are base field elements.
 impl ExtensibleField<2> for BaseElement {
-    #[inline(always)]
+    #[inline]
     fn mul(a: [Self; 2], b: [Self; 2]) -> [Self; 2] {
         // performs multiplication in the extension field using 3 multiplications, 3 additions,
         // and 2 subtractions in the base field. overall, a single multiplication in the extension
@@ -407,7 +398,6 @@ impl ExtensibleField<2> for BaseElement {
         ]
     }
 
-    #[inline(always)]
     fn square(a: [Self; 2]) -> [Self; 2] {
         let a0 = a[0];
         let a1 = a[1];
@@ -420,14 +410,13 @@ impl ExtensibleField<2> for BaseElement {
         [out0, out1]
     }
 
-    #[inline(always)]
+    #[inline]
     fn mul_base(a: [Self; 2], b: Self) -> [Self; 2] {
         // multiplying an extension field element by a base field element requires just 2
         // multiplications in the base field.
         [a[0] * b, a[1] * b]
     }
 
-    #[inline(always)]
     fn frobenius(x: [Self; 2]) -> [Self; 2] {
         [x[0] + x[1], -x[1]]
     }
@@ -440,7 +429,7 @@ impl ExtensibleField<2> for BaseElement {
 /// x - 1. Thus, an extension element is defined as α + β * φ + γ * φ^2, where φ is a root of this
 /// polynomial, and α, β and γ are base field elements.
 impl ExtensibleField<3> for BaseElement {
-    #[inline(always)]
+    #[inline]
     fn mul(a: [Self; 3], b: [Self; 3]) -> [Self; 3] {
         // performs multiplication in the extension field using 6 multiplications, 9 additions,
         // and 4 subtractions in the base field. overall, a single multiplication in the extension
@@ -467,7 +456,7 @@ impl ExtensibleField<3> for BaseElement {
         ]
     }
 
-    #[inline(always)]
+    #[inline]
     fn square(a: [Self; 3]) -> [Self; 3] {
         let a0 = a[0];
         let a1 = a[1];
@@ -483,14 +472,14 @@ impl ExtensibleField<3> for BaseElement {
         [out0, out1, out2]
     }
 
-    #[inline(always)]
+    #[inline]
     fn mul_base(a: [Self; 3], b: Self) -> [Self; 3] {
         // multiplying an extension field element by a base field element requires just 3
         // multiplications in the base field.
         [a[0] * b, a[1] * b, a[2] * b]
     }
 
-    #[inline(always)]
+    #[inline]
     fn frobenius(x: [Self; 3]) -> [Self; 3] {
         // coefficients were computed using SageMath
         [
@@ -618,7 +607,6 @@ impl Deserializable for BaseElement {
 }
 
 /// Squares the base N number of times and multiplies the result by the tail value.
-#[inline(always)]
 fn exp_acc<const N: usize>(base: BaseElement, tail: BaseElement) -> BaseElement {
     let mut result = base;
     for _ in 0..N {
@@ -629,7 +617,7 @@ fn exp_acc<const N: usize>(base: BaseElement, tail: BaseElement) -> BaseElement 
 
 /// Montgomery reduction (variable time)
 #[allow(dead_code)]
-#[inline(always)]
+#[inline]
 const fn mont_red_var(x: u128) -> u64 {
     const NPRIME: u64 = 4294967297;
     let q = (((x as u64) as u128) * (NPRIME as u128)) as u64;
@@ -643,7 +631,7 @@ const fn mont_red_var(x: u128) -> u64 {
 }
 
 /// Montgomery reduction (constant time)
-#[inline(always)]
+#[inline]
 const fn mont_red_cst(x: u128) -> u64 {
     // See reference above for a description of the following implementation.
     let xl = x as u64;
@@ -658,7 +646,7 @@ const fn mont_red_cst(x: u128) -> u64 {
 
 /// Test of equality between two BaseField elements; return value is
 /// 0xFFFFFFFFFFFFFFFF if the two values are equal, or 0 otherwise.
-#[inline(always)]
+#[inline]
 pub fn equals(lhs: u64, rhs: u64) -> u64 {
     let t = lhs ^ rhs;
     !((((t | t.wrapping_neg()) as i64) >> 63) as u64)

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -318,7 +318,7 @@ pub trait ExtensionOf<E: FieldElement>: From<E> {
 
 /// A field is always an extension of itself.
 impl<E: FieldElement> ExtensionOf<E> for E {
-    #[inline(always)]
+    #[inline]
     fn mul_base(self, other: E) -> Self {
         self * other
     }

--- a/math/src/utils/mod.rs
+++ b/math/src/utils/mod.rs
@@ -201,7 +201,7 @@ where
 /// assert_eq!(log2(2usize.pow(20)), 20);
 /// ```
 pub fn log2(n: usize) -> u32 {
-    assert!(n.is_power_of_two(), "n must be a power of two");
+    debug_assert!(n.is_power_of_two(), "n must be a power of two");
     n.trailing_zeros()
 }
 

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -112,8 +112,8 @@ impl<E: FieldElement> Matrix<E> {
     /// # Panics
     /// Panics if `row_idx` is out of bounds for this matrix.
     pub fn read_row_into(&self, row_idx: usize, row: &mut [E]) {
-        for (column, value) in self.columns.iter().zip(row.iter_mut()) {
-            *value = column[row_idx];
+        for i in 0..self.columns.len().min(row.len()) {
+            row[i] = self.columns[i][row_idx];
         }
     }
 


### PR DESCRIPTION
This commit refactors the inline directive distribution, loosing the requirements on cold spots, and introducing new directives into hot spots.

It aims to decrease the code size so we reduce the L1 cache miss for core threads. The target use case is Miden VM proof generation, and we dropped from 7.64% L1 cache miss to ~2.3% on Intel x64 for a 2^21 proof generation. We achieved a significant performance gain for such proof generation of approx. 20% for both Intel x64 and Apple M1. The performance gain will present only for large matrices that will be more likely to suffer cache miss, so there will be no significant gain for small operations.

This commit also introduces an improvement on branch miss. It is much harder for rayon to properly optimize branches if we have `skip`, and for the fft implementation, it was trivial to just refactor the starting indexes as we deal mostly with slices of matrices. The branch miss dropped from ~8.2% to 0.89% on Intel x64.

The focus of this commit is restricted to f64 as it is the one consumed by Miden VM. The f62 and f128 implementations aren't covered by this commit, and can probably benefit from a similar refactor in the future.

A particularly critical implementation of `transpose_square_stretch` was refactored to use pointers, as `slice::swap` will perform checks that are redundant, and will keep expensive call traces so they can panic if the slice bounds are violated. This unsafe implementation will extend the safety of the previous implementation as the bounds of the slice are always checked and protected by the FftInputs type safety.