### PR TITLE
To element reduction of public inputs and proof context

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ For more information about arithmetization see [air crate](air#Arithmetization),
 
 ```Rust
 use winterfell::{
-    math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable,
-    TraceInfo, TransitionConstraintDegree,
+    math::{fields::f128::BaseElement, FieldElement, ToElements},
+    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, TraceInfo,
+    TransitionConstraintDegree,
 };
 
 // Public inputs for our computation will consist of the starting value and the end result.
@@ -142,11 +142,10 @@ pub struct PublicInputs {
     result: BaseElement,
 }
 
-// We need to describe how public inputs can be converted to bytes.
-impl Serializable for PublicInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(self.start);
-        target.write(self.result);
+// We need to describe how public inputs can be converted to field elements.
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        vec![self.start, self.result]
     }
 }
 

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -5,11 +5,8 @@
 
 use crate::ProofOptions;
 use crypto::{Hasher, RandomCoin, RandomCoinError};
-use math::{fft, ExtensibleField, ExtensionOf, FieldElement, StarkField};
-use utils::{
-    collections::{BTreeMap, Vec},
-    Serializable,
-};
+use math::{fft, ExtensibleField, ExtensionOf, FieldElement, StarkField, ToElements};
+use utils::collections::{BTreeMap, Vec};
 
 mod trace_info;
 pub use trace_info::{TraceInfo, TraceLayout};
@@ -184,8 +181,8 @@ pub trait Air: Send + Sync {
     type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3>;
 
     /// A type defining shape of public inputs for the computation described by this protocol.
-    /// This could be any type as long as it can be serialized into a sequence of bytes.
-    type PublicInputs: Serializable;
+    /// This could be any type as long as it can be serialized into a sequence of field elements.
+    type PublicInputs: ToElements<Self::BaseField>;
 
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -210,7 +210,7 @@ impl ProofOptions {
 
 impl<E: StarkField> ToElements<E> for ProofOptions {
     fn to_elements(&self) -> Vec<E> {
-        // encode filed extension and FRI parameters into a single field element
+        // encode field extension and FRI parameters into a single field element
         let mut buf = self.field_extension as u32;
         buf = (buf << 8) | self.fri_folding_factor as u32;
         buf = (buf << 8) | self.fri_remainder_max_degree as u32;

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{ProofOptions, TraceInfo, TraceLayout};
-use math::StarkField;
+use math::{StarkField, ToElements};
 use utils::{
     collections::Vec, string::ToString, ByteReader, ByteWriter, Deserializable,
     DeserializationError, Serializable,
@@ -93,6 +93,45 @@ impl Context {
     }
 }
 
+impl<E: StarkField> ToElements<E> for Context {
+    /// Converts this [Context] into a vector of field elements.
+    ///
+    /// The elements are layed out as follows:
+    /// - trace layout info [1 or more elements].
+    /// - field modulus bytes [2 field elements].
+    /// - field extension and FRI parameters [1 element].
+    /// - grinding factor [1 element].
+    /// - blowup factor [1 element].
+    /// - number of queries [1 element].
+    /// - trace length [1 element].
+    /// - trace metadata [0 or more elements].
+    fn to_elements(&self) -> Vec<E> {
+        // convert trace layout
+        let mut result = self.trace_layout.to_elements();
+
+        // convert field modulus bytes into 2 elements
+        let num_modulus_bytes = self.field_modulus_bytes.len();
+        let (m1, m2) = self.field_modulus_bytes.split_at(num_modulus_bytes / 2);
+        result.push(bytes_to_element(m1));
+        result.push(bytes_to_element(m2));
+
+        // convert proof options and trace length to elements
+        result.append(&mut self.options.to_elements());
+        result.push(E::from(self.trace_length as u64));
+
+        // convert trace metadata to elements; this is done by breaking trace metadata into chunks
+        // of bytes which are slightly smaller than field element requires, and then converting
+        // these chunks into field elements.
+        if !self.trace_meta.is_empty() {
+            for chunk in self.trace_meta.chunks(E::ELEMENT_BYTES - 1) {
+                result.push(bytes_to_element(chunk));
+            }
+        }
+
+        result
+    }
+}
+
 impl Serializable for Context {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -154,5 +193,88 @@ impl Deserializable for Context {
             field_modulus_bytes,
             options,
         })
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Converts a slice of bytes into a field element.
+///
+/// Assumes that the length of `bytes` is smaller than the number of bytes needed to encode an
+/// element.
+#[allow(clippy::let_and_return)]
+fn bytes_to_element<B: StarkField>(bytes: &[u8]) -> B {
+    debug_assert!(bytes.len() < B::ELEMENT_BYTES);
+
+    let mut buf = bytes.to_vec();
+    buf.resize(B::ELEMENT_BYTES, 0);
+    let element = match B::try_from(&buf) {
+        Ok(element) => element,
+        Err(_) => panic!("element deserialization failed"),
+    };
+    element
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{Context, ProofOptions, ToElements, TraceInfo};
+    use crate::{FieldExtension, TraceLayout};
+    use math::fields::f64::BaseElement;
+
+    #[test]
+    fn context_to_elements() {
+        let field_extension = FieldExtension::None;
+        let fri_folding_factor = 8;
+        let fri_remainder_max_degree = 127;
+        let grinding_factor = 20;
+        let blowup_factor = 8;
+        let num_queries = 30;
+
+        let main_width = 20;
+        let num_aux_segments = 1;
+        let aux_width = 9;
+        let aux_rands = 12;
+        let trace_length = 4096;
+
+        let ext_fri = u32::from_le_bytes([
+            fri_remainder_max_degree,
+            fri_folding_factor,
+            field_extension as u8,
+            0,
+        ]);
+
+        let layout_info = u32::from_le_bytes([aux_rands, aux_width, num_aux_segments, main_width]);
+
+        let expected = vec![
+            BaseElement::from(layout_info),
+            BaseElement::from(1_u32),    // lower bits of field modulus
+            BaseElement::from(u32::MAX), // upper bits of field modulus
+            BaseElement::from(ext_fri),
+            BaseElement::from(grinding_factor as u32),
+            BaseElement::from(blowup_factor as u32),
+            BaseElement::from(num_queries as u32),
+            BaseElement::from(trace_length as u32),
+        ];
+
+        let options = ProofOptions::new(
+            num_queries,
+            blowup_factor,
+            grinding_factor,
+            field_extension,
+            fri_folding_factor as usize,
+            fri_remainder_max_degree as usize,
+        );
+        let layout = TraceLayout::new(
+            main_width as usize,
+            [aux_width as usize],
+            [aux_rands as usize],
+        );
+        let trace_info = TraceInfo::new_multi_segment(layout, trace_length, vec![]);
+        let context = Context::new::<BaseElement>(&trace_info, options);
+        assert_eq!(expected, context.to_elements());
     }
 }

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -120,8 +120,8 @@ impl<E: StarkField> ToElements<E> for Context {
         result.push(E::from(self.trace_length as u64));
 
         // convert trace metadata to elements; this is done by breaking trace metadata into chunks
-        // of bytes which are slightly smaller than field element requires, and then converting
-        // these chunks into field elements.
+        // of bytes which are slightly smaller than the number of bytes needed to encode a field
+        // element, and then converting these chunks into field elements.
         if !self.trace_meta.is_empty() {
             for chunk in self.trace_meta.chunks(E::ELEMENT_BYTES - 1) {
                 result.push(bytes_to_element(chunk));

--- a/examples/src/lamport/aggregate/air.rs
+++ b/examples/src/lamport/aggregate/air.rs
@@ -7,9 +7,10 @@ use super::{
     rescue, CYCLE_LENGTH as HASH_CYCLE_LEN, SIG_CYCLE_LENGTH as SIG_CYCLE_LEN, TRACE_WIDTH,
 };
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
+use core_utils::flatten_slice_elements;
 use winterfell::{
-    math::{fields::f128::BaseElement, FieldElement},
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
+    math::{fields::f128::BaseElement, FieldElement, ToElements},
+    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -26,10 +27,12 @@ pub struct PublicInputs {
     pub messages: Vec<[BaseElement; 2]>,
 }
 
-impl Serializable for PublicInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(&self.pub_keys);
-        target.write(&self.messages);
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        let mut result = Vec::new();
+        result.extend_from_slice(flatten_slice_elements(&self.pub_keys));
+        result.extend_from_slice(flatten_slice_elements(&self.messages));
+        result
     }
 }
 

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -9,8 +9,8 @@ use super::{
 };
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
-    math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
+    math::{fields::f128::BaseElement, log2, FieldElement, StarkField, ToElements},
+    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -29,12 +29,13 @@ pub struct PublicInputs {
     pub message: [BaseElement; 2],
 }
 
-impl Serializable for PublicInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(&self.pub_key_root[..]);
-        target.write_u32(self.num_pub_keys as u32);
-        target.write_u32(self.num_signatures as u32);
-        target.write(&self.message[..]);
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        let mut result = self.pub_key_root.to_vec();
+        result.push(BaseElement::from(self.num_pub_keys as u64));
+        result.push(BaseElement::from(self.num_signatures as u64));
+        result.extend_from_slice(&self.message);
+        result
     }
 }
 

--- a/examples/src/merkle/air.rs
+++ b/examples/src/merkle/air.rs
@@ -6,7 +6,7 @@
 use super::{rescue, BaseElement, FieldElement, HASH_CYCLE_LEN, HASH_STATE_WIDTH, TRACE_WIDTH};
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable, TraceInfo,
+    math::ToElements, Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -17,9 +17,9 @@ pub struct PublicInputs {
     pub tree_root: [BaseElement; 2],
 }
 
-impl Serializable for PublicInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(&self.tree_root[..]);
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        self.tree_root.to_vec()
     }
 }
 

--- a/examples/src/rescue/air.rs
+++ b/examples/src/rescue/air.rs
@@ -6,7 +6,7 @@
 use super::{rescue, BaseElement, FieldElement, ProofOptions, CYCLE_LENGTH, TRACE_WIDTH};
 use crate::utils::{are_equal, is_zero, not, EvaluationResult};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable, TraceInfo,
+    math::ToElements, Air, AirContext, Assertion, EvaluationFrame, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -41,10 +41,11 @@ pub struct PublicInputs {
     pub result: [BaseElement; 2],
 }
 
-impl Serializable for PublicInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(&self.seed[..]);
-        target.write(&self.result[..]);
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        let mut result = self.seed.to_vec();
+        result.extend_from_slice(&self.result);
+        result
     }
 }
 

--- a/examples/src/rescue_raps/air.rs
+++ b/examples/src/rescue_raps/air.rs
@@ -8,9 +8,10 @@ use super::{
     BaseElement, ExtensionOf, FieldElement, ProofOptions, CYCLE_LENGTH, TRACE_WIDTH,
 };
 use crate::utils::{are_equal, not, EvaluationResult};
+use core_utils::flatten_slice_elements;
 use winterfell::{
-    Air, AirContext, Assertion, AuxTraceRandElements, ByteWriter, EvaluationFrame, Serializable,
-    TraceInfo, TransitionConstraintDegree,
+    math::ToElements, Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame, TraceInfo,
+    TransitionConstraintDegree,
 };
 
 // CONSTANTS
@@ -43,9 +44,9 @@ pub struct PublicInputs {
     pub result: [[BaseElement; 2]; 2],
 }
 
-impl Serializable for PublicInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(&self.result[..]);
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        flatten_slice_elements(&self.result).to_vec()
     }
 }
 

--- a/examples/src/vdf/exempt/air.rs
+++ b/examples/src/vdf/exempt/air.rs
@@ -5,7 +5,7 @@
 
 use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable, TraceInfo,
+    math::ToElements, Air, AirContext, Assertion, EvaluationFrame, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -18,10 +18,9 @@ pub struct VdfInputs {
     pub result: BaseElement,
 }
 
-impl Serializable for VdfInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(self.seed);
-        target.write(self.result);
+impl ToElements<BaseElement> for VdfInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        vec![self.seed, self.result]
     }
 }
 

--- a/examples/src/vdf/regular/air.rs
+++ b/examples/src/vdf/regular/air.rs
@@ -5,7 +5,7 @@
 
 use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO};
 use winterfell::{
-    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable, TraceInfo,
+    math::ToElements, Air, AirContext, Assertion, EvaluationFrame, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -18,10 +18,9 @@ pub struct VdfInputs {
     pub result: BaseElement,
 }
 
-impl Serializable for VdfInputs {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(self.seed);
-        target.write(self.result);
+impl ToElements<BaseElement> for VdfInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        vec![self.seed, self.result]
     }
 }
 

--- a/math/src/field/mod.rs
+++ b/math/src/field/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 mod traits;
-pub use traits::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
+pub use traits::{ExtensibleField, ExtensionOf, FieldElement, StarkField, ToElements};
 
 pub mod f128;
 pub mod f62;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -323,3 +323,17 @@ impl<E: FieldElement> ExtensionOf<E> for E {
         self * other
     }
 }
+
+// TO ELEMENTS
+// ================================================================================================
+
+/// Defines how to convert a struct to a vector of field elements.
+pub trait ToElements<E: FieldElement> {
+    fn to_elements(&self) -> Vec<E>;
+}
+
+impl<E: FieldElement> ToElements<E> for () {
+    fn to_elements(&self) -> Vec<E> {
+        Vec::new()
+    }
+}

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -337,3 +337,9 @@ impl<E: FieldElement> ToElements<E> for () {
         Vec::new()
     }
 }
+
+impl<E: FieldElement> ToElements<E> for E {
+    fn to_elements(&self) -> Vec<E> {
+        vec![*self]
+    }
+}

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -97,7 +97,7 @@ pub mod fft;
 pub mod polynom;
 
 mod field;
-pub use field::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
+pub use field::{ExtensibleField, ExtensionOf, FieldElement, StarkField, ToElements};
 pub mod fields {
     //! Finite field implementations.
     //!

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -61,7 +61,7 @@ pub use math;
 use math::{
     fft::infer_degree,
     fields::{CubeExtension, QuadExtension},
-    ExtensibleField, FieldElement, StarkField,
+    ExtensibleField, FieldElement, StarkField, ToElements,
 };
 
 pub use crypto;
@@ -193,8 +193,7 @@ pub trait Prover {
 
         // serialize public inputs; these will be included in the seed for the public coin
         let pub_inputs = self.get_pub_inputs(&trace);
-        let mut pub_inputs_bytes = Vec::new();
-        pub_inputs.write_into(&mut pub_inputs_bytes);
+        let pub_inputs_elements = pub_inputs.to_elements();
 
         // create an instance of AIR for the provided parameters. this takes a generic description
         // of the computation (provided via AIR type), and creates a description of a specific
@@ -204,7 +203,8 @@ pub trait Prover {
         // create a channel which is used to simulate interaction between the prover and the
         // verifier; the channel will be used to commit to values and to draw randomness that
         // should come from the verifier.
-        let mut channel = ProverChannel::<Self::Air, E, Self::HashFn>::new(&air, pub_inputs_bytes);
+        let mut channel =
+            ProverChannel::<Self::Air, E, Self::HashFn>::new(&air, pub_inputs_elements);
 
         // 1 ----- Commit to the execution trace --------------------------------------------------
 

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -149,9 +149,9 @@
 //!
 //! ```no_run
 //! use winterfell::{
-//!     math::{fields::f128::BaseElement, FieldElement},
-//!     Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, Serializable,
-//!     TraceInfo, TransitionConstraintDegree, crypto::hashers::Blake3_256,
+//!     math::{fields::f128::BaseElement, FieldElement, ToElements},
+//!     Air, AirContext, Assertion, ByteWriter, EvaluationFrame, ProofOptions, TraceInfo,
+//!     TransitionConstraintDegree, crypto::hashers::Blake3_256,
 //! };
 //!
 //! // Public inputs for our computation will consist of the starting value and the end result.
@@ -160,11 +160,10 @@
 //!     result: BaseElement,
 //! }
 //!
-//! // We need to describe how public inputs can be converted to bytes.
-//! impl Serializable for PublicInputs {
-//!     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-//!         target.write(self.start);
-//!         target.write(self.result);
+//! // We need to describe how public inputs can be converted to field elements.
+//! impl ToElements<BaseElement> for PublicInputs {
+//!     fn to_elements(&self) -> Vec<BaseElement> {
+//!         vec![self.start, self.result]
 //!     }
 //! }
 //!
@@ -256,13 +255,13 @@
 //!
 //! ```no_run
 //! use winterfell::{
-//!     math::{fields::f128::BaseElement, FieldElement},
+//!     math::{fields::f128::BaseElement, FieldElement, ToElements},
 //!     ProofOptions, Prover, Trace, TraceTable, crypto::hashers::Blake3_256
 //! };
 //!
 //! # use winterfell::{
-//! #   Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
-//! #   TraceInfo, TransitionConstraintDegree,
+//! #   Air, AirContext, Assertion, ByteWriter, EvaluationFrame, TraceInfo,
+//! #   TransitionConstraintDegree,
 //! # };
 //! #
 //! # pub struct PublicInputs {
@@ -270,10 +269,9 @@
 //! #     result: BaseElement,
 //! # }
 //! #
-//! # impl Serializable for PublicInputs {
-//! #     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-//! #         target.write(self.start);
-//! #         target.write(self.result);
+//! # impl ToElements<BaseElement> for PublicInputs {
+//! #     fn to_elements(&self) -> Vec<BaseElement> {
+//! #         vec![self.start, self.result]
 //! #     }
 //! # }
 //! #
@@ -366,10 +364,10 @@
 //!
 //! ```
 //! # use winterfell::{
-//! #    math::{fields::f128::BaseElement, FieldElement},
-//! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
-//! #    TraceInfo, TransitionConstraintDegree, TraceTable, FieldExtension,
-//! #    Prover, ProofOptions, StarkProof, Trace, crypto::hashers::Blake3_256,
+//! #    math::{fields::f128::BaseElement, FieldElement, ToElements},
+//! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, TraceInfo,
+//! #    TransitionConstraintDegree, TraceTable, FieldExtension, Prover, ProofOptions,
+//! #    StarkProof, Trace, crypto::hashers::Blake3_256,
 //! # };
 //! #
 //! # pub fn build_do_work_trace(start: BaseElement, n: usize) -> TraceTable<BaseElement> {
@@ -392,10 +390,9 @@
 //! #     result: BaseElement,
 //! # }
 //! #
-//! # impl Serializable for PublicInputs {
-//! #     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-//! #         target.write(self.start);
-//! #         target.write(self.result);
+//! # impl ToElements<BaseElement> for PublicInputs {
+//! #     fn to_elements(&self) -> Vec<BaseElement> {
+//! #         vec![self.start, self.result]
 //! #     }
 //! # }
 //! #


### PR DESCRIPTION
This PR implements reduction to elements of public inputs and proof context. This will allow `RandomCoin` to be initialized from a list of field elements (rather than bytes). The advantage of this approach is that it simplifies handling of random coin in the context of recursive proofs.