### PR TITLE
Implement serialization and deserialization for `usize` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.5 (2023-12-21) - `utils/core` crate only
+* Added variable-length serialization and deserialization for `usize` type (#238).
+
 ## 0.7.4 (2023-12-18) - `air` crate only
 * Fixed a bug in `StarkProof` deserialization (#236).
 

--- a/utils/core/Cargo.toml
+++ b/utils/core/Cargo.toml
@@ -22,3 +22,6 @@ std = []
 
 [dependencies]
 rayon = { version = "1.8", optional = true }
+
+[dev-dependencies]
+proptest = "1.3"

--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -62,6 +62,24 @@ pub trait ByteWriter: Sized {
         self.write_bytes(&value.to_le_bytes());
     }
 
+    /// Writes a usize value in [vint64](https://docs.rs/vint64/latest/vint64/) format into `self`.
+    ///
+    /// # Panics
+    /// Panics if the value could not be written into `self`.
+    fn write_usize(&mut self, value: usize) {
+        let length = encoded_len(value);
+
+        // 9-byte special case
+        if length == 9 {
+            // length byte is zero in this case
+            self.write_u8(0);
+            self.write(value.to_le_bytes());
+        } else {
+            let encoded_bytes = ((value << 1 | 1) << (length - 1)).to_le_bytes();
+            self.write_bytes(&encoded_bytes[..length]);
+        }
+    }
+
     /// Writes a serializable value into `self`.
     ///
     /// # Panics
@@ -82,4 +100,14 @@ impl ByteWriter for Vec<u8> {
     fn write_bytes(&mut self, values: &[u8]) {
         self.extend_from_slice(values);
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns the length of the value in vint64 enсoding.
+pub fn encoded_len(value: usize) -> usize {
+    let zeros = value.leading_zeros() as usize;
+    let len = zeros.saturating_sub(1) / 7;
+    9 - core::cmp::min(len, 8)
 }

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -161,6 +161,12 @@ impl Serializable for u64 {
     }
 }
 
+impl Serializable for usize {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_usize(*self)
+    }
+}
+
 impl<T: Serializable> Serializable for Option<T> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         match self {
@@ -384,6 +390,12 @@ impl Deserializable for u32 {
 impl Deserializable for u64 {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         source.read_u64()
+    }
+}
+
+impl Deserializable for usize {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_usize()
     }
 }
 

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{collections::Vec, ByteReader, ByteWriter, Serializable, SliceReader};
+use proptest::prelude::{any, proptest};
 
 // VECTOR UTILS TESTS
 // ================================================================================================
@@ -113,6 +114,29 @@ fn write_serializable() {
 }
 
 #[test]
+fn write_serializable_usize() {
+    let mut target: Vec<u8> = Vec::new();
+
+    target.write(0usize);
+    assert_eq!(1, target.len());
+    target.write(1usize);
+    assert_eq!(2, target.len());
+    target.write(255usize);
+    assert_eq!(4, target.len());
+    target.write(234567usize);
+    assert_eq!(7, target.len());
+    target.write(usize::MAX);
+    assert_eq!(16, target.len());
+
+    let mut reader = SliceReader::new(&target);
+    assert_eq!(0usize, reader.read_usize().unwrap());
+    assert_eq!(1usize, reader.read_usize().unwrap());
+    assert_eq!(255usize, reader.read_usize().unwrap());
+    assert_eq!(234567usize, reader.read_usize().unwrap());
+    assert_eq!(usize::MAX, reader.read_usize().unwrap());
+}
+
+#[test]
 fn write_serializable_batch() {
     let mut target: Vec<u8> = Vec::new();
 
@@ -145,5 +169,18 @@ fn write_serializable_array_batch() {
     let mut reader = SliceReader::new(&target);
     for i in 1u128..9 {
         assert_eq!(i, reader.read_u128().unwrap());
+    }
+}
+
+// UTILS - RANDOMIZED - UINT SERIALIZATION AND DESERIALIZATION
+// ================================================================================================
+proptest! {
+    #[test]
+    fn usize_proptest(a in any::<usize>()) {
+        let mut target: Vec<u8> = Vec::new();
+        target.write(a);
+
+        let mut reader = SliceReader::new(&target);
+        assert_eq!(a, reader.read_usize().unwrap());
     }
 }


### PR DESCRIPTION
This PR adds [vint64](https://docs.rs/vint64/latest/vint64/) variable-length serialization and deserialization implementation for `usize` type.