### PR TITLE
Uniform randomization for field elements

### DIFF
--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -35,6 +35,7 @@ std = ["utils/std"]
 [dependencies]
 serde = { version = "1.0", features = [ "derive" ], optional = true, default-features = false }
 utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
+rand = { version = "0.8", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -15,9 +15,6 @@ use utils::{
     DeserializationError, Randomizable, Serializable, SliceReader,
 };
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 // QUADRATIC EXTENSION FIELD
 // ================================================================================================
 
@@ -28,7 +25,7 @@ use serde::{Deserialize, Serialize};
 /// field elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CubeExtension<B: ExtensibleField<3>>(B, B, B);
 
 impl<B: ExtensibleField<3>> CubeExtension<B> {

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -385,6 +385,22 @@ impl<B: ExtensibleField<3>> Deserializable for CubeExtension<B> {
     }
 }
 
+// RANDOMIZATION
+// ================================================================================================
+#[cfg(feature = "rand")]
+impl<B> rand::distributions::Distribution<CubeExtension<B>> for rand::distributions::Standard
+where
+    rand::distributions::Standard: rand::distributions::Distribution<B>,
+    B: ExtensibleField<3>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubeExtension<B> {
+        let a = rng.gen();
+        let b = rng.gen();
+        let c = rng.gen();
+        CubeExtension(a, b, c)
+    }
+}
+
 // TESTS
 // ================================================================================================
 

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -373,6 +373,21 @@ impl<B: ExtensibleField<2>> Deserializable for QuadExtension<B> {
     }
 }
 
+// RANDOMIZATION
+// ================================================================================================
+#[cfg(feature = "rand")]
+impl<B> rand::distributions::Distribution<QuadExtension<B>> for rand::distributions::Standard
+where
+    rand::distributions::Standard: rand::distributions::Distribution<B>,
+    B: ExtensibleField<2>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuadExtension<B> {
+        let a = rng.gen();
+        let b = rng.gen();
+        QuadExtension(a, b)
+    }
+}
+
 // TESTS
 // ================================================================================================
 

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -15,9 +15,6 @@ use utils::{
     DeserializationError, Randomizable, Serializable, SliceReader,
 };
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 // QUADRATIC EXTENSION FIELD
 // ================================================================================================
 
@@ -28,7 +25,7 @@ use serde::{Deserialize, Serialize};
 /// elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct QuadExtension<B: ExtensibleField<2>>(B, B);
 
 impl<B: ExtensibleField<2>> QuadExtension<B> {

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -25,9 +25,6 @@ use utils::{
     Serializable,
 };
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(test)]
 mod tests;
 
@@ -51,7 +48,7 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u128>();
 /// Internal values are stored in their canonical form in the range [0, M). The backing type is
 /// `u128`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BaseElement(u128);
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -626,3 +626,13 @@ const fn add64_with_carry(a: u64, b: u64, carry: u64) -> (u64, u64) {
     let ret = (a as u128) + (b as u128) + (carry as u128);
     (ret as u64, (ret >> 64) as u64)
 }
+
+// RANDOMIZATION
+// ================================================================================================
+#[cfg(feature = "rand")]
+impl rand::distributions::Distribution<BaseElement> for rand::distributions::Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BaseElement {
+        let value = rand::distributions::Uniform::new(0, M).sample(rng);
+        BaseElement::new(value)
+    }
+}

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -22,9 +22,6 @@ use utils::{
     DeserializationError, Randomizable, Serializable,
 };
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(test)]
 mod tests;
 
@@ -57,7 +54,7 @@ const G: u64 = 4421547261963328785;
 /// Internal values are stored in Montgomery representation and can be in the range [0; 2M). The
 /// backing type is `u64`.
 #[derive(Copy, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
 

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -630,3 +630,13 @@ fn normalize(value: u64) -> u64 {
         value
     }
 }
+
+// RANDOMIZATION
+// ================================================================================================
+#[cfg(feature = "rand")]
+impl rand::distributions::Distribution<BaseElement> for rand::distributions::Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BaseElement {
+        let value = rand::distributions::Uniform::new(0, M).sample(rng);
+        BaseElement::new(value)
+    }
+}

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -27,9 +27,6 @@ use utils::{
     DeserializationError, Randomizable, Serializable,
 };
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(test)]
 mod tests;
 
@@ -53,7 +50,7 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u64>();
 /// Internal values represent x * R mod M where R = 2^64 mod M and x in [0, M).
 /// The backing type is `u64` but the internal values are always in the range [0, M).
 #[derive(Copy, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -682,3 +682,13 @@ pub fn equals(lhs: u64, rhs: u64) -> u64 {
     let t = lhs ^ rhs;
     !((((t | t.wrapping_neg()) as i64) >> 63) as u64)
 }
+
+// RANDOMIZATION
+// ================================================================================================
+#[cfg(feature = "rand")]
+impl rand::distributions::Distribution<BaseElement> for rand::distributions::Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BaseElement {
+        let value = rand::distributions::Uniform::new(0, M).sample(rng);
+        BaseElement::new(value)
+    }
+}


### PR DESCRIPTION
This enables uniform randomization for field elements, taking in consideration the field modulus so that every element has equal probability.

When compiled with the feature `rand`, this enables the following:

```rust
let a: CubeExtension<BaseElement> = rand::thread_rng().gen(); // <-- use of `gen()`
let expected = a * a;
assert_eq!(expected, a.square());
```