### PR TITLE
Remove log2() and use .ilog2() instead

### DIFF
--- a/air/src/air/boundary/tests.rs
+++ b/air/src/air/boundary/tests.rs
@@ -8,7 +8,7 @@ use super::{
     Assertion, BoundaryConstraint,
 };
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin};
-use math::{fields::f128::BaseElement, log2, polynom, FieldElement, StarkField};
+use math::{fields::f128::BaseElement, polynom, FieldElement, StarkField};
 use rand_utils::{rand_value, rand_vector, shuffle};
 use utils::collections::{BTreeMap, Vec};
 
@@ -277,7 +277,7 @@ fn build_constraint_params(
     BTreeMap<usize, Vec<BaseElement>>,
     DefaultRandomCoin<Blake3_256<BaseElement>>,
 ) {
-    let inv_g = BaseElement::get_root_of_unity(log2(trace_length)).inv();
+    let inv_g = BaseElement::get_root_of_unity(trace_length.ilog2()).inv();
     let prng = build_prng();
     let twiddle_map = BTreeMap::<usize, Vec<BaseElement>>::new();
     (inv_g, twiddle_map, prng)

--- a/air/src/air/context.rs
+++ b/air/src/air/context.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{air::TransitionConstraintDegree, ProofOptions, TraceInfo};
-use math::{log2, StarkField};
+use math::StarkField;
 use utils::collections::Vec;
 
 // AIR CONTEXT
@@ -154,8 +154,8 @@ impl<B: StarkField> AirContext<B> {
             num_main_assertions,
             num_aux_assertions,
             ce_blowup_factor,
-            trace_domain_generator: B::get_root_of_unity(log2(trace_length)),
-            lde_domain_generator: B::get_root_of_unity(log2(lde_domain_size)),
+            trace_domain_generator: B::get_root_of_unity(trace_length.ilog2()),
+            lde_domain_generator: B::get_root_of_unity(lde_domain_size.ilog2()),
             num_transition_exemptions: 1,
         }
     }

--- a/air/src/air/divisor.rs
+++ b/air/src/air/divisor.rs
@@ -5,7 +5,7 @@
 
 use crate::air::Assertion;
 use core::fmt::{Display, Formatter};
-use math::{log2, FieldElement, StarkField};
+use math::{FieldElement, StarkField};
 use utils::collections::Vec;
 
 // CONSTRAINT DIVISOR
@@ -176,7 +176,7 @@ fn get_trace_domain_value_at<B: StarkField>(trace_length: usize, step: usize) ->
         step < trace_length,
         "step must be in the trace domain [0, {trace_length})"
     );
-    let g = B::get_root_of_unity(log2(trace_length));
+    let g = B::get_root_of_unity(trace_length.ilog2());
     g.exp((step as u64).into())
 }
 

--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{AuxTraceRandElements, FieldExtension};
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin};
-use math::{fields::f128::BaseElement, get_power_series, log2, polynom, FieldElement, StarkField};
+use math::{fields::f128::BaseElement, get_power_series, polynom, FieldElement, StarkField};
 use utils::collections::{BTreeMap, Vec};
 
 // PERIODIC COLUMNS
