### PR TITLE
change `Debug` format for fields

### DIFF
--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -50,7 +50,7 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u128>();
 ///
 /// Internal values are stored in their canonical form in the range [0, M). The backing type is
 /// `u128`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BaseElement(u128);
@@ -193,6 +193,12 @@ impl Randomizable for BaseElement {
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
         Self::try_from(bytes).ok()
+    }
+}
+
+impl Debug for BaseElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -56,7 +56,7 @@ const G: u64 = 4421547261963328785;
 ///
 /// Internal values are stored in Montgomery representation and can be in the range [0; 2M). The
 /// backing type is `u64`.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
@@ -230,6 +230,12 @@ impl Randomizable for BaseElement {
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
         Self::try_from(bytes).ok()
+    }
+}
+
+impl Debug for BaseElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -52,7 +52,7 @@ const ELEMENT_BYTES: usize = core::mem::size_of::<u64>();
 ///
 /// Internal values represent x * R mod M where R = 2^64 mod M and x in [0, M).
 /// The backing type is `u64` but the internal values are always in the range [0, M).
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct BaseElement(u64);
@@ -293,6 +293,12 @@ impl Randomizable for BaseElement {
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
         Self::try_from(bytes).ok()
+    }
+}
+
+impl Debug for BaseElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
Implements `Debug` by hand for the base fields such that it outputs a human-readable integer.

The current behavior makes the fields unintuitive when debugging `Vec<BaseElement>`. Specifically, `Vec` doesn't implement `Display`, so we're forced to use the `Debug` output:

```rust
let v: Vec<BaseElement> = vec![BaseElement::from(1u64)];

println!("{v:?}");

// current output: [ BaseElement(<Montgomery form of 1>) ]
// new output: [ 1 ]
```

I believe most users will be confused by the current output, and would expect to read an integer (as I was).