### PR TITLE
Prepare v0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.1 (2023-03-29)
+* Disabled proven security estimation in `no-std` context.
+
 ## 0.6.0 (2023-03-24)
 * Implemented more efficient remainder handling in FRI (#139)
 * Removed term involving conjugate OOD challenge z from deep composition polynomial (#166).

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-air"
-version = "0.6.0"
+version = "0.6.1"
 description = "AIR components for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-air/0.6.0"
+documentation = "https://docs.rs/winter-air/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "arithmetization", "air"]
 edition = "2021"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-crypto"
-version = "0.6.0"
+version = "0.6.1"
 description = "Cryptographic library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-crypto/0.6.0"
+documentation = "https://docs.rs/winter-crypto/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "merkle-tree", "hash"]
 edition = "2021"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.6.0"
+version = "0.6.1"
 description = "Examples of using Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-fri"
-version = "0.6.0"
+version = "0.6.1"
 description = "Implementation of FRI protocol for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-fri/0.6.0"
+documentation = "https://docs.rs/winter-fri/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "polynomial", "commitments"]
 edition = "2021"

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-math"
-version = "0.6.0"
+version = "0.6.1"
 description = "Math library for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-math/0.6.0"
+documentation = "https://docs.rs/winter-math/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "finite-fields", "polynomials", "fft"]
 edition = "2021"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-prover"
-version = "0.6.0"
+version = "0.6.1"
 description = "Winterfell STARK prover"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-prover/0.6.0"
+documentation = "https://docs.rs/winter-prover/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover"]
 edition = "2021"

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-utils"
-version = "0.6.0"
+version = "0.6.1"
 description = "Utilities for the Winterfell STARK prover/verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-utils/0.6.0"
+documentation = "https://docs.rs/winter-utils/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["serialization", "transmute"]
 edition = "2021"

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -28,11 +28,20 @@ pub use errors::DeserializationError;
 #[cfg(test)]
 mod tests;
 
+// FEATURE-BASED RE-EXPORTS
+// ================================================================================================
+
 #[cfg(feature = "concurrent")]
 use iterators::*;
 
 #[cfg(feature = "concurrent")]
 pub use rayon;
+
+#[cfg(not(feature = "std"))]
+pub use alloc::boxed::Box;
+
+#[cfg(feature = "std")]
+pub use std::boxed::Box;
 
 // AS BYTES
 // ================================================================================================

--- a/utils/rand/Cargo.toml
+++ b/utils/rand/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-rand-utils"
-version = "0.6.0"
+version = "0.6.1"
 description = "Random value generation utilities for Winterfell crates"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-rand-utils/0.6.0"
+documentation = "https://docs.rs/winter-rand-utils/0.6.1"
 categories = ["cryptography"]
 keywords = ["rand"]
 edition = "2021"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winter-verifier"
-version = "0.6.0"
+version = "0.6.1"
 description = "Winterfell STARK verifier"
 authors = ["winterfell contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winter-verifier/0.6.0"
+documentation = "https://docs.rs/winter-verifier/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "verifier"]
 edition = "2021"

--- a/winterfell/Cargo.toml
+++ b/winterfell/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "winterfell"
-version = "0.6.0"
+version = "0.6.1"
 description = "Winterfell STARK prover and verifier"
 authors = ["winterfell contributors"]
 readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/novifinancial/winterfell"
-documentation = "https://docs.rs/winterfell/0.6.0"
+documentation = "https://docs.rs/winterfell/0.6.1"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "zkp", "stark", "prover", "verifier"]
 edition = "2021"


### PR DESCRIPTION
This PR updates crate versions to v0.6.1 and also adds feature-based `Box` re-export to the core utils crate.