### PR TITLE
Adding copyright header to tests file

### DIFF
--- a/air/src/proof/tests.rs
+++ b/air/src/proof/tests.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 use super::StarkProof;
 
 #[test]


### PR DESCRIPTION
Just adding a missing copyright header to the new file introduced in https://github.com/facebook/winterfell/pull/234