### PR TITLE
Simplify DEEP composition polynomial

### DIFF
--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -528,19 +528,17 @@ pub trait Air: Send + Sync {
     {
         let mut t_coefficients = Vec::new();
         for _ in 0..self.trace_info().width() {
-            t_coefficients.push(public_coin.draw_pair()?);
+            t_coefficients.push(public_coin.draw()?);
         }
 
-        // self.ce_blowup_factor() is the same as number of composition columns
         let mut c_coefficients = Vec::new();
-        for _ in 0..self.ce_blowup_factor() {
+        for _ in 0..self.context().num_constraint_composition_columns() {
             c_coefficients.push(public_coin.draw()?);
         }
 
         Ok(DeepCompositionCoefficients {
             trace: t_coefficients,
             constraints: c_coefficients,
-            degree: public_coin.draw_pair()?,
         })
     }
 }

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -193,9 +193,8 @@ fn get_conjectured_security(
     let field_security = field_size - trace_domain_size.trailing_zeros();
 
     // compute security we get by executing multiple query rounds
-    let lde_domain_size = (options.blowup_factor() as u64) * trace_domain_size;
-    let security_per_query = ((lde_domain_size as f64) / (trace_domain_size as f64 + 2_f64)).log2();
-    let mut query_security = (security_per_query * options.num_queries() as f64) as u32;
+    let security_per_query = options.blowup_factor().ilog2();
+    let mut query_security = security_per_query * options.num_queries() as u32;
 
     // include grinding factor contributions only for proofs adequate security
     if query_security >= GRINDING_CONTRIBUTION_FLOOR {

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -119,6 +119,7 @@ impl StarkProof {
                 self.context.options(),
                 self.context.num_modulus_bits(),
                 self.lde_domain_size() as u64,
+                self.trace_length() as u64,
                 H::COLLISION_RESISTANCE,
             )
         }
@@ -192,8 +193,9 @@ fn get_conjectured_security(
     let field_security = field_size - trace_domain_size.trailing_zeros();
 
     // compute security we get by executing multiple query rounds
-    let security_per_query = options.blowup_factor().ilog2();
-    let mut query_security = security_per_query * options.num_queries() as u32;
+    let lde_domain_size = (options.blowup_factor() as u64) * trace_domain_size;
+    let security_per_query = ((lde_domain_size as f64) / (trace_domain_size as f64 + 2_f64)).log2();
+    let mut query_security = (security_per_query * options.num_queries() as f64) as u32;
 
     // include grinding factor contributions only for proofs adequate security
     if query_security >= GRINDING_CONTRIBUTION_FLOOR {
@@ -212,12 +214,21 @@ fn get_proven_security(
     options: &ProofOptions,
     base_field_bits: u32,
     lde_domain_size: u64,
+    trace_domain_size: u64,
     collision_resistance: u32,
 ) -> u32 {
     let extension_field_bits = (base_field_bits * options.field_extension().degree()) as f64;
+
     let blowup_bits = options.blowup_factor().ilog2() as f64;
     let num_fri_queries = options.num_queries() as f64;
     let lde_size_bits = lde_domain_size.trailing_zeros() as f64;
+
+    // blowup_plus_bits is the number of bits in the blowup factor which is the inverse of
+    // `\rho^+ := (trace_domain_size + 2) / lde_domain_size`. `\rho^+` is used in order to define a larger
+    // agreement parameter `\alpha^+ := (1 + 1/2m)\sqrt{rho^+} := 1 - \theta^+`. The reason for
+    // running FRI with a larger agreement parameter is to account for the simplified
+    // DEEP composition polynomial. See Protocol 3 in https://eprint.iacr.org/2022/1216.
+    let blowup_plus_bits = ((lde_domain_size as f64) / (trace_domain_size as f64 + 2_f64)).log2();
 
     // m is a parameter greater or equal to 3.
     // A larger m gives a worse field security bound but a better query security bound.
@@ -227,7 +238,8 @@ fn get_proven_security(
     // of m, unless the calculated value is less than 3 in which case it gets rounded up to 3.
     let mut m = extension_field_bits + 1.0;
     m -= options.grinding_factor() as f64;
-    m -= (num_fri_queries + 3.0) / 2.0 * blowup_bits;
+    m -= 1.5 * blowup_bits;
+    m -= 0.5 * num_fri_queries * blowup_plus_bits;
     m -= 2.0 * lde_size_bits;
     m /= 7.0;
     m = 2.0_f64.powf(m);
@@ -244,7 +256,7 @@ fn get_proven_security(
         - 7.0 * (m + 0.5).log2()) as u32;
 
     // compute security we get by executing multiple query rounds
-    let security_per_query = 0.5 * blowup_bits - (1.0 + 1.0 / (2.0 * m)).log2();
+    let security_per_query = 0.5 * blowup_plus_bits - (1.0 + 1.0 / (2.0 * m)).log2();
     let mut query_security = (security_per_query * num_fri_queries) as u32;
 
     query_security += options.grinding_factor();

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -70,19 +70,4 @@ pub trait RandomCoin: Sync {
         num_values: usize,
         domain_size: usize,
     ) -> Result<Vec<usize>, RandomCoinError>;
-
-    // PROVIDED METHODS
-    // --------------------------------------------------------------------------------------------
-
-    /// Returns the next pair of pseudo-random field elements.
-    ///
-    /// # Errors
-    /// Returns an error if any of the field elements could not be generated after 100 calls to
-    /// the PRNG;
-    fn draw_pair<E>(&mut self) -> Result<(E, E), RandomCoinError>
-    where
-        E: FieldElement<BaseField = Self::BaseField>,
-    {
-        Ok((self.draw()?, self.draw()?))
-    }
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -369,10 +369,6 @@ pub trait Prover {
         // merge columns of constraint composition polynomial into the DEEP composition polynomial;
         deep_composition_poly.add_composition_poly(composition_poly, ood_evaluations);
 
-        // raise the degree of the DEEP composition polynomial by one to make sure it is equal to
-        // trace_length - 1
-        deep_composition_poly.adjust_degree();
-
         #[cfg(feature = "std")]
         debug!(
             "Built DEEP composition polynomial of degree {} in {} ms",
@@ -381,8 +377,8 @@ pub trait Prover {
         );
 
         // make sure the degree of the DEEP composition polynomial is equal to trace polynomial
-        // degree
-        assert_eq!(domain.trace_length() - 1, deep_composition_poly.degree());
+        // degree minus 1.
+        assert_eq!(domain.trace_length() - 2, deep_composition_poly.degree());
 
         // 5 ----- evaluate DEEP composition polynomial over LDE domain ---------------------------
         #[cfg(feature = "std")]
@@ -391,7 +387,7 @@ pub trait Prover {
         // we check the following condition in debug mode only because infer_degree is an expensive
         // operation
         debug_assert_eq!(
-            domain.trace_length() - 1,
+            domain.trace_length() - 2,
             infer_degree(&deep_evaluations, domain.offset())
         );
         #[cfg(feature = "std")]


### PR DESCRIPTION
Removes the degree adjustment performed on the DEEP composition polynomial. This leads to a negligible increase in the soundness error of the protocol i.e. the $+2$ in the formula for $k^+$. The new soundness error for the current protocol is given by:

$$
L^{+}\cdot\left(\frac{1}{|\mathbb{F}|} + \frac{d\cdot(k^+ - 1) + (k-1)}{|\mathbb{F}| - |D\cup H|}\right) + \epsilon_{FRI}
$$

where:

1. $H$ is the trace domain of size $k$
2. $D$ is the LDE domain of size $n$
3. $k^+ := k + 2$
4. $L^+ := \frac{m+0.5}{\sqrt{\rho^+}}$ where $m\geq 3$ is the Johnson proximity parameter which for simiplicity can be taken to be equal to $3$ and $\rho^+ := \frac{k^+}{n}$
5. $\mathbb{F}$ is the extension field.
6. $\epsilon_{FRI}$ is the soundness error bound for FRI run with proximity parameter $\theta^+ := 1 - \alpha^+ := 1 - (1 + \frac{1}{2m})\cdot \sqrt{\rho^+}$
7. $d$ is the number of constraint composition column polynomials.