### PR TITLE
Enhancement: Introducing Dynamic FRI Folding Schedules

### DIFF
--- a/fri/src/fri_schedule.rs
+++ b/fri/src/fri_schedule.rs
@@ -3,11 +3,42 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+
+/// Enumerates the possible schedules for the FRI folding process.
+///
+/// The FRI folding process can operate under a constant factor or
+/// can follow a dynamic sequence of factors. This enum provides a
+/// way to specify which approach to use.
+///
+/// # Variants
+///
+/// - `Constant`: Represents a constant folding factor. This means that
+///   the prover will use the same folding factor iteratively throughout
+///   the FRI folding process. The prover will also specify the maximum
+///   degree of the remainder polynomial at the last FRI layer.
+///
+/// - `Dynamic`: Represents a dynamic schedule of folding factors. This means
+///   that the prover can use different folding factors across different rounds.
+///
+/// # Examples
+///
+/// Using a constant factor:
+///
+/// ```
+/// let constant_schedule = FoldingSchedule::constant(4, 2);
+/// ```
+///
+/// Using a dynamic schedule:
+///
+/// ```
+/// let dynamic_schedule = FoldingSchedule::dynamic(vec![4, 2, 2]);
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FoldingSchedule {
     Constant {
-        factor: u8,
-        remainder_max_degree: u8,
+        fri_folding_factor: u8,
+        fri_remainder_max_degree: u8,
     },
     Dynamic {
         schedule: Vec<u8>,
@@ -18,10 +49,10 @@ impl FoldingSchedule {
     // Constructors
     // -------------------------------------------------------------------------------------------
 
-    pub fn new_constant(factor: u8, remainder_max_degree: u8) -> Self {
+    pub fn new_constant(fri_folding_factor: u8, fri_remainder_max_degree: u8) -> Self {
         FoldingSchedule::Constant {
-            factor,
-            remainder_max_degree,
+            fri_folding_factor,
+            fri_remainder_max_degree,
         }
     }
 
@@ -34,7 +65,9 @@ impl FoldingSchedule {
 
     pub fn get_factor(&self) -> Option<u8> {
         match self {
-            FoldingSchedule::Constant { factor, .. } => Some(*factor),
+            FoldingSchedule::Constant {
+                fri_folding_factor, ..
+            } => Some(*fri_folding_factor),
             FoldingSchedule::Dynamic { schedule: _ } => None,
         }
     }
@@ -49,9 +82,9 @@ impl FoldingSchedule {
     pub fn get_max_remainder_degree(&self) -> Option<u8> {
         match self {
             FoldingSchedule::Constant {
-                remainder_max_degree,
+                fri_remainder_max_degree,
                 ..
-            } => Some(*remainder_max_degree),
+            } => Some(*fri_remainder_max_degree),
             FoldingSchedule::Dynamic { schedule: _ } => None,
         }
     }
@@ -74,6 +107,55 @@ impl FoldingSchedule {
         match self {
             FoldingSchedule::Dynamic { schedule, .. } => Some(schedule.len()),
             _ => None,
+        }
+    }
+}
+
+// FRI SCHEDULE IMPLEMENTATION
+// ================================================================================================
+
+impl Serializable for FoldingSchedule {
+    // Serializes `FoldingSchedule` and writes the resulting bytes into the `target`.
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            FoldingSchedule::Constant {
+                fri_folding_factor,
+                fri_remainder_max_degree,
+            } => {
+                target.write_u8(1);
+                target.write_u8(*fri_folding_factor);
+                target.write_u8(*fri_remainder_max_degree);
+            }
+            FoldingSchedule::Dynamic { schedule } => {
+                target.write_u8(2);
+                target.write_u8(schedule.len() as u8);
+                for factor in schedule {
+                    target.write_u8(*factor);
+                }
+            }
+        }
+    }
+}
+
+impl Deserializable for FoldingSchedule {
+    // Reads a `FoldingSchedule` from the specified `source`.
+    fn read_from<W: ByteReader>(source: &mut W) -> Result<Self, DeserializationError> {
+        match source.read_u8()? {
+            1 => Ok(FoldingSchedule::Constant {
+                fri_folding_factor: source.read_u8()?,
+                fri_remainder_max_degree: source.read_u8()?,
+            }),
+            2 => {
+                let len = source.read_u8()?;
+                let mut schedule = Vec::with_capacity(len as usize);
+                for _ in 0..len {
+                    schedule.push(source.read_u8()?);
+                }
+                Ok(FoldingSchedule::Dynamic { schedule })
+            }
+            value => Err(DeserializationError::InvalidValue(format!(
+                "value {value} cannot be deserialized as FoldingSchedule enum"
+            ))),
         }
     }
 }

--- a/fri/src/fri_schedule.rs
+++ b/fri/src/fri_schedule.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FoldingSchedule {
+    Constant {
+        factor: u8,
+        remainder_max_degree: u8,
+    },
+    Dynamic {
+        schedule: Vec<u8>,
+    },
+}
+
+impl FoldingSchedule {
+    // Constructors
+    // -------------------------------------------------------------------------------------------
+
+    pub fn new_constant(factor: u8, remainder_max_degree: u8) -> Self {
+        FoldingSchedule::Constant {
+            factor,
+            remainder_max_degree,
+        }
+    }
+
+    pub fn new_dynamic(schedule: Vec<u8>) -> Self {
+        FoldingSchedule::Dynamic { schedule }
+    }
+
+    // Accessors
+    // -------------------------------------------------------------------------------------------
+
+    pub fn get_factor(&self) -> Option<u8> {
+        match self {
+            FoldingSchedule::Constant { factor, .. } => Some(*factor),
+            FoldingSchedule::Dynamic { schedule: _ } => None,
+        }
+    }
+
+    pub fn get_schedule(&self) -> Option<&[u8]> {
+        match self {
+            FoldingSchedule::Constant { .. } => None,
+            FoldingSchedule::Dynamic { schedule } => Some(schedule),
+        }
+    }
+
+    pub fn get_max_remainder_degree(&self) -> Option<u8> {
+        match self {
+            FoldingSchedule::Constant {
+                remainder_max_degree,
+                ..
+            } => Some(*remainder_max_degree),
+            FoldingSchedule::Dynamic { schedule: _ } => None,
+        }
+    }
+
+    // Utility methods
+    // -------------------------------------------------------------------------------------------
+
+    /// Returns true if the schedule is constant, false otherwise.
+    pub fn is_constant(&self) -> bool {
+        matches!(self, FoldingSchedule::Constant { .. })
+    }
+
+    /// Returns true if the schedule is dynamic, false otherwise.
+    pub fn is_dynamic(&self) -> bool {
+        matches!(self, FoldingSchedule::Dynamic { .. })
+    }
+
+    /// Returns the number of layers in the schedule if the schedule is dynamic, None otherwise.
+    pub fn len_schedule(&self) -> Option<usize> {
+        match self {
+            FoldingSchedule::Dynamic { schedule, .. } => Some(schedule.len()),
+            _ => None,
+        }
+    }
+}

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -69,6 +69,7 @@ extern crate alloc;
 
 pub mod folding;
 
+pub mod fri_schedule;
 mod prover;
 pub use prover::{DefaultProverChannel, FriProver, ProverChannel};
 

--- a/fri/src/options.rs
+++ b/fri/src/options.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use crate::fri_schedule::FoldingSchedule;
 use math::StarkField;
 
 // FRI OPTIONS
@@ -11,8 +12,7 @@ use math::StarkField;
 /// FRI protocol config options for proof generation and verification.
 #[derive(Clone, PartialEq, Eq)]
 pub struct FriOptions {
-    folding_factor: usize,
-    remainder_max_degree: usize,
+    folding_schedule: FoldingSchedule,
     blowup_factor: usize,
 }
 
@@ -23,22 +23,37 @@ impl FriOptions {
     /// Panics if:
     /// - `blowup_factor` is not a power of two.
     /// - `folding_factor` is not 2, 4, 8, or 16.
-    pub fn new(blowup_factor: usize, folding_factor: usize, remainder_max_degree: usize) -> Self {
+    pub fn new(blowup_factor: usize, folding_schedule: FoldingSchedule) -> Self {
         // TODO: change panics to errors
         assert!(
             blowup_factor.is_power_of_two(),
             "blowup factor must be a power of two, but was {blowup_factor}"
         );
-        assert!(
-            folding_factor == 2
-                || folding_factor == 4
-                || folding_factor == 8
-                || folding_factor == 16,
-            "folding factor {folding_factor} is not supported"
-        );
+
+        match &folding_schedule {
+            FoldingSchedule::Constant {
+                fri_folding_factor,
+                fri_remainder_max_degree: _,
+            } => {
+                assert!(
+                    *fri_folding_factor == 2
+                        || *fri_folding_factor == 4
+                        || *fri_folding_factor == 8
+                        || *fri_folding_factor == 16,
+                    "folding factor {fri_folding_factor} is not supported"
+                );
+            }
+            FoldingSchedule::Dynamic { schedule } => {
+                assert!(
+                    schedule.iter().all(|factor| factor.is_power_of_two()),
+                    "FRI folding factors must be powers of 2"
+                );
+                assert!(schedule.len() > 0, "FRI folding schedule cannot be empty");
+            }
+        }
+
         FriOptions {
-            folding_factor,
-            remainder_max_degree,
+            folding_schedule,
             blowup_factor,
         }
     }
@@ -57,16 +72,18 @@ impl FriOptions {
     ///
     /// In combination with `remainder_max_degree_plus_1` this property defines how many FRI layers are
     /// needed for an evaluation domain of a given size.
-    pub fn folding_factor(&self) -> usize {
-        self.folding_factor
+    pub fn folding_factor(&self) -> Option<usize> {
+        self.folding_schedule
+            .get_factor()
+            .map(|factor| factor as usize)
     }
 
     /// Returns maximum allowed remainder polynomial degree.
     ///
     /// In combination with `folding_factor` this property defines how many FRI layers are needed
     /// for an evaluation domain of a given size.
-    pub fn remainder_max_degree(&self) -> usize {
-        self.remainder_max_degree
+    pub fn remainder_max_degree(&self) -> Option<usize> {
+        self.remainder_max_degree().map(|d| d as usize)
     }
 
     /// Returns a blowup factor of the evaluation domain.
@@ -78,17 +95,36 @@ impl FriOptions {
         self.blowup_factor
     }
 
-    /// Computes and return the number of FRI layers required for a domain of the specified size.
+    pub fn get_schedule(&self) -> &FoldingSchedule {
+        &self.folding_schedule
+    }
+
+    /// Computes and returns the number of FRI layers required for a domain of the specified size.
     ///
-    /// The number of layers for a given domain size is defined by the `folding_factor` and
-    /// `remainder_max_degree` and `blowup_factor` settings.
+    /// The number of layers for a given domain size is determined based on the folding schedule:
+    /// - For a `Constant` schedule, the number of layers is defined by the `fri_folding_factor`,
+    ///   `fri_remainder_max_degree`, and `blowup_factor` settings.
+    /// - For a `Dynamic` schedule, it's simply the length of the custom folding schedule.
+    ///
+    /// Note that for a `Constant` schedule, the domain size is progressively reduced by the folding
+    /// factor until it is less than or equal to the threshold defined by
+    /// `(fri_remainder_max_degree + 1) * blowup_factor`.
     pub fn num_fri_layers(&self, mut domain_size: usize) -> usize {
-        let mut result = 0;
-        let max_remainder_size = (self.remainder_max_degree + 1) * self.blowup_factor;
-        while domain_size > max_remainder_size {
-            domain_size /= self.folding_factor;
-            result += 1;
+        match self.get_schedule() {
+            FoldingSchedule::Constant {
+                fri_folding_factor,
+                fri_remainder_max_degree,
+            } => {
+                let mut result = 0;
+                let max_remainder_size =
+                    (*fri_remainder_max_degree as usize + 1) * self.blowup_factor();
+                while domain_size > max_remainder_size {
+                    domain_size /= *fri_folding_factor as usize;
+                    result += 1;
+                }
+                return result;
+            }
+            FoldingSchedule::Dynamic { schedule } => schedule.len(),
         }
-        result
     }
 }

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -5,6 +5,7 @@
 
 use super::{DefaultProverChannel, FriProver};
 use crate::{
+    fri_schedule::FoldingSchedule,
     verifier::{DefaultVerifierChannel, FriVerifier},
     FriOptions, FriProof, VerifierError,
 };
@@ -23,12 +24,8 @@ fn fri_folding_2() {
     let lde_blowup_e = 3;
     let folding_factor_e = 1;
     let max_remainder_degree = 7;
-    fri_prove_verify(
-        trace_length_e,
-        lde_blowup_e,
-        folding_factor_e,
-        max_remainder_degree,
-    )
+    let folding_schedule = FoldingSchedule::new_constant(folding_factor_e, max_remainder_degree);
+    fri_prove_verify(trace_length_e, lde_blowup_e, folding_schedule)
 }
 
 #[test]
@@ -37,12 +34,8 @@ fn fri_folding_4() {
     let lde_blowup_e = 3;
     let folding_factor_e = 2;
     let max_remainder_degree = 255;
-    fri_prove_verify(
-        trace_length_e,
-        lde_blowup_e,
-        folding_factor_e,
-        max_remainder_degree,
-    )
+    let folding_schedule = FoldingSchedule::new_constant(folding_factor_e, max_remainder_degree);
+    fri_prove_verify(trace_length_e, lde_blowup_e, folding_schedule)
 }
 
 // TEST UTILS
@@ -101,17 +94,12 @@ pub fn verify_proof(
     verifier.verify(&mut channel, &queried_evaluations, positions)
 }
 
-fn fri_prove_verify(
-    trace_length_e: usize,
-    lde_blowup_e: usize,
-    folding_factor_e: usize,
-    max_remainder_degree: usize,
-) {
+fn fri_prove_verify(trace_length_e: usize, lde_blowup_e: usize, folding_schedule: FoldingSchedule) {
     let trace_length = 1 << trace_length_e;
     let lde_blowup = 1 << lde_blowup_e;
-    let folding_factor = 1 << folding_factor_e;
+    // let folding_factor = 1 << folding_factor_e;
 
-    let options = FriOptions::new(lde_blowup, folding_factor, max_remainder_degree);
+    let options = FriOptions::new(lde_blowup, folding_schedule);
     let mut channel = build_prover_channel(trace_length, &options);
     let evaluations = build_evaluations(trace_length, lde_blowup);
 

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -5,7 +5,12 @@
 
 //! Contains an implementation of FRI verifier and associated components.
 
-use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierError};
+use crate::{
+    folding::{self, fold_positions},
+    fri_schedule::FoldingSchedule,
+    utils::map_positions_to_indexes,
+    FriOptions, VerifierError,
+};
 use core::{convert::TryInto, marker::PhantomData, mem};
 use crypto::{ElementHasher, RandomCoin};
 use math::{polynom, FieldElement, StarkField};
@@ -115,23 +120,45 @@ where
         let layer_commitments = channel.read_fri_layer_commitments();
         let mut layer_alphas = Vec::with_capacity(layer_commitments.len());
         let mut max_degree_plus_1 = max_poly_degree + 1;
+        let num_layers = layer_commitments.len();
+
         for (depth, commitment) in layer_commitments.iter().enumerate() {
             public_coin.reseed(*commitment);
             let alpha = public_coin.draw().map_err(VerifierError::RandomCoinError)?;
             layer_alphas.push(alpha);
 
-            // make sure the degree can be reduced by the folding factor at all layers
-            // but the remainder layer
-            if depth != layer_commitments.len() - 1
-                && max_degree_plus_1 % options.folding_factor() != 0
-            {
-                return Err(VerifierError::DegreeTruncation(
-                    max_degree_plus_1 - 1,
-                    options.folding_factor(),
-                    depth,
-                ));
+            match options.get_schedule() {
+                FoldingSchedule::Constant {
+                    fri_folding_factor,
+                    fri_remainder_max_degree: _,
+                } => {
+                    // make sure the degree can be reduced by the folding factor at all layers
+                    // but the remainder layer
+                    if depth != num_layers - 1
+                        && max_degree_plus_1 % *fri_folding_factor as usize != 0
+                    {
+                        return Err(VerifierError::DegreeTruncation(
+                            max_degree_plus_1 - 1,
+                            *fri_folding_factor as usize,
+                            depth,
+                        ));
+                    }
+                    max_degree_plus_1 /= *fri_folding_factor as usize;
+                }
+                FoldingSchedule::Dynamic { schedule } => {
+                    // make sure the degree can be reduced by the folding factor at all layers
+                    // but the remainder layer
+                    if depth != num_layers - 1 && max_degree_plus_1 % schedule[depth] as usize != 0
+                    {
+                        return Err(VerifierError::DegreeTruncation(
+                            max_degree_plus_1 - 1,
+                            schedule[depth] as usize,
+                            depth,
+                        ));
+                    }
+                    max_degree_plus_1 /= schedule[depth] as usize;
+                }
             }
-            max_degree_plus_1 /= options.folding_factor();
         }
 
         Ok(FriVerifier {
@@ -214,26 +241,268 @@ where
             ));
         }
 
-        // static dispatch for folding factor parameter
-        let folding_factor = self.options.folding_factor();
-        match folding_factor {
-            2 => self.verify_generic::<2>(channel, evaluations, positions),
-            4 => self.verify_generic::<4>(channel, evaluations, positions),
-            8 => self.verify_generic::<8>(channel, evaluations, positions),
-            16 => self.verify_generic::<16>(channel, evaluations, positions),
-            _ => Err(VerifierError::UnsupportedFoldingFactor(folding_factor)),
+        let mut domain_generator = self.domain_generator;
+        let mut domain_size = self.domain_size;
+        let mut max_degree_plus_1 = self.max_poly_degree + 1;
+        let mut positions = positions.to_vec();
+        let mut evaluations = evaluations.to_vec();
+
+        match self.options.get_schedule() {
+            FoldingSchedule::Constant {
+                fri_folding_factor,
+                fri_remainder_max_degree: _,
+            } => {
+                for depth in 0..self.options.num_fri_layers(self.domain_size) {
+                    let (next_evaluations, next_positions) = match fri_folding_factor {
+                        2 => self.verify_layer::<2>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        4 => self.verify_layer::<4>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        8 => self.verify_layer::<8>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        16 => self.verify_layer::<16>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        _ => {
+                            return Err(VerifierError::UnsupportedFoldingFactor(
+                                (*fri_folding_factor).into(),
+                            ))
+                        }
+                    };
+
+                    evaluations = next_evaluations;
+                    positions = next_positions;
+
+                    // Update the variables
+                    domain_generator =
+                        domain_generator.exp_vartime((*fri_folding_factor as u32).into());
+                    max_degree_plus_1 /= *fri_folding_factor as usize;
+                    domain_size /= *fri_folding_factor as usize;
+                }
+            }
+            FoldingSchedule::Dynamic { schedule } => {
+                for (depth, &factor) in schedule.iter().enumerate() {
+                    let (next_evaluations, next_positions) = match factor {
+                        2 => self.verify_layer::<2>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        4 => self.verify_layer::<4>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        8 => self.verify_layer::<8>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        16 => self.verify_layer::<16>(
+                            channel,
+                            &evaluations,
+                            &positions,
+                            depth,
+                            domain_generator,
+                            domain_size,
+                            max_degree_plus_1,
+                        )?,
+                        _ => return Err(VerifierError::UnsupportedFoldingFactor(factor.into())),
+                    };
+
+                    evaluations = next_evaluations;
+                    positions = next_positions;
+
+                    // Update the variables
+                    domain_generator = domain_generator.exp_vartime((factor as u32).into());
+                    max_degree_plus_1 /= factor as usize;
+                    domain_size /= factor as usize;
+                }
+            }
         }
+
+        self.verify_remainder(
+            channel,
+            &evaluations,
+            &positions,
+            max_degree_plus_1,
+            domain_generator,
+        )
     }
 
-    /// This is the actual implementation of the verification procedure described above, but it
-    /// also takes folding factor as a generic parameter N.
-    fn verify_generic<const N: usize>(
+    // /// This is the actual implementation of the verification procedure described above, but it
+    // /// also takes folding factor as a generic parameter N.
+    // fn verify_generic<const N: usize>(
+    //     &self,
+    //     channel: &mut C,
+    //     evaluations: &[E],
+    //     positions: &[usize],
+    // ) -> Result<(), VerifierError> {
+    //     // pre-compute roots of unity used in computing x coordinates in the folded domain
+    //     let folding_roots = (0..N)
+    //         .map(|i| {
+    //             self.domain_generator
+    //                 .exp_vartime(((self.domain_size / N * i) as u64).into())
+    //         })
+    //         .collect::<Vec<_>>();
+
+    //     // 1 ----- verify the recursive components of the FRI proof -----------------------------------
+    //     let mut domain_generator = self.domain_generator;
+    //     let mut domain_size = self.domain_size;
+    //     let mut max_degree_plus_1 = self.max_poly_degree + 1;
+    //     let mut positions = positions.to_vec();
+    //     let mut evaluations = evaluations.to_vec();
+
+    //     for depth in 0..self.options.num_fri_layers(self.domain_size) {
+    //         // determine which evaluations were queried in the folded layer
+    //         let mut folded_positions =
+    //             fold_positions(&positions, domain_size, self.options.folding_factor());
+    //         // determine where these evaluations are in the commitment Merkle tree
+    //         let position_indexes = map_positions_to_indexes(
+    //             &folded_positions,
+    //             domain_size,
+    //             self.options.folding_factor(),
+    //             self.num_partitions,
+    //         );
+    //         // read query values from the specified indexes in the Merkle tree
+    //         let layer_commitment = self.layer_commitments[depth];
+    //         // TODO: add layer depth to the potential error message
+    //         let layer_values = channel.read_layer_queries(&position_indexes, &layer_commitment)?;
+    //         let query_values =
+    //             get_query_values::<E, N>(&layer_values, &positions, &folded_positions, domain_size);
+    //         if evaluations != query_values {
+    //             return Err(VerifierError::InvalidLayerFolding(depth));
+    //         }
+
+    //         // build a set of x coordinates for each row polynomial
+    //         #[rustfmt::skip]
+    //         let xs = folded_positions.iter().map(|&i| {
+    //             let xe = domain_generator.exp_vartime((i as u64).into()) * self.options.domain_offset();
+    //             folding_roots.iter()
+    //                 .map(|&r| E::from(xe * r))
+    //                 .collect::<Vec<_>>().try_into().unwrap()
+    //         })
+    //         .collect::<Vec<_>>();
+
+    //         // interpolate x and y values into row polynomials
+    //         let row_polys = polynom::interpolate_batch(&xs, &layer_values);
+
+    //         // calculate the pseudo-random value used for linear combination in layer folding
+    //         let alpha = self.layer_alphas[depth];
+
+    //         // check that when the polynomials are evaluated at alpha, the result is equal to
+    //         // the corresponding column value
+    //         evaluations = row_polys.iter().map(|p| polynom::eval(p, alpha)).collect();
+
+    //         // make sure next degree reduction does not result in degree truncation
+    //         if max_degree_plus_1 % N != 0 {
+    //             return Err(VerifierError::DegreeTruncation(
+    //                 max_degree_plus_1 - 1,
+    //                 N,
+    //                 depth,
+    //             ));
+    //         }
+
+    //         // update variables for the next iteration of the loop
+    //         domain_generator = domain_generator.exp_vartime((N as u32).into());
+    //         max_degree_plus_1 /= N;
+    //         domain_size /= N;
+    //         mem::swap(&mut positions, &mut folded_positions);
+    //     }
+
+    //     // 2 ----- verify the remainder polynomial of the FRI proof -------------------------------
+
+    //     // read the remainder polynomial from the channel and make sure it agrees with the evaluations
+    //     // from the previous layer.
+    //     let remainder_poly = channel.read_remainder()?;
+    //     if remainder_poly.len() > max_degree_plus_1 {
+    //         return Err(VerifierError::RemainderDegreeMismatch(
+    //             max_degree_plus_1 - 1,
+    //         ));
+    //     }
+    //     let offset: E::BaseField = self.options().domain_offset();
+
+    //     for (&position, evaluation) in positions.iter().zip(evaluations) {
+    //         let comp_eval = eval_horner::<E>(
+    //             &remainder_poly,
+    //             offset * domain_generator.exp_vartime((position as u64).into()),
+    //         );
+    //         if comp_eval != evaluation {
+    //             return Err(VerifierError::InvalidRemainderFolding);
+    //         }
+    //     }
+
+    //     Ok(())
+    // }
+
+    fn verify_layer<const N: usize>(
         &self,
         channel: &mut C,
         evaluations: &[E],
         positions: &[usize],
-    ) -> Result<(), VerifierError> {
-        // pre-compute roots of unity used in computing x coordinates in the folded domain
+        depth: usize,
+        domain_generator: E::BaseField,
+        domain_size: usize,
+        max_degree_plus_1: usize,
+    ) -> Result<(Vec<E>, Vec<usize>), VerifierError> {
+        // 1. Determining which evaluations were queried in the folded layer.
+        let folded_positions = fold_positions(&positions, domain_size, N);
+
+        // 2. Finding these evaluations in the commitment Merkle tree.
+        let position_indexes =
+            map_positions_to_indexes(&folded_positions, domain_size, N, self.num_partitions);
+
+        // 3. Reading the query values from the specified indexes in the Merkle tree.
+        let layer_commitment = self.layer_commitments[depth];
+        let layer_values: Vec<[E; N]> =
+            channel.read_layer_queries(&position_indexes, &layer_commitment)?;
+        let query_values =
+            get_query_values(&layer_values, &positions, &folded_positions, domain_size);
+
+        if evaluations != query_values {
+            return Err(VerifierError::InvalidLayerFolding(depth));
+        }
+
+        // 4. Building x coordinates for each row polynomial.
         let folding_roots = (0..N)
             .map(|i| {
                 self.domain_generator
@@ -241,83 +510,57 @@ where
             })
             .collect::<Vec<_>>();
 
-        // 1 ----- verify the recursive components of the FRI proof -----------------------------------
-        let mut domain_generator = self.domain_generator;
-        let mut domain_size = self.domain_size;
-        let mut max_degree_plus_1 = self.max_poly_degree + 1;
-        let mut positions = positions.to_vec();
-        let mut evaluations = evaluations.to_vec();
-
-        for depth in 0..self.options.num_fri_layers(self.domain_size) {
-            // determine which evaluations were queried in the folded layer
-            let mut folded_positions =
-                fold_positions(&positions, domain_size, self.options.folding_factor());
-            // determine where these evaluations are in the commitment Merkle tree
-            let position_indexes = map_positions_to_indexes(
-                &folded_positions,
-                domain_size,
-                self.options.folding_factor(),
-                self.num_partitions,
-            );
-            // read query values from the specified indexes in the Merkle tree
-            let layer_commitment = self.layer_commitments[depth];
-            // TODO: add layer depth to the potential error message
-            let layer_values = channel.read_layer_queries(&position_indexes, &layer_commitment)?;
-            let query_values =
-                get_query_values::<E, N>(&layer_values, &positions, &folded_positions, domain_size);
-            if evaluations != query_values {
-                return Err(VerifierError::InvalidLayerFolding(depth));
-            }
-
-            // build a set of x coordinates for each row polynomial
-            #[rustfmt::skip]
-            let xs = folded_positions.iter().map(|&i| {
-                let xe = domain_generator.exp_vartime((i as u64).into()) * self.options.domain_offset();
-                folding_roots.iter()
+        let xs = folded_positions
+            .iter()
+            .map(|&i| {
+                let xe =
+                    domain_generator.exp_vartime((i as u64).into()) * self.options.domain_offset();
+                folding_roots
+                    .iter()
                     .map(|&r| E::from(xe * r))
-                    .collect::<Vec<_>>().try_into().unwrap()
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap()
             })
             .collect::<Vec<_>>();
 
-            // interpolate x and y values into row polynomials
-            let row_polys = polynom::interpolate_batch(&xs, &layer_values);
+        // 5. Interpolating x and y values into row polynomials.
+        let row_polys = polynom::interpolate_batch(&xs, &layer_values);
+        let alpha = self.layer_alphas[depth];
+        let next_evaluations = row_polys.iter().map(|p| polynom::eval(p, alpha)).collect();
 
-            // calculate the pseudo-random value used for linear combination in layer folding
-            let alpha = self.layer_alphas[depth];
-
-            // check that when the polynomials are evaluated at alpha, the result is equal to
-            // the corresponding column value
-            evaluations = row_polys.iter().map(|p| polynom::eval(p, alpha)).collect();
-
-            // make sure next degree reduction does not result in degree truncation
-            if max_degree_plus_1 % N != 0 {
-                return Err(VerifierError::DegreeTruncation(
-                    max_degree_plus_1 - 1,
-                    N,
-                    depth,
-                ));
-            }
-
-            // update variables for the next iteration of the loop
-            domain_generator = domain_generator.exp_vartime((N as u32).into());
-            max_degree_plus_1 /= N;
-            domain_size /= N;
-            mem::swap(&mut positions, &mut folded_positions);
+        if max_degree_plus_1 % N != 0 {
+            return Err(VerifierError::DegreeTruncation(
+                max_degree_plus_1 - 1,
+                N,
+                depth,
+            ));
         }
 
-        // 2 ----- verify the remainder polynomial of the FRI proof -------------------------------
+        Ok((next_evaluations, folded_positions))
+    }
 
+    fn verify_remainder(
+        &self,
+        channel: &mut C,
+        evaluations: &[E],
+        positions: &[usize],
+        max_degree_plus_1: usize,
+        domain_generator: E::BaseField,
+    ) -> Result<(), VerifierError> {
         // read the remainder polynomial from the channel and make sure it agrees with the evaluations
         // from the previous layer.
         let remainder_poly = channel.read_remainder()?;
+
         if remainder_poly.len() > max_degree_plus_1 {
             return Err(VerifierError::RemainderDegreeMismatch(
                 max_degree_plus_1 - 1,
             ));
         }
-        let offset: E::BaseField = self.options().domain_offset();
 
-        for (&position, evaluation) in positions.iter().zip(evaluations) {
+        let offset: E::BaseField = self.options.domain_offset();
+
+        for (&position, &evaluation) in positions.iter().zip(evaluations) {
             let comp_eval = eval_horner::<E>(
                 &remainder_poly,
                 offset * domain_generator.exp_vartime((position as u64).into()),


### PR DESCRIPTION
This PR introduces a significant enhancement to the FRI layer-building process, allowing users more flexibility and control over the folding process during proof generation. The core idea is to allow users to define a custom schedule, essentially a sequence of folding factors, that will be applied in subsequent FRI rounds. This dynamic approach can coexist with the traditional constant folding method and is abstracted away behind an enum `FoldingSchedule`.

1. **Introduction of Dynamic FRI Folding Schedules:**
     -  a custom `FoldingSchedule::Dynamic` could be defined with a vector of folding factors. These factors will be applied in the order provided during the FRI folding process.
     - The prover  supports both the traditional `FoldingSchedule::Constant` and the new dynamic schedule, ensuring backward compatibility.

2. **Streamlined FRI Layer Building:**
     -  Unified logic for handling both constant and dynamic schedules
     -  Update FriOptions struct, Fri prover to handle both the schedules
     -  Broke the monolithic `verify_generic` method into `verify_layer` which verify each fold and `verify_remainder` to handle the FRI remainder verification