### PR TITLE
Allow duplicate query positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added support for proven security estimation in `no_std` context (#218).
 * [BREAKING] refactored `verify()` function to take `AcceptableOptions` as a parameter (#219).
 * Increased min version of `rustc` to 1.73 (#221).
+* Allowed duplicate query positions (#224).
 
 ## 0.6.5 (2023-08-09) - math crate only
 * Added conditional support for serde on field elements (#209)

--- a/crypto/src/random/default.rs
+++ b/crypto/src/random/default.rs
@@ -153,12 +153,12 @@ impl<B: StarkField, H: ElementHasher<BaseField = B>> RandomCoin for DefaultRando
         Err(RandomCoinError::FailedToDrawFieldElement(1000))
     }
 
-    /// Returns a vector of unique integers selected from the range [0, domain_size) after reseeding
+    /// Returns a vector of integers selected from the range [0, domain_size) after reseeding
     /// the PRNG with the specified `nonce` by setting the new seed to hash(`seed` || `nonce`).
     ///
     /// # Errors
-    /// Returns an error if the specified number of unique integers could not be generated
-    /// after 1000 calls to the PRNG.
+    /// Returns an error if the specified number of integers could not be generated after 1000
+    /// calls to the PRNG.
     ///
     /// # Panics
     /// Panics if:
@@ -182,10 +182,8 @@ impl<B: StarkField, H: ElementHasher<BaseField = B>> RandomCoin for DefaultRando
     ///
     /// assert_eq!(num_values, values.len());
     ///
-    /// let mut value_set = HashSet::new();
     /// for value in values {
     ///     assert!(value < domain_size);
-    ///     assert!(value_set.insert(value));
     /// }
     /// ```
     fn draw_integers(
@@ -214,9 +212,6 @@ impl<B: StarkField, H: ElementHasher<BaseField = B>> RandomCoin for DefaultRando
             // into the specified domain
             let value = (u64::from_le_bytes(bytes) & v_mask) as usize;
 
-            if values.contains(&value) {
-                continue;
-            }
             values.push(value);
             if values.len() == num_values {
                 break;

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -47,12 +47,12 @@ pub trait RandomCoin: Sync {
     /// PRNG.
     fn draw<E: FieldElement<BaseField = Self::BaseField>>(&mut self) -> Result<E, RandomCoinError>;
 
-    /// Returns a vector of unique integers selected from the range [0, domain_size) after it reseeds
+    /// Returns a vector of integers selected from the range [0, domain_size) after it reseeds
     /// the coin with a nonce.
     ///
     /// # Errors
-    /// Returns an error if the specified number of unique integers could not be generated
-    /// after 1000 calls to the PRNG.
+    /// Returns an error if the specified number of integers could not be generated after 1000
+    /// calls to the PRNG.
     ///
     /// # Panics
     /// Panics if:

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -439,7 +439,7 @@ pub trait Prover {
         let query_positions = channel.get_query_positions();
         #[cfg(feature = "std")]
         debug!(
-            "Determined {} query positions in {} ms",
+            "Determined {} unique query positions in {} ms",
             query_positions.len(),
             now.elapsed().as_millis()
         );
@@ -461,7 +461,12 @@ pub trait Prover {
         let constraint_queries = constraint_commitment.query(&query_positions);
 
         // build the proof object
-        let proof = channel.build_proof(trace_queries, constraint_queries, fri_proof);
+        let proof = channel.build_proof(
+            trace_queries,
+            constraint_queries,
+            fri_proof,
+            query_positions.len(),
+        );
         #[cfg(feature = "std")]
         debug!("Built proof object in {} ms", now.elapsed().as_millis());
 

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -264,9 +264,14 @@ where
     // interactive version of the protocol, the verifier sends these query positions to the prover,
     // and the prover responds with decommitments against these positions for trace and constraint
     // composition polynomial evaluations.
-    let query_positions = public_coin
+    let mut query_positions = public_coin
         .draw_integers(air.options().num_queries(), air.lde_domain_size(), pow_nonce)
         .map_err(|_| VerifierError::RandomCoinError)?;
+
+    // remove any potential duplicates from the positions as the prover will send openings only
+    // for unique queries
+    query_positions.sort_unstable();
+    query_positions.dedup();
 
     // read evaluations of trace and constraint composition polynomials at the queried positions;
     // this also checks that the read values are valid against trace and constraint commitments


### PR DESCRIPTION
This PR is an alternative to #220 (and as such it also addresses #216). However, the approach taken here is de-duplicate query positions explicitly at the prover and the verifier, rather than doing it implicitly during Merkle path generation.