### PR TITLE
MerkleTree, Segment, ColMatrix changes for GPU RPO support

### DIFF
--- a/crypto/src/merkle/mod.rs
+++ b/crypto/src/merkle/mod.rs
@@ -94,8 +94,9 @@ pub struct MerkleTree<H: Hasher> {
 // ================================================================================================
 
 impl<H: Hasher> MerkleTree<H> {
-    // CONSTRUCTOR
+    // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
+
     /// Returns new Merkle tree built from the provide leaves using hash function specified by the
     /// `H` generic parameter.
     ///
@@ -123,6 +124,31 @@ impl<H: Hasher> MerkleTree<H> {
             concurrent::build_merkle_nodes::<H>(&leaves)
         };
 
+        Ok(MerkleTree { nodes, leaves })
+    }
+
+    /// Forms a MerkleTree from a list of nodes and leaves.
+    ///
+    /// Nodes are supplied as a vector where the root is stored at position 1.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * Fewer than two leaves were provided.
+    /// * Number of leaves is not a power of two.
+    ///
+    /// # Panics
+    /// Panics if nodes doesn't have the same length as leaves.
+    pub fn from_raw_parts(
+        nodes: Vec<H::Digest>,
+        leaves: Vec<H::Digest>,
+    ) -> Result<Self, MerkleTreeError> {
+        if leaves.len() < 2 {
+            return Err(MerkleTreeError::TooFewLeaves(2, leaves.len()));
+        }
+        if !leaves.len().is_power_of_two() {
+            return Err(MerkleTreeError::NumberOfLeavesNotPowerOfTwo(leaves.len()));
+        }
+        assert_eq!(nodes.len(), leaves.len());
         Ok(MerkleTree { nodes, leaves })
     }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -77,7 +77,7 @@ use std::time::Instant;
 mod domain;
 pub use domain::StarkDomain;
 
-mod matrix;
+pub mod matrix;
 pub use matrix::{ColMatrix, RowMatrix};
 
 mod constraints;

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -156,6 +156,17 @@ impl<E: FieldElement> ColMatrix<E> {
         }
     }
 
+    /// Merges a column to the end of the matrix provided its length matches the matrix.
+    ///
+    /// # Panics
+    /// Panics if the column has a different length to other columns in the matrix.
+    pub fn merge_column(&mut self, column: Vec<E>) {
+        if let Some(first_column) = self.columns.first() {
+            assert_eq!(first_column.len(), column.len());
+        }
+        self.columns.push(column);
+    }
+
     // ITERATION
     // --------------------------------------------------------------------------------------------
 

--- a/prover/src/matrix/mod.rs
+++ b/prover/src/matrix/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 mod row_matrix;
-pub use row_matrix::RowMatrix;
+pub use row_matrix::{get_evaluation_offsets, RowMatrix};
 
 mod col_matrix;
 pub use col_matrix::{ColMatrix, ColumnIter, MultiColumnIter};

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -57,7 +57,8 @@ impl<E: FieldElement> RowMatrix<E> {
 
         // pre-compute offsets for each row
         let poly_size = polys.num_rows();
-        let offsets = get_offsets::<E>(poly_size, blowup_factor, E::BaseField::GENERATOR);
+        let offsets =
+            get_evaluation_offsets::<E>(poly_size, blowup_factor, E::BaseField::GENERATOR);
 
         // compute twiddles for polynomial evaluation
         let twiddles = fft::get_twiddles::<E::BaseField>(polys.num_rows());
@@ -86,7 +87,8 @@ impl<E: FieldElement> RowMatrix<E> {
 
         // pre-compute offsets for each row
         let poly_size = polys.num_rows();
-        let offsets = get_offsets::<E>(poly_size, domain.trace_to_lde_blowup(), domain.offset());
+        let offsets =
+            get_evaluation_offsets::<E>(poly_size, domain.trace_to_lde_blowup(), domain.offset());
 
         // build matrix segments by evaluating all polynomials
         let segments = build_segments::<E, N>(polys, domain.trace_twiddles(), &offsets);
@@ -207,7 +209,7 @@ impl<E: FieldElement> RowMatrix<E> {
 /// factor and domain offset.
 ///
 /// When `concurrent` feature is enabled, offsets are computed in multiple threads.
-fn get_offsets<E: FieldElement>(
+pub fn get_evaluation_offsets<E: FieldElement>(
     poly_size: usize,
     blowup_factor: usize,
     domain_offset: E::BaseField,
@@ -299,7 +301,7 @@ fn transpose<B: StarkField, const N: usize>(mut segments: Vec<Segment<B, N>>) ->
         for i in 0..rows_per_batch {
             let row_idx = i + row_offset;
             for j in 0..num_segs {
-                let v = &segments[j].data()[row_idx];
+                let v = &segments[j][row_idx];
                 batch[i * num_segs + j].copy_from_slice(v);
             }
         }


### PR DESCRIPTION
Changes:
* Make MerkleTree fields public so the merkle nodes can be generated in a custom way (on the GPU in my case)
* Add merge_column to ColMatrix to append columns
* Make get_offsets public
* Make Segment public
* remove .data() from Segment and instead implement Deref (gives access to the data Vec instead of the slice which I need to call .capacity() on)