### PR TITLE
bugfix: StarkProof is not always the last element in a serialization buffer

### DIFF
--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -211,9 +211,6 @@ impl Deserializable for StarkProof {
             fri_proof: FriProof::read_from(source)?,
             pow_nonce: source.read_u64()?,
         };
-        if source.has_more_bytes() {
-            return Err(DeserializationError::UnconsumedBytes);
-        }
         Ok(proof)
     }
 }


### PR DESCRIPTION
This prevents other data structure to be serialized in the same buffer, which happen naturally for structs with additional field elements.