### PR TITLE
Increased size bounds for traces and blowup factor

### DIFF
--- a/air/src/air/trace_info.rs
+++ b/air/src/air/trace_info.rs
@@ -31,14 +31,14 @@ pub struct TraceInfo {
 }
 
 impl TraceInfo {
-    /// Smallest allowed execution trace length; currently set at 8.
-    pub const MIN_TRACE_LENGTH: usize = 8;
-    /// Maximum number of columns in an execution trace (across all segments); currently set at 255.
-    pub const MAX_TRACE_WIDTH: usize = 255;
+    /// Smallest allowed execution trace length; currently set at 4.
+    pub const MIN_TRACE_LENGTH: usize = 4;
+    /// Maximum number of columns in an execution trace (across all segments); currently set at 65535.
+    pub const MAX_TRACE_WIDTH: usize = 65535;
     /// Maximum number of bytes in trace metadata; currently set at 65535.
     pub const MAX_META_LENGTH: usize = 65535;
-    /// Maximum number of random elements per auxiliary trace segment; currently set to 255.
-    pub const MAX_RAND_SEGMENT_ELEMENTS: usize = 255;
+    /// Maximum number of random elements per auxiliary trace segment; currently set to 65535.
+    pub const MAX_RAND_SEGMENT_ELEMENTS: usize = 65535;
 
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
@@ -49,8 +49,8 @@ impl TraceInfo {
     ///
     /// # Panics
     /// Panics if:
-    /// * Trace width is zero or greater than 255.
-    /// * Trace length is smaller than 8 or is not a power of two.
+    /// * Trace width is zero or greater than 65535.
+    /// * Trace length is smaller than 4 or is not a power of two.
     pub fn new(width: usize, length: usize) -> Self {
         Self::with_meta(width, length, vec![])
     }
@@ -61,8 +61,8 @@ impl TraceInfo {
     ///
     /// # Panics
     /// Panics if:
-    /// * Trace width is zero or greater than 255.
-    /// * Trace length is smaller than 8 or is not a power of two.
+    /// * Trace width is zero or greater than 25655355.
+    /// * Trace length is smaller than 4 or is not a power of two.
     /// * Length of `meta` is greater than 65535;
     pub fn with_meta(width: usize, length: usize, meta: Vec<u8>) -> Self {
         assert!(width > 0, "trace width must be greater than 0");
@@ -75,8 +75,8 @@ impl TraceInfo {
     /// # Panics
     /// Panics if:
     /// * The width of the first trace segment is zero.
-    /// * Total width of all trace segments is greater than 255.
-    /// * Trace length is smaller than 8 or is not a power of two.
+    /// * Total width of all trace segments is greater than 65535.
+    /// * Trace length is smaller than 4 or is not a power of two.
     pub fn new_multi_segment(layout: TraceLayout, length: usize, meta: Vec<u8>) -> Self {
         assert!(
             length >= Self::MIN_TRACE_LENGTH,
@@ -113,7 +113,7 @@ impl TraceInfo {
 
     /// Returns the total number of columns in an execution trace.
     ///
-    /// This is guaranteed to be between 1 and 255.
+    /// This is guaranteed to be between 1 and 65535.
     pub fn width(&self) -> usize {
         self.layout.main_trace_width() + self.layout().aux_trace_width()
     }
@@ -170,11 +170,11 @@ impl TraceLayout {
     /// # Panics
     /// Panics if:
     /// * Width of the main trace segment is set to zero.
-    /// * Sum of all segment widths exceeds 255.
+    /// * Sum of all segment widths exceeds 65535.
     /// * A zero entry in auxiliary segment width array is followed by a non-zero entry.
     /// * Number of random elements for an auxiliary trace segment of non-zero width is set to zero.
     /// * Number of random elements for an auxiliary trace segment of zero width is set to non-zero.
-    /// * Number of random elements for any auxiliary trace segment is greater than 255.
+    /// * Number of random elements for any auxiliary trace segment is greater than 65535.
     pub fn new(
         main_width: usize,
         aux_widths: [usize; NUM_AUX_SEGMENTS],
@@ -235,7 +235,7 @@ impl TraceLayout {
 
     /// Returns the number of columns in the main segment of an execution trace.
     ///
-    /// This is guaranteed to be between 1 and 255.
+    /// This is guaranteed to be between 1 and 65535.
     pub fn main_trace_width(&self) -> usize {
         self.main_segment_width
     }

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -77,7 +77,7 @@ pub enum FieldExtension {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ProofOptions {
     num_queries: u8,
-    blowup_factor: u8,
+    blowup_factor: u16,
     grinding_factor: u8,
     field_extension: FieldExtension,
     fri_folding_factor: u8,
@@ -142,7 +142,7 @@ impl ProofOptions {
 
         ProofOptions {
             num_queries: num_queries as u8,
-            blowup_factor: blowup_factor as u8,
+            blowup_factor: blowup_factor as u16,
             grinding_factor: grinding_factor as u8,
             field_extension,
             fri_folding_factor: fri_folding_factor as u8,
@@ -228,7 +228,7 @@ impl Serializable for ProofOptions {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u8(self.num_queries);
-        target.write_u8(self.blowup_factor);
+        target.write_u16(self.blowup_factor);
         target.write_u8(self.grinding_factor);
         target.write(self.field_extension);
         target.write_u8(self.fri_folding_factor);
@@ -244,7 +244,7 @@ impl Deserializable for ProofOptions {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         Ok(ProofOptions::new(
             source.read_u8()? as usize,
-            source.read_u8()? as usize,
+            source.read_u16()? as usize,
             source.read_u8()? as u32,
             FieldExtension::read_from(source)?,
             source.read_u8()? as usize,

--- a/air/src/proof/table.rs
+++ b/air/src/proof/table.rs
@@ -10,8 +10,8 @@ use math::FieldElement;
 // CONSTANTS
 // ================================================================================================
 
-const MAX_ROWS: usize = 255;
-const MAX_COLS: usize = 255;
+const MAX_ROWS: usize = 65535;
+const MAX_COLS: usize = 65535;
 
 // TABLE
 // ================================================================================================
@@ -34,8 +34,8 @@ impl<E: FieldElement> Table<E> {
     ///
     /// # Panics
     /// Panics if:
-    /// * Specified number of rows is 0 or greater than 255.
-    /// * Specified number of columns is 0 or greater than 255.
+    /// * Specified number of rows is 0 or greater than 65535.
+    /// * Specified number of columns is 0 or greater than 65535.
     /// * Provided bytes do not encode valid field elements required to fill the table.
     pub fn from_bytes(
         bytes: &[u8],

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -48,27 +48,27 @@ pub struct ExampleOptions {
 
     /// Hash function used in the protocol
     #[structopt(short = "h", long = "hash_fn", default_value = "blake3_256")]
-    hash_fn: String,
+    pub hash_fn: String,
 
     /// Number of queries to include in a proof
     #[structopt(short = "q", long = "queries")]
-    num_queries: Option<usize>,
+    pub num_queries: Option<usize>,
 
     /// Blowup factor for low degree extension
     #[structopt(short = "b", long = "blowup")]
-    blowup_factor: Option<usize>,
+    pub blowup_factor: Option<usize>,
 
     /// Grinding factor for query seed
     #[structopt(short = "g", long = "grinding", default_value = "16")]
-    grinding_factor: u32,
+    pub grinding_factor: u32,
 
     /// Field extension degree for composition polynomial
     #[structopt(short = "e", long = "field_extension", default_value = "1")]
-    field_extension: u32,
+    pub field_extension: u32,
 
     /// Folding factor for FRI protocol
     #[structopt(short = "f", long = "folding", default_value = "8")]
-    folding_factor: usize,
+    pub folding_factor: usize,
 }
 
 impl ExampleOptions {

--- a/examples/src/rescue_raps/custom_trace_table.rs
+++ b/examples/src/rescue_raps/custom_trace_table.rs
@@ -44,8 +44,8 @@ impl<B: StarkField> RapTraceTable<B> {
     ///
     /// # Panics
     /// Panics if:
-    /// * `width` is zero or greater than 255.
-    /// * `length` is smaller than 8, greater than biggest multiplicative subgroup in the field
+    /// * `width` is zero or greater than 65535.
+    /// * `length` is smaller than 4, greater than biggest multiplicative subgroup in the field
     ///   `B`, or is not a power of two.
     pub fn new(width: usize, length: usize) -> Self {
         Self::with_meta(width, length, vec![])
@@ -59,7 +59,7 @@ impl<B: StarkField> RapTraceTable<B> {
     ///
     /// # Panics
     /// Panics if:
-    /// * `width` is zero or greater than 255.
+    /// * `width` is zero or greater than 65535.
     /// * `length` is smaller than 8, greater than the biggest multiplicative subgroup in the
     ///   field `B`, or is not a power of two.
     /// * Length of `meta` is greater than 65535;

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -76,8 +76,8 @@ impl<B: StarkField> TraceTable<B> {
     ///
     /// # Panics
     /// Panics if:
-    /// * `width` is zero or greater than 255.
-    /// * `length` is smaller than 8, greater than biggest multiplicative subgroup in the field
+    /// * `width` is zero or greater than 65535.
+    /// * `length` is smaller than 4, greater than biggest multiplicative subgroup in the field
     ///   `B`, or is not a power of two.
     pub fn new(width: usize, length: usize) -> Self {
         Self::with_meta(width, length, vec![])
@@ -91,8 +91,8 @@ impl<B: StarkField> TraceTable<B> {
     ///
     /// # Panics
     /// Panics if:
-    /// * `width` is zero or greater than 255.
-    /// * `length` is smaller than 8, greater than the biggest multiplicative subgroup in the
+    /// * `width` is zero or greater than 65535.
+    /// * `length` is smaller than 4, greater than the biggest multiplicative subgroup in the
     ///   field `B`, or is not a power of two.
     /// * Length of `meta` is greater than 65535;
     pub fn with_meta(width: usize, length: usize, meta: Vec<u8>) -> Self {


### PR DESCRIPTION
This commit 

- Increases the size bounds for traces, the blowup factor and updates the corresponding comments.
- Updates the visibility of the fields for the ExampleOptions struct.