### PR TITLE
feature: add conditional support for serde

### DIFF
--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -33,6 +33,7 @@ default = ["std"]
 std = ["utils/std"]
 
 [dependencies]
+serde = { version = "1.0", features = [ "derive" ], optional = true, default-features = false }
 utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -15,6 +15,9 @@ use utils::{
     DeserializationError, Randomizable, Serializable, SliceReader,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 // QUADRATIC EXTENSION FIELD
 // ================================================================================================
 
@@ -25,6 +28,7 @@ use utils::{
 /// field elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct CubeExtension<B: ExtensibleField<3>>(B, B, B);
 
 impl<B: ExtensibleField<3>> CubeExtension<B> {

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -15,6 +15,9 @@ use utils::{
     DeserializationError, Randomizable, Serializable, SliceReader,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 // QUADRATIC EXTENSION FIELD
 // ================================================================================================
 
@@ -25,6 +28,7 @@ use utils::{
 /// elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct QuadExtension<B: ExtensibleField<2>>(B, B);
 
 impl<B: ExtensibleField<2>> QuadExtension<B> {

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -25,6 +25,9 @@ use utils::{
     Serializable,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(test)]
 mod tests;
 
@@ -48,6 +51,8 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u128>();
 /// Internal values are stored in their canonical form in the range [0, M). The backing type is
 /// `u128`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BaseElement(u128);
 
 impl BaseElement {

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -22,6 +22,9 @@ use utils::{
     DeserializationError, Randomizable, Serializable,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(test)]
 mod tests;
 
@@ -54,6 +57,8 @@ const G: u64 = 4421547261963328785;
 /// Internal values are stored in Montgomery representation and can be in the range [0; 2M). The
 /// backing type is `u64`.
 #[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
 
 impl BaseElement {
@@ -454,6 +459,18 @@ impl From<[u8; 8]> for BaseElement {
     fn from(bytes: [u8; 8]) -> Self {
         let value = u64::from_le_bytes(bytes);
         BaseElement::new(value)
+    }
+}
+
+impl From<BaseElement> for u128 {
+    fn from(value: BaseElement) -> Self {
+        value.as_int() as u128
+    }
+}
+
+impl From<BaseElement> for u64 {
+    fn from(value: BaseElement) -> Self {
+        value.as_int()
     }
 }
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -27,6 +27,9 @@ use utils::{
     DeserializationError, Randomizable, Serializable,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(test)]
 mod tests;
 
@@ -50,7 +53,10 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u64>();
 /// Internal values represent x * R mod M where R = 2^64 mod M and x in [0, M).
 /// The backing type is `u64` but the internal values are always in the range [0, M).
 #[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
+
 impl BaseElement {
     /// Creates a new field element from the provided `value`; the value is converted into
     /// Montgomery representation.
@@ -588,6 +594,18 @@ impl<'a> TryFrom<&'a [u8]> for BaseElement {
             )));
         }
         Ok(Self::new(value))
+    }
+}
+
+impl From<BaseElement> for u128 {
+    fn from(value: BaseElement) -> Self {
+        value.as_int() as u128
+    }
+}
+
+impl From<BaseElement> for u64 {
+    fn from(value: BaseElement) -> Self {
+        value.as_int()
     }
 }
 


### PR DESCRIPTION
This adds conditional support for serde. It allow serializing/deserializing the field elements, which is useful for downstream applications, for instance, to save test data.

The change is behind a feature flag to avoid impacting compilation times.