### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## 0.6.0 (TBD)
+## 0.6.0 (2023-03-24)
+* Implemented more efficient remainder handling in FRI (#139)
 * Removed term involving conjugate OOD challenge z from deep composition polynomial (#166).
 * Added `FieldElement::EXTENSION_DEGREE` constant.
 * Added `FieldElement::base_element` and `FieldElement::slice_from_base_elements` methods.
@@ -8,6 +9,10 @@
 * Added `Matrix::num_base_cols` and `Matrix::get_base_element` methods.
 * [BREAKING] Renamed `Matrix` into `ColMatrix`.
 * [BREAKING] Replaced `ColMatrix` with `RowMatrix` to hold LDE trace in the prover (#168).
+* Updated conjectured security computation and added estimation of proven security (#151).
+* Changed root of unity for `f64` field (#169).
+* Implemented reduction of public inputs and proof context to field elements (#172).
+* [BREAKING] Replaced `RandomCoin` struct with a trait (#176).
 
 ## 0.5.1 (2023-02-20)
 * Fix no-std build for winter-utils (#153)

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-air"
-version = "0.5.1"
+version = "0.6.0"
 description = "AIR components for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-air/0.5.1"
+documentation = "https://docs.rs/winter-air/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "arithmetization", "air"]
 edition = "2021"
@@ -20,13 +20,13 @@ default = ["std"]
 std = ["crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.5", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.6", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.6", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
-rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.6", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -248,7 +248,7 @@ impl Deserializable for ProofOptions {
             source.read_u8()? as u32,
             FieldExtension::read_from(source)?,
             source.read_u8()? as usize,
-            2usize.pow(source.read_u8()? as u32),
+            source.read_u8()? as usize,
         ))
     }
 }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-crypto"
-version = "0.5.1"
+version = "0.6.0"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-crypto/0.5.1"
+documentation = "https://docs.rs/winter-crypto/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2021"
@@ -31,11 +31,11 @@ std = ["blake3/std", "math/std", "sha3/std", "utils/std"]
 
 [dependencies]
 blake3 = { version = "1.3", default-features = false }
-math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
+math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
 proptest = "1.1"
-rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.6", path = "../utils/rand", package = "winter-rand-utils" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.5.1"
+version = "0.6.0"
 description = "Examples of using Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
@@ -26,9 +26,9 @@ default = ["std"]
 std = ["hex/std", "winterfell/std", "core-utils/std", "rand-utils"]
 
 [dependencies]
-winterfell = { version="0.5", path = "../winterfell", default-features = false }
-core-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
-rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils", optional = true }
+winterfell = { version="0.6", path = "../winterfell", default-features = false }
+core-utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
+rand-utils = { version = "0.6", path = "../utils/rand", package = "winter-rand-utils", optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
 blake3 = { version = "1.3", default-features = false }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-fri"
-version = "0.5.1"
+version = "0.6.0"
 description = "Implementation of FRI protocol for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-fri/0.5.1"
+documentation = "https://docs.rs/winter-fri/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "polynomial", "commitments"]
 edition = "2021"
@@ -29,10 +29,10 @@ default = ["std"]
 std = ["crypto/std", "math/std", "utils/std"]
 
 [dependencies]
-crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
-math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+crypto = { version = "0.6", path = "../crypto", package = "winter-crypto", default-features = false }
+math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
-rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.6", path = "../utils/rand", package = "winter-rand-utils" }

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-math"
-version = "0.5.1"
+version = "0.6.0"
 description = "Math library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-math/0.5.1"
+documentation = "https://docs.rs/winter-math/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "finite-fields", "polynomials", "fft"]
 edition = "2021"
@@ -33,13 +33,13 @@ default = ["std"]
 std = ["utils/std"]
 
 [dependencies]
-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
 num-bigint = "0.4"
 proptest = "1.1"
-rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.6", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-prover"
-version = "0.5.1"
+version = "0.6.0"
 description = "Winterfell STARK prover"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-prover/0.5.1"
+documentation = "https://docs.rs/winter-prover/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover"]
 edition = "2021"
@@ -25,16 +25,16 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.5", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.5", path = '../fri', package = "winter-fri", default-features = false }
+air = { version = "0.6", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.6", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.6", path = '../fri', package = "winter-fri", default-features = false }
 log = { version = "0.4", default-features = false }
-math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"
-rand-utils = { version = "0.5", path = "../utils/rand", package = "winter-rand-utils" }
+rand-utils = { version = "0.6", path = "../utils/rand", package = "winter-rand-utils" }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-utils"
-version = "0.5.1"
+version = "0.6.0"
 description = "Utilities for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-utils/0.5.1"
+documentation = "https://docs.rs/winter-utils/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["serialization", "transmute"]
 edition = "2021"
@@ -21,4 +21,4 @@ default = ["std"]
 std = []
 
 [dependencies]
-rayon = { version = "1.6", optional = true }
+rayon = { version = "1.7", optional = true }

--- a/utils/rand/Cargo.toml
+++ b/utils/rand/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-rand-utils"
-version = "0.5.1"
+version = "0.6.0"
 description = "Random value generation utilities for Winterfell crates"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-rand-utils/0.5.1"
+documentation = "https://docs.rs/winter-rand-utils/0.6.0"
 categories = ["cryptography"]
 keywords = ["rand"]
 edition = "2021"
@@ -16,7 +16,7 @@ rust-version = "1.67"
 bench = false
 
 [dependencies]
-utils = { version = "0.5", path = "../core", package = "winter-utils" }
+utils = { version = "0.6", path = "../core", package = "winter-utils" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rand =  { version = "0.8" }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-verifier"
-version = "0.5.1"
+version = "0.6.0"
 description = "Winterfell STARK verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-verifier/0.5.1"
+documentation = "https://docs.rs/winter-verifier/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "verifier"]
 edition = "2021"
@@ -20,11 +20,11 @@ default = ["std"]
 std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 
 [dependencies]
-air = { version = "0.5", path = "../air", package = "winter-air", default-features = false }
-crypto = { version = "0.5", path = "../crypto", package = "winter-crypto", default-features = false }
-fri = { version = "0.5", path = "../fri", package = "winter-fri", default-features = false }
-math = { version = "0.5", path = "../math", package = "winter-math", default-features = false }
-utils = { version = "0.5", path = "../utils/core", package = "winter-utils", default-features = false }
+air = { version = "0.6", path = "../air", package = "winter-air", default-features = false }
+crypto = { version = "0.6", path = "../crypto", package = "winter-crypto", default-features = false }
+fri = { version = "0.6", path = "../fri", package = "winter-fri", default-features = false }
+math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
+utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]

--- a/winterfell/Cargo.toml
+++ b/winterfell/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winterfell"
-version = "0.5.1"
+version = "0.6.0"
 description = "Winterfell STARK prover and verifier"
 authors = ["winterfell contributors"]
 readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winterfell/0.5.1"
+documentation = "https://docs.rs/winterfell/0.6.0"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover", "verifier"]
 edition = "2021"
@@ -21,8 +21,8 @@ default = ["std"]
 std = ["prover/std", "verifier/std"]
 
 [dependencies]
-prover = { version = "0.5", path = "../prover", package = "winter-prover", default-features = false }
-verifier = { version = "0.5", path = "../verifier", package = "winter-verifier", default-features = false }
+prover = { version = "0.6", path = "../prover", package = "winter-prover", default-features = false }
+verifier = { version = "0.6", path = "../verifier", package = "winter-verifier", default-features = false }
 
 # Allow math in docs
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR prepares for v0.6.0 release. Specifically, all crate version numbers were increased to v0.6.0 and changelog was updated.