### PR TITLE
Stark proof serializable deserializable

### DIFF
--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -272,10 +272,18 @@ impl FieldExtension {
     }
 }
 
+// SERIALIZATION
+// ================================================================================================
+
 impl Serializable for FieldExtension {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u8(*self as u8);
+    }
+
+    /// Returns an estimate of how many bytes are needed to represent self.
+    fn get_size_hint(&self) -> usize {
+        1
     }
 }
 

--- a/air/src/proof/commitments.rs
+++ b/air/src/proof/commitments.rs
@@ -86,12 +86,20 @@ impl Commitments {
     }
 }
 
+// SERIALIZATION
+// ================================================================================================
+
 impl Serializable for Commitments {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         assert!(self.0.len() < u16::MAX as usize);
         target.write_u16(self.0.len() as u16);
         target.write_bytes(&self.0);
+    }
+
+    /// Returns an estimate of how many bytes are needed to represent self.
+    fn get_size_hint(&self) -> usize {
+        self.0.len() + 2
     }
 }
 

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -132,6 +132,9 @@ impl<E: StarkField> ToElements<E> for Context {
     }
 }
 
+// SERIALIZATION
+// ================================================================================================
+
 impl Serializable for Context {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {

--- a/air/src/proof/ood_frame.rs
+++ b/air/src/proof/ood_frame.rs
@@ -119,6 +119,9 @@ impl OodFrame {
     }
 }
 
+// SERIALIZATION
+// ================================================================================================
+
 impl Serializable for OodFrame {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -129,6 +132,11 @@ impl Serializable for OodFrame {
         // write constraint evaluations row
         target.write_u16(self.evaluations.len() as u16);
         target.write_bytes(&self.evaluations)
+    }
+
+    /// Returns an estimate of how many bytes are needed to represent self.
+    fn get_size_hint(&self) -> usize {
+        self.trace_states.len() + self.evaluations.len() + 4
     }
 }
 

--- a/air/src/proof/queries.rs
+++ b/air/src/proof/queries.rs
@@ -128,6 +128,9 @@ impl Queries {
     }
 }
 
+// SERIALIZATION
+// ================================================================================================
+
 impl Serializable for Queries {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -138,6 +141,11 @@ impl Serializable for Queries {
         // write path bytes
         target.write_u32(self.paths.len() as u32);
         target.write_bytes(&self.paths);
+    }
+
+    /// Returns an estimate of how many bytes are needed to represent self.
+    fn get_size_hint(&self) -> usize {
+        self.paths.len() + self.values.len() + 8
     }
 }
 

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -53,6 +53,54 @@ impl Serializable for () {
     fn write_into<W: ByteWriter>(&self, _target: &mut W) {}
 }
 
+impl Serializable for u8 {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u8(*self);
+    }
+}
+
+impl Serializable for u16 {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u16(*self);
+    }
+}
+
+impl Serializable for u32 {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u32(*self);
+    }
+}
+
+impl Serializable for u64 {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u64(*self);
+    }
+}
+
+impl<T: Serializable> Serializable for Option<T> {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            Some(v) => {
+                target.write_bool(true);
+                v.write_into(target);
+            }
+            None => target.write_bool(false),
+        }
+    }
+}
+
+impl<T: Serializable> Serializable for &Option<T> {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            Some(v) => {
+                target.write_bool(true);
+                v.write_into(target);
+            }
+            None => target.write_bool(false),
+        }
+    }
+}
+
 impl<T: Serializable> Serializable for Vec<T> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         T::write_batch_into(self, target);


### PR DESCRIPTION
- adds size hints to some serializations
- implement serialization and deserialization traits for StarkProof (using existing code)
- add blanket implementation for integers and option type