### PR TITLE
implement `Ord` for `BaseElement`

### DIFF
--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -50,7 +50,7 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u128>();
 ///
 /// Internal values are stored in their canonical form in the range [0, M). The backing type is
 /// `u128`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BaseElement(u128);

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -56,7 +56,7 @@ const G: u64 = 4421547261963328785;
 ///
 /// Internal values are stored in Montgomery representation and can be in the range [0; 2M). The
 /// backing type is `u64`.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
@@ -250,8 +250,6 @@ impl PartialEq for BaseElement {
         normalize(self.0) == normalize(other.0)
     }
 }
-
-impl Eq for BaseElement {}
 
 // OVERLOADED OPERATORS
 // ================================================================================================

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -52,7 +52,7 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u64>();
 ///
 /// Internal values represent x * R mod M where R = 2^64 mod M and x in [0, M).
 /// The backing type is `u64` but the internal values are always in the range [0, M).
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
@@ -311,8 +311,6 @@ impl PartialEq for BaseElement {
         equals(self.0, other.0) == 0xFFFFFFFFFFFFFFFF
     }
 }
-
-impl Eq for BaseElement {}
 
 // OVERLOADED OPERATORS
 // ================================================================================================


### PR DESCRIPTION
Implements `Ord` for all `BaseElement`s. One benefit is that they can be used as the key to a `BTreeMap` (or any other data structure that requires ordering).