@@ -88,7 +88,7 @@ fn get_boundary_constraints() {
     let trace_length = 16;
     let air = MockAir::with_assertions(assertions, trace_length);
     let no_poly_offset = (0, BaseElement::ONE);
-    let g = BaseElement::get_root_of_unity(log2(trace_length)); // trace domain generator
+    let g = BaseElement::get_root_of_unity(trace_length.ilog2()); // trace domain generator
 
     // build coefficients for random liner combination; these will be derived for assertions
     // sorted first by stride, then by first step, and finally by column (similar to the order)
@@ -307,14 +307,14 @@ pub fn build_prng() -> DefaultRandomCoin<Blake3_256<BaseElement>> {
 pub fn build_sequence_poly(values: &[BaseElement], trace_length: usize) -> Vec<BaseElement> {
     let cycle_length = trace_length / values.len();
     let domain_size = trace_length / cycle_length;
-    let g = BaseElement::get_root_of_unity(log2(domain_size));
+    let g = BaseElement::get_root_of_unity(domain_size.ilog2());
     let xs = get_power_series(g, domain_size);
     polynom::interpolate(&xs, values, false)
 }
 
 pub fn build_periodic_column_poly(values: &[BaseElement]) -> Vec<BaseElement> {
     let domain_size = values.len();
-    let g = BaseElement::get_root_of_unity(log2(domain_size));
+    let g = BaseElement::get_root_of_unity(domain_size.ilog2());
     let xs = get_power_series(g, domain_size);
     polynom::interpolate(&xs, values, false)
 }

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -136,7 +136,7 @@ impl Serializable for Context {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.trace_layout.write_into(target);
-        target.write_u8(math::log2(self.trace_length) as u8); // store as power of two
+        target.write_u8(self.trace_length.ilog2() as u8); // store as power of two
         target.write_u16(self.trace_meta.len() as u16);
         target.write_bytes(&self.trace_meta);
         assert!(self.field_modulus_bytes.len() < u8::MAX as usize);
@@ -157,10 +157,10 @@ impl Deserializable for Context {
 
         // read and validate trace length (which was stored as a power of two)
         let trace_length = source.read_u8()?;
-        if trace_length < math::log2(TraceInfo::MIN_TRACE_LENGTH) as u8 {
+        if trace_length < TraceInfo::MIN_TRACE_LENGTH.ilog2() as u8 {
             return Err(DeserializationError::InvalidValue(format!(
                 "trace length cannot be smaller than 2^{}, but was 2^{}",
-                math::log2(TraceInfo::MIN_TRACE_LENGTH),
+                TraceInfo::MIN_TRACE_LENGTH.ilog2(),
                 trace_length
             )));
         }

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -9,7 +9,6 @@ use crate::{ProofOptions, TraceInfo, TraceLayout};
 use core::cmp;
 use crypto::Hasher;
 use fri::FriProof;
-use math::log2;
 use utils::{
     collections::Vec, ByteReader, Deserializable, DeserializationError, Serializable, SliceReader,
 };
@@ -193,7 +192,7 @@ fn get_conjectured_security(
     let field_security = field_size - trace_domain_size.trailing_zeros();
 
     // compute security we get by executing multiple query rounds
-    let security_per_query = log2(options.blowup_factor());
+    let security_per_query = options.blowup_factor().ilog2();
     let mut query_security = security_per_query * options.num_queries() as u32;
 
     // include grinding factor contributions only for proofs adequate security
@@ -216,7 +215,7 @@ fn get_proven_security(
     collision_resistance: u32,
 ) -> u32 {
     let extension_field_bits = (base_field_bits * options.field_extension().degree()) as f64;
-    let blowup_bits = log2(options.blowup_factor()) as f64;
+    let blowup_bits = options.blowup_factor().ilog2() as f64;
     let num_fri_queries = options.num_queries() as f64;
     let lde_size_bits = lde_domain_size.trailing_zeros() as f64;
 

--- a/air/src/proof/queries.rs
+++ b/air/src/proof/queries.rs
@@ -5,7 +5,7 @@
 
 use super::Table;
 use crypto::{BatchMerkleProof, ElementHasher, Hasher};
-use math::{log2, FieldElement};
+use math::FieldElement;
 use utils::{
     collections::Vec, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     SliceReader,
@@ -130,7 +130,7 @@ impl Queries {
 
         // build batch Merkle proof
         let mut reader = SliceReader::new(&self.paths);
-        let tree_depth = log2(domain_size) as u8;
+        let tree_depth = domain_size.ilog2() as u8;
         let merkle_proof = BatchMerkleProof::deserialize(&mut reader, hashed_queries, tree_depth)?;
         if reader.has_more_bytes() {
             return Err(DeserializationError::UnconsumedBytes);

--- a/crypto/src/merkle/mod.rs
+++ b/crypto/src/merkle/mod.rs
@@ -5,7 +5,6 @@
 
 use crate::{errors::MerkleTreeError, hash::Hasher};
 use core::slice;
-use math::log2;
 use utils::collections::{BTreeMap, BTreeSet, Vec};
 
 mod proofs;
@@ -139,7 +138,7 @@ impl<H: Hasher> MerkleTree<H> {
     /// The depth of a tree is zero-based. Thus, a tree with two leaves has depth 1, a tree with
     /// four leaves has depth 2 etc.
     pub fn depth(&self) -> usize {
-        log2(self.leaves.len()) as usize
+        self.leaves.len().ilog2() as usize
     }
 
     /// Returns leaf nodes of the tree.

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -10,7 +10,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -112,7 +112,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -10,7 +10,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -111,7 +111,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/fibonacci/fib_small/mod.rs
+++ b/examples/src/fibonacci/fib_small/mod.rs
@@ -10,7 +10,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f64::BaseElement, log2, FieldElement},
+    math::{fields::f64::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -130,7 +130,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -10,7 +10,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -106,7 +106,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -10,7 +10,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -107,7 +107,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -12,7 +12,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
+    math::{fields::f128::BaseElement, get_power_series, FieldElement, StarkField},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -146,7 +146,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::utils::{are_equal, is_binary, is_zero, not, EvaluationResult};
 use winterfell::{
-    math::{fields::f128::BaseElement, log2, FieldElement, StarkField, ToElements},
+    math::{fields::f128::BaseElement, FieldElement, StarkField, ToElements},
     Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
@@ -171,7 +171,7 @@ impl Air for LamportThresholdAir {
         // these steps depend on the depth of the public key Merkle tree; for example, if the Merkle
         // tree has 4 elements, then the steps are: 24, 1048, 2072, 3096
         let num_cycles = self.num_pub_keys.next_power_of_two();
-        let merkle_root_offset = (log2(num_cycles) + 1) as usize * HASH_CYCLE_LEN;
+        let merkle_root_offset = (num_cycles.ilog2() + 1) as usize * HASH_CYCLE_LEN;
 
         // distinct key indexes should be used; the sequence starts at the last index of the tree
         // (to pad the first cycle) and then wraps around and proceeds with index 0, 1, 2 etc.

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -13,7 +13,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, get_power_series, log2, FieldElement, StarkField},
+    math::{fields::f128::BaseElement, get_power_series, FieldElement, StarkField},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -142,7 +142,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -17,7 +17,7 @@ use rand_utils::{rand_value, rand_vector};
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, Digest, ElementHasher, MerkleTree},
-    math::{fields::f128::BaseElement, log2, FieldElement, StarkField},
+    math::{fields::f128::BaseElement, FieldElement, StarkField},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -130,7 +130,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -118,7 +118,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/rescue_raps/custom_trace_table.rs
+++ b/examples/src/rescue_raps/custom_trace_table.rs
@@ -5,7 +5,7 @@
 
 use core_utils::{collections::Vec, uninit_vector};
 use winterfell::{
-    math::{log2, FieldElement, StarkField},
+    math::{FieldElement, StarkField},
     ColMatrix, EvaluationFrame, Trace, TraceInfo, TraceLayout,
 };
 
@@ -85,10 +85,10 @@ impl<B: StarkField> RapTraceTable<B> {
             "execution trace length must be a power of 2"
         );
         assert!(
-            log2(length) <= B::TWO_ADICITY,
+            length.ilog2() <= B::TWO_ADICITY,
             "execution trace length cannot exceed 2^{} steps, but was 2^{}",
             B::TWO_ADICITY,
-            log2(length)
+            length.ilog2()
         );
         assert!(
             meta.len() <= TraceInfo::MAX_META_LENGTH,

--- a/examples/src/rescue_raps/mod.rs
+++ b/examples/src/rescue_raps/mod.rs
@@ -10,7 +10,7 @@ use rand_utils::rand_array;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, ExtensionOf, FieldElement},
+    math::{fields::f128::BaseElement, ExtensionOf, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, VerifierError,
 };
 
@@ -131,7 +131,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/vdf/exempt/mod.rs
+++ b/examples/src/vdf/exempt/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -104,7 +104,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/examples/src/vdf/regular/mod.rs
+++ b/examples/src/vdf/regular/mod.rs
@@ -9,7 +9,7 @@ use log::debug;
 use std::time::Instant;
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
-    math::{fields::f128::BaseElement, log2, FieldElement},
+    math::{fields::f128::BaseElement, FieldElement},
     ProofOptions, Prover, StarkProof, Trace, TraceTable, VerifierError,
 };
 
@@ -104,7 +104,7 @@ where
         debug!(
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
-            log2(trace_length),
+            trace_length.ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/fri/benches/folding.rs
+++ b/fri/benches/folding.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use math::{fields::f128::BaseElement, get_power_series, log2, polynom, StarkField};
+use math::{fields::f128::BaseElement, get_power_series, polynom, StarkField};
 use rand_utils::{rand_value, rand_vector};
 use utils::group_vector_elements;
 use winter_fri::folding;
@@ -41,7 +41,7 @@ criterion_main!(quartic_group);
 // ================================================================================================
 
 fn build_coordinate_batches(batch_size: usize) -> (Vec<[BaseElement; 4]>, Vec<[BaseElement; 4]>) {
-    let r = BaseElement::get_root_of_unity(log2(batch_size));
+    let r = BaseElement::get_root_of_unity(batch_size.ilog2());
     let xs = group_vector_elements(get_power_series(r, batch_size));
     let ys = group_vector_elements(rand_vector::<BaseElement>(batch_size));
     (xs, ys)

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crypto::{BatchMerkleProof, ElementHasher, Hasher};
-use math::{log2, FieldElement};
+use math::FieldElement;
 use utils::{
     collections::Vec, string::ToString, ByteReader, ByteWriter, Deserializable,
     DeserializationError, Serializable, SliceReader,
@@ -319,7 +319,7 @@ impl FriProofLayer {
 
         // build batch Merkle proof
         let mut reader = SliceReader::new(&self.paths);
-        let tree_depth = log2(domain_size) as u8;
+        let tree_depth = domain_size.ilog2() as u8;
         let merkle_proof = BatchMerkleProof::deserialize(&mut reader, hashed_queries, tree_depth)?;
         if reader.has_more_bytes() {
             return Err(DeserializationError::UnconsumedBytes);

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -8,7 +8,7 @@
 use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierError};
 use core::{convert::TryInto, marker::PhantomData, mem};
 use crypto::{ElementHasher, RandomCoin};
-use math::{log2, polynom, FieldElement, StarkField};
+use math::{polynom, FieldElement, StarkField};
 use utils::collections::Vec;
 
 mod channel;
@@ -107,7 +107,7 @@ where
     ) -> Result<Self, VerifierError> {
         // infer evaluation domain info
         let domain_size = max_poly_degree.next_power_of_two() * options.blowup_factor();
-        let domain_generator = E::BaseField::get_root_of_unity(log2(domain_size));
+        let domain_generator = E::BaseField::get_root_of_unity(domain_size.ilog2());
 
         let num_partitions = channel.read_fri_num_partitions();
 

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -4,10 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::fft_inputs::FftInputs;
-use crate::{
-    field::{FieldElement, StarkField},
-    utils::log2,
-};
+use crate::field::{FieldElement, StarkField};
 use utils::{collections::Vec, iterators::*, rayon, uninit_vector};
 
 // POLYNOMIAL EVALUATION
@@ -30,7 +27,7 @@ pub fn evaluate_poly_with_offset<B: StarkField, E: FieldElement<BaseField = B>>(
     blowup_factor: usize,
 ) -> Vec<E> {
     let domain_size = p.len() * blowup_factor;
-    let g = B::get_root_of_unity(log2(domain_size));
+    let g = B::get_root_of_unity(domain_size.ilog2());
     let mut result = unsafe { uninit_vector(domain_size) };
 
     result
@@ -130,7 +127,7 @@ pub(super) fn split_radix_fft<B: StarkField, E: FieldElement<BaseField = B>>(
     let g = twiddles[twiddles.len() / 2];
     debug_assert_eq!(g.exp((n as u32).into()), E::BaseField::ONE);
 
-    let inner_len = 1_usize << (log2(n) / 2);
+    let inner_len = 1_usize << (n.ilog2() / 2);
     let outer_len = n / inner_len;
     let stretch = outer_len / inner_len;
     debug_assert!(outer_len == inner_len || outer_len == 2 * inner_len);

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -14,7 +14,7 @@
 use crate::{
     fft::fft_inputs::FftInputs,
     field::{FieldElement, StarkField},
-    utils::{get_power_series, log2},
+    utils::get_power_series,
 };
 
 pub mod fft_inputs;
@@ -63,7 +63,7 @@ const MIN_CONCURRENT_SIZE: usize = 1024;
 ///
 /// # Examples
 /// ```
-/// # use winter_math::{polynom, fft::*, get_power_series, log2};
+/// # use winter_math::{polynom, fft::*, get_power_series};
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement, StarkField};
 /// # use rand_utils::rand_vector;
 /// let n = 2048;
@@ -72,7 +72,7 @@ const MIN_CONCURRENT_SIZE: usize = 1024;
 /// let mut p: Vec<BaseElement> = rand_vector(n);
 ///
 /// // evaluate the polynomial over the domain using regular polynomial evaluation
-/// let g = BaseElement::get_root_of_unity(log2(n));
+/// let g = BaseElement::get_root_of_unity(n.ilog2());
 /// let domain = get_power_series(g, n);
 /// let expected = polynom::eval_many(&p, &domain);
 ///
@@ -99,7 +99,7 @@ where
         twiddles.len()
     );
     assert!(
-        log2(p.len()) <= B::TWO_ADICITY,
+        p.len().ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         p.len()
     );
@@ -146,7 +146,7 @@ where
 ///
 /// # Examples
 /// ```
-/// # use winter_math::{polynom, fft::*, log2, get_power_series};
+/// # use winter_math::{polynom, fft::*, get_power_series};
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement, StarkField};
 /// # use rand_utils::rand_vector;
 /// let n = 2048;
@@ -157,7 +157,7 @@ where
 /// let mut p: Vec<BaseElement> = rand_vector(n / blowup_factor);
 ///
 /// // evaluate the polynomial over the domain using regular polynomial evaluation
-/// let g = BaseElement::get_root_of_unity(log2(n));
+/// let g = BaseElement::get_root_of_unity(n.ilog2());
 /// let domain = get_power_series(g, n);
 /// let shifted_domain = domain.iter().map(|&x| x * offset).collect::<Vec<_>>();
 /// let expected = polynom::eval_many(&p, &shifted_domain);
@@ -194,7 +194,7 @@ where
         twiddles.len()
     );
     assert!(
-        log2(p.len() * blowup_factor) <= B::TWO_ADICITY,
+        (p.len() * blowup_factor).ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         p.len() * blowup_factor
     );
@@ -252,7 +252,7 @@ where
 ///
 /// # Examples
 /// ```
-/// # use winter_math::{polynom, fft::*, get_power_series, log2};
+/// # use winter_math::{polynom, fft::*, get_power_series};
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement, StarkField};
 /// # use rand_utils::rand_vector;
 /// let n = 2048;
@@ -261,7 +261,7 @@ where
 /// let p: Vec<BaseElement> = rand_vector(n);
 ///
 /// // evaluate the polynomial over the domain using regular polynomial evaluation
-/// let g = BaseElement::get_root_of_unity(log2(n));
+/// let g = BaseElement::get_root_of_unity(n.ilog2());
 /// let domain = get_power_series(g, n);
 /// let mut ys = polynom::eval_many(&p, &domain);
 ///
@@ -289,7 +289,7 @@ where
         inv_twiddles.len()
     );
     assert!(
-        log2(evaluations.len()) <= B::TWO_ADICITY,
+        evaluations.len().ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         evaluations.len()
     );
@@ -338,7 +338,7 @@ where
 ///
 /// # Examples
 /// ```
-/// # use winter_math::{polynom, fft::*, get_power_series, log2};
+/// # use winter_math::{polynom, fft::*, get_power_series};
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement, StarkField};
 /// # use rand_utils::rand_vector;
 /// let n = 2048;
@@ -348,7 +348,7 @@ where
 /// let p: Vec<BaseElement> = rand_vector(n);
 ///
 /// // evaluate the polynomial over the domain using regular polynomial evaluation
-/// let g = BaseElement::get_root_of_unity(log2(n));
+/// let g = BaseElement::get_root_of_unity(n.ilog2());
 /// let domain = get_power_series(g, n);
 /// let shifted_domain = domain.iter().map(|&x| x * offset).collect::<Vec<_>>();
 /// let mut ys = polynom::eval_many(&p, &shifted_domain);
@@ -380,7 +380,7 @@ pub fn interpolate_poly_with_offset<B, E>(
         inv_twiddles.len()
     );
     assert!(
-        log2(evaluations.len()) <= B::TWO_ADICITY,
+        evaluations.len().ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         evaluations.len()
     );
@@ -431,7 +431,7 @@ where
         twiddles.len()
     );
     assert!(
-        log2(values.len()) <= B::TWO_ADICITY,
+        values.len().ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         values.len()
     );
@@ -472,10 +472,10 @@ where
         "domain size must be a power of 2"
     );
     assert!(
-        log2(domain_size) <= B::TWO_ADICITY,
+        domain_size.ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {domain_size} does not exist in the specified base field"
     );
-    let root = B::get_root_of_unity(log2(domain_size));
+    let root = B::get_root_of_unity(domain_size.ilog2());
     let mut twiddles = get_power_series(root, domain_size / 2);
     permute(&mut twiddles);
     twiddles
@@ -511,10 +511,10 @@ where
         "domain size must be a power of 2"
     );
     assert!(
-        log2(domain_size) <= B::TWO_ADICITY,
+        domain_size.ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {domain_size} does not exist in the specified base field"
     );
-    let root = B::get_root_of_unity(log2(domain_size));
+    let root = B::get_root_of_unity(domain_size.ilog2());
     let inv_root = root.exp((domain_size as u32 - 1).into());
     let mut inv_twiddles = get_power_series(inv_root, domain_size / 2);
     permute(&mut inv_twiddles);
@@ -544,7 +544,7 @@ where
 ///
 /// # Examples
 /// ```
-/// # use winter_math::{polynom, fft::*, get_power_series, log2};
+/// # use winter_math::{polynom, fft::*, get_power_series};
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement, StarkField};
 /// let offset = BaseElement::GENERATOR;
 /// // p(x) = x^2 + 1
@@ -555,7 +555,7 @@ where
 ///     BaseElement::ZERO,
 /// ];
 ///
-/// let g = BaseElement::get_root_of_unity(log2(p.len()));
+/// let g = BaseElement::get_root_of_unity(p.len().ilog2());
 /// let domain = get_power_series(g, p.len());
 /// let shifted_domain = domain.iter().map(|&x| x * offset).collect::<Vec<_>>();
 /// let evaluations = polynom::eval_many(&p, &shifted_domain);
@@ -572,7 +572,7 @@ where
         "number of evaluations must be a power of 2"
     );
     assert!(
-        log2(evaluations.len()) <= B::TWO_ADICITY,
+        evaluations.len().ilog2() <= B::TWO_ADICITY,
         "multiplicative subgroup of size {} does not exist in the specified base field",
         evaluations.len()
     );

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::fft_inputs::FftInputs;
-use crate::{field::StarkField, utils::log2, FieldElement};
+use crate::{field::StarkField, FieldElement};
 use utils::{collections::Vec, uninit_vector};
 
 // POLYNOMIAL EVALUATION
@@ -34,7 +34,7 @@ where
     E: FieldElement<BaseField = B>,
 {
     let domain_size = p.len() * blowup_factor;
-    let g = B::get_root_of_unity(log2(domain_size));
+    let g = B::get_root_of_unity(domain_size.ilog2());
     let mut result = unsafe { uninit_vector(domain_size) };
 
     result

--- a/math/src/fft/tests.rs
+++ b/math/src/fft/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     fft::fft_inputs::FftInputs,
     field::{f128::BaseElement, StarkField},
     polynom,
-    utils::{get_power_series, log2},
+    utils::get_power_series,
 };
 use rand_utils::rand_vector;
 use utils::collections::Vec;
@@ -61,7 +61,7 @@ fn fft_in_place() {
 #[test]
 fn fft_get_twiddles() {
     let n = super::MIN_CONCURRENT_SIZE * 2;
-    let g = BaseElement::get_root_of_unity(log2(n));
+    let g = BaseElement::get_root_of_unity(n.ilog2());
 
     let mut expected = get_power_series(g, n / 2);
     expected.permute();
@@ -74,6 +74,6 @@ fn fft_get_twiddles() {
 // ================================================================================================
 
 fn build_domain(size: usize) -> Vec<BaseElement> {
-    let g = BaseElement::get_root_of_unity(log2(size));
+    let g = BaseElement::get_root_of_unity(size.ilog2());
     get_power_series(g, size)
 }

--- a/math/src/polynom/tests.rs
+++ b/math/src/polynom/tests.rs
@@ -6,7 +6,7 @@
 use super::remove_leading_zeros;
 use crate::{
     field::{f128::BaseElement, FieldElement, StarkField},
-    utils::{get_power_series, log2},
+    utils::get_power_series,
 };
 use utils::collections::Vec;
 
@@ -215,7 +215,7 @@ fn syn_div() {
         .collect();
 
     // build the domain
-    let root = BaseElement::get_root_of_unity(log2(ys.len()));
+    let root = BaseElement::get_root_of_unity(ys.len().ilog2());
     let domain = get_power_series(root, ys.len());
 
     // build the polynomial

--- a/prover/src/composer/mod.rs
+++ b/prover/src/composer/mod.rs
@@ -5,7 +5,7 @@
 
 use super::{constraints::CompositionPoly, StarkDomain, TracePolyTable};
 use air::DeepCompositionCoefficients;
-use math::{add_in_place, fft, log2, mul_acc, polynom, ExtensionOf, FieldElement, StarkField};
+use math::{add_in_place, fft, mul_acc, polynom, ExtensionOf, FieldElement, StarkField};
 use utils::{collections::Vec, iter_mut};
 
 #[cfg(feature = "concurrent")]
@@ -69,7 +69,7 @@ impl<E: FieldElement> DeepCompositionPoly<E> {
         // compute a second out-of-domain point offset from z by exactly trace generator; this
         // point defines the "next" computation state in relation to point z
         let trace_length = trace_polys.poly_size();
-        let g = E::from(E::BaseField::get_root_of_unity(log2(trace_length)));
+        let g = E::from(E::BaseField::get_root_of_unity(trace_length.ilog2()));
         let next_z = self.z * g;
 
         // combine trace polynomials into 2 composition polynomials T'(x) and T''(x)

--- a/prover/src/constraints/periodic_table.rs
+++ b/prover/src/constraints/periodic_table.rs
@@ -99,8 +99,7 @@ mod tests {
     use crate::tests::MockAir;
     use air::Air;
     use math::{
-        fields::f128::BaseElement, get_power_series_with_offset, log2, polynom, FieldElement,
-        StarkField,
+        fields::f128::BaseElement, get_power_series_with_offset, polynom, FieldElement, StarkField,
     };
     use utils::collections::Vec;
 
@@ -155,7 +154,7 @@ mod tests {
     }
 
     fn build_ce_domain(domain_size: usize, domain_offset: BaseElement) -> Vec<BaseElement> {
-        let g = BaseElement::get_root_of_unity(log2(domain_size));
+        let g = BaseElement::get_root_of_unity(domain_size.ilog2());
         get_power_series_with_offset(g, domain_offset, domain_size)
     }
 }

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use air::Air;
-use math::{fft, get_power_series, log2, StarkField};
+use math::{fft, get_power_series, StarkField};
 use utils::collections::Vec;
 
 // TYPES AND INTERFACES
@@ -39,7 +39,7 @@ impl<B: StarkField> StarkDomain<B> {
         let trace_twiddles = fft::get_twiddles(air.trace_length());
 
         // build constraint evaluation domain
-        let domain_gen = B::get_root_of_unity(log2(air.ce_domain_size()));
+        let domain_gen = B::get_root_of_unity(air.ce_domain_size().ilog2());
         let ce_domain = get_power_series(domain_gen, air.ce_domain_size());
 
         StarkDomain {
@@ -64,7 +64,7 @@ impl<B: StarkField> StarkDomain<B> {
         );
 
         let ce_domain_size = trace_twiddles.len() * blowup_factor * 2;
-        let domain_gen = B::get_root_of_unity(log2(ce_domain_size));
+        let domain_gen = B::get_root_of_unity(ce_domain_size.ilog2());
         let ce_domain = get_power_series(domain_gen, ce_domain_size);
 
         StarkDomain {
@@ -110,7 +110,7 @@ impl<B: StarkField> StarkDomain<B> {
 
     /// Returns the generator of constraint evaluation domain.
     pub fn ce_domain_generator(&self) -> B {
-        B::get_root_of_unity(log2(self.ce_domain_size()))
+        B::get_root_of_unity(self.ce_domain_size().ilog2())
     }
 
     /// Returns blowup factor from constraint evaluation to LDE domain.

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -70,8 +70,6 @@ use crypto::{ElementHasher, MerkleTree, RandomCoin};
 #[cfg(feature = "std")]
 use log::debug;
 #[cfg(feature = "std")]
-use math::log2;
-#[cfg(feature = "std")]
 use std::time::Instant;
 
 mod domain;
@@ -220,7 +218,7 @@ pub trait Prover {
         #[cfg(feature = "std")]
         debug!(
             "Built domain of 2^{} elements in {} ms",
-            log2(domain.lde_domain_size()),
+            domain.lde_domain_size().ilog2(),
             now.elapsed().as_millis()
         );
 
@@ -261,7 +259,7 @@ pub trait Prover {
             debug!(
                 "Built auxiliary trace segment of {} columns and 2^{} steps in {} ms",
                 aux_segment.num_cols(),
-                log2(aux_segment.num_rows()),
+                aux_segment.num_rows().ilog2(),
                 now.elapsed().as_millis()
             );
 
@@ -301,7 +299,7 @@ pub trait Prover {
         #[cfg(feature = "std")]
         debug!(
             "Evaluated constraints over domain of 2^{} elements in {} ms",
-            log2(constraint_evaluations.num_rows()),
+            constraint_evaluations.num_rows().ilog2(),
             now.elapsed().as_millis()
         );
 
@@ -394,7 +392,7 @@ pub trait Prover {
         #[cfg(feature = "std")]
         debug!(
             "Evaluated DEEP composition polynomial over LDE domain (2^{} elements) in {} ms",
-            log2(domain.lde_domain_size()),
+            domain.lde_domain_size().ilog2(),
             now.elapsed().as_millis()
         );
 
@@ -480,8 +478,8 @@ pub trait Prover {
         debug!(
             "Extended execution trace of {} columns from 2^{} to 2^{} steps ({}x blowup) in {} ms",
             trace_lde.num_cols(),
-            log2(trace_polys.num_rows()),
-            log2(trace_lde.num_rows()),
+            trace_polys.num_rows().ilog2(),
+            trace_lde.num_rows().ilog2(),
             domain.trace_to_lde_blowup(),
             now.elapsed().as_millis()
         );
@@ -524,7 +522,7 @@ pub trait Prover {
         debug!(
             "Evaluated {} composition polynomial columns over LDE domain (2^{} elements) in {} ms",
             composed_evaluations.num_cols(),
-            log2(composed_evaluations.num_rows()),
+            composed_evaluations.num_rows().ilog2(),
             now.elapsed().as_millis()
         );
 

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -6,7 +6,7 @@
 use super::{ColMatrix, Segment};
 use crate::StarkDomain;
 use crypto::{ElementHasher, MerkleTree};
-use math::{fft, log2, FieldElement, StarkField};
+use math::{fft, FieldElement, StarkField};
 use utils::collections::Vec;
 use utils::{batch_iter_mut, flatten_vector_elements, uninit_vector};
 
@@ -213,7 +213,7 @@ fn get_offsets<E: FieldElement>(
     domain_offset: E::BaseField,
 ) -> Vec<E::BaseField> {
     let domain_size = poly_size * blowup_factor;
-    let g = E::BaseField::get_root_of_unity(log2(domain_size));
+    let g = E::BaseField::get_root_of_unity(domain_size.ilog2());
 
     // allocate memory to hold the offsets
     let mut offsets = unsafe { uninit_vector(domain_size) };

--- a/prover/src/matrix/tests.rs
+++ b/prover/src/matrix/tests.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
-    math::{fields::f64::BaseElement, get_power_series, log2, polynom, StarkField},
+    math::{fields::f64::BaseElement, get_power_series, polynom, StarkField},
     ColMatrix, RowMatrix,
 };
 use rand_utils::rand_vector;
@@ -44,7 +44,7 @@ fn test_eval_poly_with_offset_matrix() {
 
 /// Builds a domain of size `size` using the primitive element of the field.
 fn build_domain(size: usize) -> Vec<BaseElement> {
-    let g = BaseElement::get_root_of_unity(log2(size));
+    let g = BaseElement::get_root_of_unity(size.ilog2());
     get_power_series(g, size)
 }
 

--- a/prover/src/trace/poly_table.rs
+++ b/prover/src/trace/poly_table.rs
@@ -7,7 +7,7 @@ use crate::{
     matrix::{ColumnIter, MultiColumnIter},
     ColMatrix,
 };
-use math::{log2, FieldElement, StarkField};
+use math::{FieldElement, StarkField};
 use utils::collections::Vec;
 
 // TRACE POLYNOMIAL TABLE
@@ -67,7 +67,7 @@ impl<E: FieldElement> TracePolyTable<E> {
     /// Returns an out-of-domain evaluation frame constructed by evaluating trace polynomials
     /// for all columns at points z and z * g, where g is the generator of the trace domain.
     pub fn get_ood_frame(&self, z: E) -> Vec<Vec<E>> {
-        let g = E::from(E::BaseField::get_root_of_unity(log2(self.poly_size())));
+        let g = E::from(E::BaseField::get_root_of_unity(self.poly_size().ilog2()));
         vec![self.evaluate_at(z), self.evaluate_at(z * g)]
     }
 

--- a/prover/src/trace/tests.rs
+++ b/prover/src/trace/tests.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use crypto::{hashers::Blake3_256, ElementHasher, MerkleTree};
 use math::{
-    fields::f128::BaseElement, get_power_series, get_power_series_with_offset, log2, polynom,
+    fields::f128::BaseElement, get_power_series, get_power_series_with_offset, polynom,
     FieldElement, StarkField,
 };
 use utils::collections::Vec;
@@ -61,7 +61,7 @@ fn extend_trace_table() {
     assert_eq!(64, trace_comm.trace_table().trace_len());
 
     // make sure trace polynomials evaluate to Fibonacci trace
-    let trace_root = BaseElement::get_root_of_unity(log2(trace_length));
+    let trace_root = BaseElement::get_root_of_unity(trace_length.ilog2());
     let trace_domain = get_power_series(trace_root, trace_length);
     assert_eq!(2, trace_polys.num_main_trace_polys());
     assert_eq!(
@@ -131,6 +131,6 @@ fn commit_trace_table() {
 // ================================================================================================
 
 fn build_lde_domain<B: StarkField>(domain_size: usize) -> Vec<B> {
-    let g = B::get_root_of_unity(log2(domain_size));
+    let g = B::get_root_of_unity(domain_size.ilog2());
     get_power_series_with_offset(g, B::GENERATOR, domain_size)
 }

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -5,7 +5,7 @@
 
 use super::{ColMatrix, Trace};
 use air::{EvaluationFrame, TraceInfo, TraceLayout};
-use math::{log2, FieldElement, StarkField};
+use math::{FieldElement, StarkField};
 use utils::{collections::Vec, uninit_vector};
 
 #[cfg(not(feature = "concurrent"))]
@@ -117,10 +117,10 @@ impl<B: StarkField> TraceTable<B> {
             "execution trace length must be a power of 2"
         );
         assert!(
-            log2(length) <= B::TWO_ADICITY,
+            length.ilog2() <= B::TWO_ADICITY,
             "execution trace length cannot exceed 2^{} steps, but was 2^{}",
             B::TWO_ADICITY,
-            log2(length)
+            length.ilog2()
         );
         assert!(
             meta.len() <= TraceInfo::MAX_META_LENGTH,
@@ -168,10 +168,10 @@ impl<B: StarkField> TraceTable<B> {
             "execution trace length must be a power of 2"
         );
         assert!(
-            log2(trace_length) <= B::TWO_ADICITY,
+            trace_length.ilog2() <= B::TWO_ADICITY,
             "execution trace length cannot exceed 2^{} steps, but was 2^{}",
             B::TWO_ADICITY,
-            log2(trace_length)
+            trace_length.ilog2()
         );
         for column in columns.iter().skip(1) {
             assert_eq!(


### PR DESCRIPTION
Removed log2() since .ilog2() has been stabilized https://blog.rust-lang.org/2023/01/26/Rust-1.67.0.html#stabilized-apis