### PR TITLE
Speedup proof verification using batched inverse.

### DIFF
--- a/math/src/utils/mod.rs
+++ b/math/src/utils/mod.rs
@@ -160,7 +160,7 @@ where
 /// threads.
 ///
 /// This function is significantly faster than inverting elements one-by-one because it
-/// essentially transforms `n` inversions into `4 * n` multiplications + 1 inversion.
+/// essentially transforms `n` inversions into `3 * n` multiplications + 1 inversion.
 ///
 /// # Examples
 /// ```


### PR DESCRIPTION
Uses batch inverse function to save some cycles during verification.
This was derived while working on [zkDilithium](https://github.com/guruvamsi-policharla/zkdilithium) as part of [ia.cr/2023/414](https://ia.cr/2023/414).

|code| old | new| 
|--|--|--|
| rescue | 0.9 ms| 0.6 ms|
| vdf    | 2.0 ms| 1.8 ms|
| mulfib | 0.8 ms| 0.7 ms|
