### PR TITLE
Fix `StarkProof::new_dummy()`

### DIFF
--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -9,6 +9,7 @@ use crate::{ProofOptions, TraceInfo, TraceLayout};
 use core::cmp;
 use crypto::Hasher;
 use fri::FriProof;
+use math::FieldElement;
 use utils::{
     collections::Vec, ByteReader, Deserializable, DeserializationError, Serializable, SliceReader,
 };
@@ -152,8 +153,8 @@ impl StarkProof {
 
         Self {
             context: Context::new::<DummyField>(
-                &TraceInfo::new(0, 0),
-                ProofOptions::new(0, 0, 0, FieldExtension::None, 0, 0),
+                &TraceInfo::new(1, 8),
+                ProofOptions::new(1, 2, 2, FieldExtension::None, 8, 1),
             ),
             num_unique_queries: 0,
             commitments: Commitments::default(),
@@ -164,7 +165,7 @@ impl StarkProof {
                     nodes: Vec::new(),
                     depth: 0,
                 },
-                Vec::new(),
+                vec![vec![DummyField::ONE]],
             ),
             ood_frame: OodFrame::default(),
             fri_proof: FriProof::new_dummy(),

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -28,6 +28,9 @@ pub use ood_frame::OodFrame;
 mod table;
 pub use table::Table;
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTS
 // ================================================================================================
 

--- a/air/src/proof/tests.rs
+++ b/air/src/proof/tests.rs
@@ -1,0 +1,6 @@
+use super::StarkProof;
+
+#[test]
+pub fn starkproof_new_dummy_works() {
+    let _ = StarkProof::new_dummy();
+}

--- a/air/src/proof/tests.rs
+++ b/air/src/proof/tests.rs
@@ -1,6 +1,6 @@
 use super::StarkProof;
 
 #[test]
-pub fn starkproof_new_dummy_works() {
+pub fn starkproof_new_dummy_doesnt_panic() {
     let _ = StarkProof::new_dummy();
 }


### PR DESCRIPTION
`StarkProof::new_dummy()` no longer panics.