### PR TITLE
Make changes to enable custom build_constraint_commitment

### DIFF
--- a/prover/src/constraints/commitment.rs
+++ b/prover/src/constraints/commitment.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::ColMatrix;
+use super::RowMatrix;
 use air::proof::Queries;
 use crypto::{ElementHasher, MerkleTree};
 use math::FieldElement;
@@ -19,14 +19,14 @@ use utils::collections::Vec;
 /// * Merkle tree where each leaf in the tree corresponds to a row in the composition polynomial
 ///   evaluation matrix.
 pub struct ConstraintCommitment<E: FieldElement, H: ElementHasher<BaseField = E::BaseField>> {
-    evaluations: ColMatrix<E>,
+    evaluations: RowMatrix<E>,
     commitment: MerkleTree<H>,
 }
 
 impl<E: FieldElement, H: ElementHasher<BaseField = E::BaseField>> ConstraintCommitment<E, H> {
     /// Creates a new constraint evaluation commitment from the provided composition polynomial
     /// evaluations and the corresponding Merkle tree commitment.
-    pub fn new(evaluations: ColMatrix<E>, commitment: MerkleTree<H>) -> ConstraintCommitment<E, H> {
+    pub fn new(evaluations: RowMatrix<E>, commitment: MerkleTree<H>) -> ConstraintCommitment<E, H> {
         assert_eq!(
             evaluations.num_rows(),
             commitment.leaves().len(),
@@ -61,8 +61,7 @@ impl<E: FieldElement, H: ElementHasher<BaseField = E::BaseField>> ConstraintComm
         // determine a set of evaluations corresponding to each position
         let mut evaluations = Vec::new();
         for &position in positions {
-            let mut row = vec![E::ZERO; self.evaluations.num_cols()];
-            self.evaluations.read_row_into(position, &mut row);
+            let row = self.evaluations.row(position).to_vec();
             evaluations.push(row);
         }
 

--- a/prover/src/constraints/composition_poly.rs
+++ b/prover/src/constraints/composition_poly.rs
@@ -3,8 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{ColMatrix, StarkDomain};
-use math::{polynom, FieldElement, StarkField};
+use super::ColMatrix;
+use math::{polynom, FieldElement};
 use utils::{collections::Vec, uninit_vector};
 
 // COMPOSITION POLYNOMIAL
@@ -67,31 +67,16 @@ impl<E: FieldElement> CompositionPoly<E> {
         self.column_len() - 1
     }
 
-    // LOW-DEGREE EXTENSION
-    // --------------------------------------------------------------------------------------------
-    /// Evaluates the columns of the composition polynomial over the specified LDE domain and
-    /// returns the result.
-    pub fn evaluate<B>(&self, domain: &StarkDomain<B>) -> ColMatrix<E>
-    where
-        B: StarkField,
-        E: FieldElement<BaseField = B>,
-    {
-        assert_eq!(
-            self.column_len(),
-            domain.trace_length(),
-            "inconsistent trace domain size; expected {}, but received {}",
-            self.column_len(),
-            domain.trace_length()
-        );
-
-        self.data.evaluate_columns_over(domain)
-    }
-
     /// Returns evaluations of all composition polynomial columns at point z^m, where m is
     /// the number of column polynomials.
     pub fn evaluate_at(&self, z: E) -> Vec<E> {
         let z_m = z.exp((self.num_columns() as u32).into());
         self.data.evaluate_columns_at(z_m)
+    }
+
+    /// Returns a reference to the matrix of individual column polynomials.
+    pub fn data(&self) -> &ColMatrix<E> {
+        &self.data
     }
 
     /// Transforms this composition polynomial into a vector of individual column polynomials.

--- a/prover/src/constraints/mod.rs
+++ b/prover/src/constraints/mod.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{ColMatrix, ConstraintDivisor, ProverError, StarkDomain};
+use super::{ColMatrix, ConstraintDivisor, ProverError, RowMatrix, StarkDomain};
 
 mod boundary;
 use boundary::BoundaryConstraints;


### PR DESCRIPTION
Changes:
* Made CompositionPoly and ConstraintCommitment public to allow overriding build_constraint_commitment
* Removed `.evaluate` from composition poly and use RowMatrix::evaluate_polys_over instead (this is now consistent with build_trace_commitment)
* ConstraintCommitment takes a RowMatrix of evaluations instead of a ColMatrix