### PR TITLE
Protocol proven security in no-std

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -22,6 +22,7 @@ std = ["crypto/std", "fri/std", "math/std", "utils/std"]
 [dependencies]
 crypto = { version = "0.6", path = "../crypto", package = "winter-crypto", default-features = false }
 fri = { version = "0.6", path = "../fri", package = "winter-fri", default-features = false }
+libm = "0.2.8"
 math = { version = "0.6", path = "../math", package = "winter-math", default-features = false }
 utils = { version = "0.6", path = "../utils/core", package = "winter-utils", default-features = false }
 


### PR DESCRIPTION
Addresses #183 
This solution relies on the `fixed` crate for fixed point arithmetic. It also uses an approximation for the `log(1 + x)` function as well as other upper/lower bounds. To compensate for the pessimistic bounds in the no-std version, some `-1` subtractions after `cmp::min` were removed. Surprisingly this lead to results which are closer to the results using infinite precision integers, at least in the cases that were tested.
Still the logic seems a bit over complicated and this means that there are probably some corner cases that were overlooked. 