### PR TITLE
serde: add default deserializers implementations

### DIFF
--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -197,3 +197,44 @@ pub trait Deserializable: Sized {
         Ok(result)
     }
 }
+
+impl Deserializable for () {
+    fn read_from<R: ByteReader>(_source: &mut R) -> Result<Self, DeserializationError> {
+        Ok(())
+    }
+}
+
+impl Deserializable for u8 {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u8()
+    }
+}
+
+impl Deserializable for u16 {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u16()
+    }
+}
+
+impl Deserializable for u32 {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u32()
+    }
+}
+
+impl Deserializable for u64 {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u64()
+    }
+}
+
+impl<T: Deserializable> Deserializable for Option<T> {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let contains = source.read_bool()?;
+
+        match contains {
+            true => Ok(Some(T::read_from(source)?)),
+            false => Ok(None),
+        }
+    }
+}

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -53,6 +53,90 @@ impl Serializable for () {
     fn write_into<W: ByteWriter>(&self, _target: &mut W) {}
 }
 
+impl<T1> Serializable for (T1,)
+where
+    T1: Serializable,
+{
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+    }
+}
+
+impl<T1, T2> Serializable for (T1, T2)
+where
+    T1: Serializable,
+    T2: Serializable,
+{
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+        self.1.write_into(target);
+    }
+}
+
+impl<T1, T2, T3> Serializable for (T1, T2, T3)
+where
+    T1: Serializable,
+    T2: Serializable,
+    T3: Serializable,
+{
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+        self.1.write_into(target);
+        self.2.write_into(target);
+    }
+}
+
+impl<T1, T2, T3, T4> Serializable for (T1, T2, T3, T4)
+where
+    T1: Serializable,
+    T2: Serializable,
+    T3: Serializable,
+    T4: Serializable,
+{
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+        self.1.write_into(target);
+        self.2.write_into(target);
+        self.3.write_into(target);
+    }
+}
+
+impl<T1, T2, T3, T4, T5> Serializable for (T1, T2, T3, T4, T5)
+where
+    T1: Serializable,
+    T2: Serializable,
+    T3: Serializable,
+    T4: Serializable,
+    T5: Serializable,
+{
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+        self.1.write_into(target);
+        self.2.write_into(target);
+        self.3.write_into(target);
+        self.4.write_into(target);
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> Serializable for (T1, T2, T3, T4, T5, T6)
+where
+    T1: Serializable,
+    T2: Serializable,
+    T3: Serializable,
+    T4: Serializable,
+    T5: Serializable,
+    T6: Serializable,
+{
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+        self.1.write_into(target);
+        self.2.write_into(target);
+        self.3.write_into(target);
+        self.4.write_into(target);
+        self.5.write_into(target);
+    }
+}
+
 impl Serializable for u8 {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u8(*self);
@@ -214,6 +298,96 @@ pub trait Deserializable: Sized {
 impl Deserializable for () {
     fn read_from<R: ByteReader>(_source: &mut R) -> Result<Self, DeserializationError> {
         Ok(())
+    }
+}
+
+impl<T1> Deserializable for (T1,)
+where
+    T1: Deserializable,
+{
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = T1::read_from(source)?;
+        Ok((v1,))
+    }
+}
+
+impl<T1, T2> Deserializable for (T1, T2)
+where
+    T1: Deserializable,
+    T2: Deserializable,
+{
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = T1::read_from(source)?;
+        let v2 = T2::read_from(source)?;
+        Ok((v1, v2))
+    }
+}
+
+impl<T1, T2, T3> Deserializable for (T1, T2, T3)
+where
+    T1: Deserializable,
+    T2: Deserializable,
+    T3: Deserializable,
+{
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = T1::read_from(source)?;
+        let v2 = T2::read_from(source)?;
+        let v3 = T3::read_from(source)?;
+        Ok((v1, v2, v3))
+    }
+}
+
+impl<T1, T2, T3, T4> Deserializable for (T1, T2, T3, T4)
+where
+    T1: Deserializable,
+    T2: Deserializable,
+    T3: Deserializable,
+    T4: Deserializable,
+{
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = T1::read_from(source)?;
+        let v2 = T2::read_from(source)?;
+        let v3 = T3::read_from(source)?;
+        let v4 = T4::read_from(source)?;
+        Ok((v1, v2, v3, v4))
+    }
+}
+
+impl<T1, T2, T3, T4, T5> Deserializable for (T1, T2, T3, T4, T5)
+where
+    T1: Deserializable,
+    T2: Deserializable,
+    T3: Deserializable,
+    T4: Deserializable,
+    T5: Deserializable,
+{
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = T1::read_from(source)?;
+        let v2 = T2::read_from(source)?;
+        let v3 = T3::read_from(source)?;
+        let v4 = T4::read_from(source)?;
+        let v5 = T5::read_from(source)?;
+        Ok((v1, v2, v3, v4, v5))
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> Deserializable for (T1, T2, T3, T4, T5, T6)
+where
+    T1: Deserializable,
+    T2: Deserializable,
+    T3: Deserializable,
+    T4: Deserializable,
+    T5: Deserializable,
+    T6: Deserializable,
+{
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let v1 = T1::read_from(source)?;
+        let v2 = T2::read_from(source)?;
+        let v3 = T3::read_from(source)?;
+        let v4 = T4::read_from(source)?;
+        let v5 = T5::read_from(source)?;
+        let v6 = T6::read_from(source)?;
+        Ok((v1, v2, v3, v4, v5, v6))
     }
 }
 


### PR DESCRIPTION
The `Deserializer` trait does not have an associated type, all methods return `Self`. That means it is not possible to have a blanket implementation for slices `&[T]`, because the signature is required to be `fn read_from<R: ByteReader>(source: &mut R) -> Result<&[T], DeserializationError>;`. I can't add a associated type without making a breaking change because default associated types are unstable https://github.com/rust-lang/rfcs/blob/master/text/2532-associated-type-defaults.md. I also can't define a blanket implementation for `Vec<T>` because the default serializer does not include the length of the vector.

edit: also note:

- the serializer doesn't return errors, if one decides to encode an `usize` into `u8` there is nothing to do besides panicking, this could be an attack vector.
- the `write_batch_into` is the same as the vec implementation, should probably be removed since it doesn't have a clear receiver and there is equivalent functionality 