### PR TITLE
Fix `no_std` support

### DIFF
--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -112,6 +112,10 @@ impl StarkProof {
                 H::COLLISION_RESISTANCE,
             )
         } else {
+            #[cfg(not(feature = "std"))]
+            panic!("proven security level is not available in no_std mode");
+
+            #[cfg(feature = "std")]
             get_proven_security(
                 self.context.options(),
                 self.context.num_modulus_bits(),
@@ -203,6 +207,7 @@ fn get_conjectured_security(
     )
 }
 
+#[cfg(feature = "std")]
 /// Estimates proven security level for the specified proof parameters.
 fn get_proven_security(
     options: &ProofOptions,

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -77,11 +77,19 @@ fn main() {
     let proof_bytes = proof.to_bytes();
     debug!("Proof size: {:.1} KB", proof_bytes.len() as f64 / 1024f64);
     let conjectured_security_level = options.get_proof_security_level(&proof, true);
-    let proven_security_level = options.get_proof_security_level(&proof, false);
-    debug!(
-        "Proof security: {} bits ({} proven)",
-        conjectured_security_level, proven_security_level,
-    );
+
+    #[cfg(feature = "std")]
+    {
+        let proven_security_level = options.get_proof_security_level(&proof, false);
+        debug!(
+            "Proof security: {} bits ({} proven)",
+            conjectured_security_level, proven_security_level,
+        );
+    }
+
+    #[cfg(not(feature = "std"))]
+    debug!("Proof security: {} bits", conjectured_security_level);
+
     #[cfg(feature = "std")]
     debug!(
         "Proof hash: {}",


### PR DESCRIPTION
The `get_proven_security` function uses both `log2` and `powf` which are both incompatible with a `no_std` environment.  To fix support for `no_std` this PR moves the `get_proven_security` function behind a `std` feature flag and panics if it is called in a `no_std` context. 