### PR TITLE
Performance improvement for FRI

### DIFF
--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -12,7 +12,6 @@
 use utils::iterators::*;
 
 use math::{
-    batch_inversion,
     fft::{get_inv_twiddles, serial_fft},
     get_power_series_with_offset, polynom, FieldElement, StarkField,
 };
@@ -183,8 +182,6 @@ where
     B: StarkField,
 {
     let n = domain_size * folding_factor;
-    let g = B::get_root_of_unity(n.trailing_zeros());
-    let offsets = get_power_series_with_offset(g, domain_offset, domain_size);
-
-    batch_inversion(&offsets)
+    let g = B::get_root_of_unity(n.ilog2());
+    get_power_series_with_offset(g.inv(), domain_offset.inv(), domain_size)
 }


### PR DESCRIPTION
Refactored `get_inv_offsets` for some performance improvements. Results:

<img width="558" alt="Screen Shot 2023-04-25 at 11 09 24 pm" src="https://user-images.githubusercontent.com/6158251/234286766-0a63e9e9-b783-40c0-8d88-e6549ee317f6.png">
<img width="558" alt="Screen Shot 2023-04-25 at 11 09 39 pm" src="https://user-images.githubusercontent.com/6158251/234286814-98a7e171-4664-4c19-bdd6-cd04b4050a27.png">
