### PR TITLE
add hash function Tip5

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -33,6 +33,8 @@ std = ["blake3/std", "math/std", "sha3/std", "utils/std"]
 blake3 = { version = "1.3", default-features = false }
 math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
 sha3 = { version = "0.10", default-features = false }
+twenty-first = "0.19.3"
+rand = "0.8.5"
 utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]

--- a/crypto/src/hash/griffin/griffin64_256_jive/digest.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/digest.rs
@@ -31,13 +31,13 @@ impl ElementDigest {
 }
 
 impl Digest for ElementDigest {
-    fn as_bytes(&self) -> [u8; 32] {
-        let mut result = [0; 32];
+    fn as_bytes(&self) -> [u8; 40] {
+        let mut result = [0; 40];
 
         result[..8].copy_from_slice(&self.0[0].as_int().to_le_bytes());
         result[8..16].copy_from_slice(&self.0[1].as_int().to_le_bytes());
         result[16..24].copy_from_slice(&self.0[2].as_int().to_le_bytes());
-        result[24..].copy_from_slice(&self.0[3].as_int().to_le_bytes());
+        result[24..32].copy_from_slice(&self.0[3].as_int().to_le_bytes());
 
         result
     }
@@ -79,7 +79,7 @@ impl From<ElementDigest> for [BaseElement; DIGEST_SIZE] {
     }
 }
 
-impl From<ElementDigest> for [u8; 32] {
+impl From<ElementDigest> for [u8; 40] {
     fn from(value: ElementDigest) -> Self {
         value.as_bytes()
     }

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -21,6 +21,8 @@ pub use rescue::{Rp62_248, Rp64_256, RpJive64_256};
 mod griffin;
 pub use griffin::GriffinJive64_256;
 
+mod tip5;
+
 // HASHER TRAITS
 // ================================================================================================
 
@@ -73,9 +75,9 @@ pub trait Digest:
     ///
     /// Ideally, the length of the returned array should be defined by an associated constant, but
     /// using associated constants in const generics is not supported by Rust yet. Thus, we put an
-    /// upper limit on the possible digest size. For digests which are smaller than 32 bytes, the
+    /// upper limit on the possible digest size. For digests which are smaller than 40 bytes, the
     /// unused bytes should be set to 0.
-    fn as_bytes(&self) -> [u8; 32];
+    fn as_bytes(&self) -> [u8; 40];
 }
 
 // BYTE DIGEST
@@ -105,8 +107,8 @@ impl<const N: usize> ByteDigest<N> {
 }
 
 impl<const N: usize> Digest for ByteDigest<N> {
-    fn as_bytes(&self) -> [u8; 32] {
-        let mut result = [0; 32];
+    fn as_bytes(&self) -> [u8; 40] {
+        let mut result = [0; 40];
         result[..N].copy_from_slice(&self.0);
         result
     }
@@ -136,12 +138,12 @@ mod tests {
 
     #[test]
     fn byte_digest_as_bytes() {
-        let d = ByteDigest::new([255_u8; 32]);
-        assert_eq!([255_u8; 32], d.as_bytes());
+        let d = ByteDigest::new([255_u8; 40]);
+        assert_eq!([255_u8; 40], d.as_bytes());
 
-        let d = ByteDigest::new([255_u8; 31]);
-        let mut expected = [255_u8; 32];
-        expected[31] = 0;
+        let d = ByteDigest::new([255_u8; 39]);
+        let mut expected = [255_u8; 40];
+        expected[39] = 0;
         assert_eq!(expected, d.as_bytes());
     }
 }

--- a/crypto/src/hash/rescue/rp62_248/digest.rs
+++ b/crypto/src/hash/rescue/rp62_248/digest.rs
@@ -31,17 +31,17 @@ impl ElementDigest {
 }
 
 impl Digest for ElementDigest {
-    fn as_bytes(&self) -> [u8; 32] {
+    fn as_bytes(&self) -> [u8; 40] {
         let v1 = self.0[0].as_int();
         let v2 = self.0[1].as_int();
         let v3 = self.0[2].as_int();
         let v4 = self.0[3].as_int();
 
-        let mut result = [0; 32];
+        let mut result = [0; 40];
         result[..8].copy_from_slice(&(v1 | (v2 << 62)).to_le_bytes());
         result[8..16].copy_from_slice(&((v2 >> 2) | (v3 << 60)).to_le_bytes());
         result[16..24].copy_from_slice(&((v3 >> 4) | (v4 << 58)).to_le_bytes());
-        result[24..].copy_from_slice(&(v4 >> 6).to_le_bytes());
+        result[24..32].copy_from_slice(&(v4 >> 6).to_le_bytes());
 
         result
     }

--- a/crypto/src/hash/rescue/rp64_256/digest.rs
+++ b/crypto/src/hash/rescue/rp64_256/digest.rs
@@ -31,13 +31,13 @@ impl ElementDigest {
 }
 
 impl Digest for ElementDigest {
-    fn as_bytes(&self) -> [u8; 32] {
-        let mut result = [0; 32];
+    fn as_bytes(&self) -> [u8; 40] {
+        let mut result = [0; 40];
 
         result[..8].copy_from_slice(&self.0[0].as_int().to_le_bytes());
         result[8..16].copy_from_slice(&self.0[1].as_int().to_le_bytes());
         result[16..24].copy_from_slice(&self.0[2].as_int().to_le_bytes());
-        result[24..].copy_from_slice(&self.0[3].as_int().to_le_bytes());
+        result[24..32].copy_from_slice(&self.0[3].as_int().to_le_bytes());
 
         result
     }
@@ -79,7 +79,7 @@ impl From<ElementDigest> for [BaseElement; DIGEST_SIZE] {
     }
 }
 
-impl From<ElementDigest> for [u8; 32] {
+impl From<ElementDigest> for [u8; 40] {
     fn from(value: ElementDigest) -> Self {
         value.as_bytes()
     }

--- a/crypto/src/hash/rescue/rp64_256_jive/digest.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/digest.rs
@@ -31,13 +31,13 @@ impl ElementDigest {
 }
 
 impl Digest for ElementDigest {
-    fn as_bytes(&self) -> [u8; 32] {
-        let mut result = [0; 32];
+    fn as_bytes(&self) -> [u8; 40] {
+        let mut result = [0; 40];
 
         result[..8].copy_from_slice(&self.0[0].as_int().to_le_bytes());
         result[8..16].copy_from_slice(&self.0[1].as_int().to_le_bytes());
         result[16..24].copy_from_slice(&self.0[2].as_int().to_le_bytes());
-        result[24..].copy_from_slice(&self.0[3].as_int().to_le_bytes());
+        result[24..32].copy_from_slice(&self.0[3].as_int().to_le_bytes());
 
         result
     }
@@ -79,7 +79,7 @@ impl From<ElementDigest> for [BaseElement; DIGEST_SIZE] {
     }
 }
 
-impl From<ElementDigest> for [u8; 32] {
+impl From<ElementDigest> for [u8; 40] {
     fn from(value: ElementDigest) -> Self {
         value.as_bytes()
     }

--- a/crypto/src/hash/tip5/mod.rs
+++ b/crypto/src/hash/tip5/mod.rs
@@ -1,0 +1,154 @@
+use twenty_first::shared_math::b_field_element::BFieldElement;
+use twenty_first::shared_math::tip5;
+use twenty_first::shared_math::tip5::Tip5;
+use twenty_first::shared_math::tip5::DIGEST_LENGTH;
+use twenty_first::shared_math::tip5::RATE;
+use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
+
+use math::fields::f64::BaseElement;
+use math::FieldElement;
+use math::StarkField;
+use utils::ByteReader;
+use utils::ByteWriter;
+use utils::Deserializable;
+use utils::DeserializationError;
+use utils::Serializable;
+
+use crate::Digest;
+use crate::Hasher;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Tip5Digest([BaseElement; DIGEST_LENGTH]);
+
+impl Tip5Digest {
+    pub fn new(digest: [BaseElement; DIGEST_LENGTH]) -> Self {
+        Self(digest)
+    }
+
+    pub fn as_elements(&self) -> &[BaseElement; DIGEST_LENGTH] {
+        &self.0
+    }
+}
+
+impl Serializable for Tip5Digest {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_bytes(&self.as_bytes());
+    }
+}
+
+impl Deserializable for Tip5Digest {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let read_values = [
+            source.read_u64()?,
+            source.read_u64()?,
+            source.read_u64()?,
+            source.read_u64()?,
+            source.read_u64()?,
+        ];
+        if read_values.iter().any(|&x| x >= BaseElement::MODULUS) {
+            return Err(DeserializationError::InvalidValue(
+                "Read u64 must be a valid field element.".into(),
+            ));
+        }
+        Ok(Self(read_values.map(BaseElement::new)))
+    }
+}
+
+impl IntoIterator for Tip5Digest {
+    type Item = BaseElement;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_elements().to_vec().into_iter()
+    }
+}
+
+impl Digest for Tip5Digest {
+    fn as_bytes(&self) -> [u8; 40] {
+        self.into_iter()
+            .flat_map(|element| element.as_int().to_le_bytes())
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap()
+    }
+}
+
+impl Hasher for Tip5 {
+    type Digest = Tip5Digest;
+    const COLLISION_RESISTANCE: u32 = 160;
+
+    fn hash(bytes: &[u8]) -> Self::Digest {
+        let bytes_iterator = bytes.chunks_exact(8);
+        let last_element = {
+            let mut last_bytes = [0_u8; 8];
+            last_bytes[..bytes_iterator.remainder().len()]
+                .copy_from_slice(bytes_iterator.remainder());
+            let last_element = u64::from_le_bytes(last_bytes);
+            BFieldElement::new(last_element)
+        };
+        let hash_input = bytes_iterator
+            .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
+            .map(BFieldElement::new)
+            .chain(std::iter::once(last_element))
+            .collect::<Vec<_>>();
+        let digest = Tip5::hash_varlen(&hash_input);
+        let digest = digest.values().map(b_field_element_to_base_element);
+        Tip5Digest::new(digest)
+    }
+
+    fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
+        let left_and_right = values.map(|digest| {
+            let elements = digest.as_elements();
+            let elements = elements.map(base_element_to_b_field_element);
+            tip5::Digest::new(elements)
+        });
+        let digest = Tip5::hash_pair(&left_and_right[0], &left_and_right[1]);
+        let digest = digest.values().map(b_field_element_to_base_element);
+        Tip5Digest::new(digest)
+    }
+
+    fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {
+        let mut initial_state = [BaseElement::ZERO; RATE];
+        initial_state[..DIGEST_LENGTH].copy_from_slice(seed.as_elements());
+        initial_state[DIGEST_LENGTH] = BaseElement::new(value);
+        let initial_state = initial_state.map(base_element_to_b_field_element);
+        let digest = Tip5::hash_10(&initial_state);
+        let digest = digest.map(b_field_element_to_base_element);
+        Tip5Digest::new(digest)
+    }
+}
+
+fn base_element_to_b_field_element(base_element: BaseElement) -> BFieldElement {
+    BFieldElement::from_raw_u64(base_element.inner())
+}
+
+fn b_field_element_to_base_element(b_field_element: BFieldElement) -> BaseElement {
+    BaseElement::from_mont(b_field_element.raw_u64())
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+    use rand::Rng;
+
+    use math::StarkField;
+
+    use super::*;
+
+    #[test]
+    fn base_field_element_conversion() {
+        let random_element: u64 = thread_rng().gen();
+
+        let base_element = BaseElement::new(random_element);
+        let b_field_element = base_element_to_b_field_element(base_element);
+        let base_element = b_field_element_to_base_element(b_field_element);
+        let inner_value_after_double_conversion = base_element.as_int();
+        assert_eq!(random_element, inner_value_after_double_conversion);
+
+        let b_field_element = BFieldElement::new(random_element);
+        let base_element = b_field_element_to_base_element(b_field_element);
+        let b_field_element = base_element_to_b_field_element(base_element);
+        let inner_value_after_double_conversion = b_field_element.value();
+        assert_eq!(random_element, inner_value_after_double_conversion);
+    }
+}

--- a/examples/src/utils/rescue.rs
+++ b/examples/src/utils/rescue.rs
@@ -148,9 +148,9 @@ impl Hash {
 }
 
 impl Digest for Hash {
-    fn as_bytes(&self) -> [u8; 32] {
+    fn as_bytes(&self) -> [u8; 40] {
         let bytes = BaseElement::elements_as_bytes(&self.0);
-        let mut result = [0; 32];
+        let mut result = [0; 40];
         result[..bytes.len()].copy_from_slice(bytes);
         result
     }


### PR DESCRIPTION
This PR is trying to address #187.

Unfortunately, the tests are not passing. I suspect this has to do with me raising the upper bound for the number of bytes in a `Digest` (see [here](https://github.com/facebook/winterfell/blob/main/crypto/src/hash/mod.rs#L69)). However, the feedback provided by the failing tests doesn't let me pinpoint the root cause very easily. Since I don't know the codebase very well, I'd be happy if someone in the know could take a look.

Additionally, I'm not sure if my handling of bytes is correct in all places. For example (but not limited to): my current implementation of the `Hasher`'s trait method `fn hash(bytes: &[u8])` interprets 8 bytes as a field element of the field with $2^{64} - 2^{32} + 1$ elements[^0]. This can lead to hash collisions, depending on the type of objects being fed into the method. I'd appreciate some guidance here.

[^0]: This is the only field the hash function Tip5 is defined over, so there is no need to be generic with respect to the field.