### PR TITLE
Remove `Serializable` and `Deserializable` implementations from slices and vecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.7.5 (2023-12-21) - `utils/core` crate only
+## 0.8.0 (TBD)
 * Added variable-length serialization and deserialization for `usize` type (#238).
+* [BREAKING] Removed `Serializable` and `Deserializable` implementations from slices and vectors (#239).
 
 ## 0.7.4 (2023-12-18) - `air` crate only
 * Fixed a bug in `StarkProof` deserialization (#236).

--- a/air/src/proof/commitments.rs
+++ b/air/src/proof/commitments.rs
@@ -34,9 +34,9 @@ impl Commitments {
         fri_roots: Vec<H::Digest>,
     ) -> Self {
         let mut bytes = Vec::new();
-        bytes.write(trace_roots);
+        bytes.write_many(&trace_roots);
         bytes.write(constraint_root);
-        bytes.write(fri_roots);
+        bytes.write_many(&fri_roots);
         Commitments(bytes)
     }
 
@@ -70,13 +70,13 @@ impl Commitments {
         let mut reader = SliceReader::new(&self.0);
 
         // parse trace commitments
-        let trace_commitments = H::Digest::read_batch_from(&mut reader, num_trace_segments)?;
+        let trace_commitments = reader.read_many(num_trace_segments)?;
 
         // parse constraint evaluation commitment:
-        let constraint_commitment = H::Digest::read_from(&mut reader)?;
+        let constraint_commitment = reader.read()?;
 
         // read FRI commitments (+ 1 for remainder polynomial commitment)
-        let fri_commitments = H::Digest::read_batch_from(&mut reader, num_fri_layers + 1)?;
+        let fri_commitments = reader.read_many(num_fri_layers + 1)?;
 
         // make sure we consumed all available commitment bytes
         if reader.has_more_bytes() {

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -182,7 +182,7 @@ impl Serializable for StarkProof {
         self.context.write_into(target);
         target.write_u8(self.num_unique_queries);
         self.commitments.write_into(target);
-        self.trace_queries.write_into(target);
+        target.write_many(&self.trace_queries);
         self.constraint_queries.write_into(target);
         self.ood_frame.write_into(target);
         self.fri_proof.write_into(target);

--- a/air/src/proof/queries.rs
+++ b/air/src/proof/queries.rs
@@ -66,7 +66,7 @@ impl Queries {
                 elements_per_query,
                 "all queries must contain the same number of evaluations"
             );
-            values.write(elements);
+            values.write_many(elements);
         }
 
         // serialize internal nodes of the batch Merkle proof; we care about internal nodes only

--- a/air/src/proof/table.rs
+++ b/air/src/proof/table.rs
@@ -6,6 +6,7 @@
 use super::{DeserializationError, SliceReader, Vec};
 use core::iter::FusedIterator;
 use math::FieldElement;
+use utils::ByteReader;
 
 // CONSTANTS
 // ================================================================================================
@@ -56,7 +57,7 @@ impl<E: FieldElement> Table<E> {
         let mut reader = SliceReader::new(bytes);
         let num_elements = num_rows * num_cols;
         Ok(Self {
-            data: E::read_batch_from(&mut reader, num_elements)?,
+            data: reader.read_many(num_elements)?,
             row_width: num_cols,
         })
     }

--- a/crypto/src/hash/blake/mod.rs
+++ b/crypto/src/hash/blake/mod.rs
@@ -53,7 +53,7 @@ impl<B: StarkField> ElementHasher for Blake3_256<B> {
             // when elements' internal and canonical representations differ, we need to serialize
             // them before hashing
             let mut hasher = BlakeHasher::new();
-            hasher.write(elements);
+            hasher.write_many(elements);
             ByteDigest(hasher.finalize())
         }
     }
@@ -106,7 +106,7 @@ impl<B: StarkField> ElementHasher for Blake3_192<B> {
             // when elements' internal and canonical representations differ, we need to serialize
             // them before hashing
             let mut hasher = BlakeHasher::new();
-            hasher.write(elements);
+            hasher.write_many(elements);
             let result = hasher.finalize();
             ByteDigest(result[..24].try_into().unwrap())
         }

--- a/crypto/src/hash/sha/mod.rs
+++ b/crypto/src/hash/sha/mod.rs
@@ -50,7 +50,7 @@ impl<B: StarkField> ElementHasher for Sha3_256<B> {
             // when elements' internal and canonical representations differ, we need to serialize
             // them before hashing
             let mut hasher = ShaHasher::new();
-            hasher.write(elements);
+            hasher.write_many(elements);
             ByteDigest(hasher.finalize())
         }
     }

--- a/crypto/src/merkle/proofs.rs
+++ b/crypto/src/merkle/proofs.rs
@@ -7,7 +7,7 @@ use crate::{errors::MerkleTreeError, Hasher};
 use utils::{
     collections::{BTreeMap, Vec},
     string::ToString,
-    ByteReader, Deserializable, DeserializationError, Serializable,
+    ByteReader, DeserializationError, Serializable,
 };
 
 // CONSTANTS
@@ -463,7 +463,7 @@ impl<H: Hasher> BatchMerkleProof<H> {
             let num_digests = node_bytes.read_u8()? as usize;
 
             // read the digests and add them to the node vector
-            let digests = H::Digest::read_batch_from(node_bytes, num_digests)?;
+            let digests = node_bytes.read_many(num_digests)?;
             nodes.push(digests);
         }
 

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -4,8 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{
-    AsBytes, BaseElement, ByteReader, Deserializable, DeserializationError, FieldElement,
-    StarkField, Vec, M,
+    AsBytes, BaseElement, ByteReader, DeserializationError, FieldElement, StarkField, Vec, M,
 };
 use crate::field::{ExtensionOf, QuadExtension};
 use core::convert::TryFrom;
@@ -207,21 +206,21 @@ fn read_elements_from() {
 
     // fill whole target
     let mut reader = SliceReader::new(&bytes[..64]);
-    let result = BaseElement::read_batch_from(&mut reader, 4);
+    let result = reader.read_many(4);
     assert!(result.is_ok());
     assert_eq!(expected, result.unwrap());
     assert!(!reader.has_more_bytes());
 
     // partial number of elements
     let mut reader = SliceReader::new(&bytes[..65]);
-    let result = BaseElement::read_batch_from(&mut reader, 4);
+    let result = reader.read_many(4);
     assert!(result.is_ok());
     assert_eq!(expected, result.unwrap());
     assert!(reader.has_more_bytes());
 
     // invalid element
     let mut reader = SliceReader::new(&bytes[16..]);
-    let result = BaseElement::read_batch_from(&mut reader, 4);
+    let result = reader.read_many::<BaseElement>(4);
     assert!(result.is_err());
     if let Err(err) = result {
         assert!(matches!(err, DeserializationError::InvalidValue(_)));

--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -62,6 +62,14 @@ pub trait ByteWriter: Sized {
         self.write_bytes(&value.to_le_bytes());
     }
 
+    /// Writes a u128 value in little-endian byte order into `self`.
+    ///
+    /// # Panics
+    /// Panics if the value could not be written into `self`.
+    fn write_u128(&mut self, value: u128) {
+        self.write_bytes(&value.to_le_bytes());
+    }
+
     /// Writes a usize value in [vint64](https://docs.rs/vint64/latest/vint64/) format into `self`.
     ///
     /// # Panics
@@ -87,6 +95,15 @@ pub trait ByteWriter: Sized {
     fn write<S: Serializable>(&mut self, value: S) {
         value.write_into(self)
     }
+
+    /// Serializes all `elements` and writes the resulting bytes into `self`.
+    ///
+    /// This method does not write any metadata (e.g. number of serialized elements) into `self`.
+    fn write_many<S: Serializable>(&mut self, elements: &[S]) {
+        for element in elements {
+            element.write_into(self);
+        }
+    }
 }
 
 // BYTE WRITER IMPLEMENTATIONS
@@ -105,8 +122,8 @@ impl ByteWriter for Vec<u8> {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Returns the length of the value in vint64 enсoding.
-pub fn encoded_len(value: usize) -> usize {
+/// Returns the length of the value in vint64 encoding.
+fn encoded_len(value: usize) -> usize {
     let zeros = value.leading_zeros() as usize;
     let len = zeros.saturating_sub(1) / 7;
     9 - core::cmp::min(len, 8)

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -31,16 +31,6 @@ pub trait Serializable: Sized {
         result
     }
 
-    /// Serializes all elements of the `source` and writes these bytes into the `target`.
-    ///
-    /// This method does not write any metadata (e.g. number of serialized elements) into the
-    /// `target`.
-    fn write_batch_into<W: ByteWriter>(source: &[Self], target: &mut W) {
-        for item in source {
-            item.write_into(target);
-        }
-    }
-
     /// Returns an estimate of how many bytes are needed to represent self.
     ///
     /// The default implementation returns zero.
@@ -161,6 +151,12 @@ impl Serializable for u64 {
     }
 }
 
+impl Serializable for u128 {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u128(*self);
+    }
+}
+
 impl Serializable for usize {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_usize(*self)
@@ -191,27 +187,9 @@ impl<T: Serializable> Serializable for &Option<T> {
     }
 }
 
-impl<T: Serializable> Serializable for Vec<T> {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        T::write_batch_into(self, target);
-    }
-}
-
-impl<T: Serializable> Serializable for &Vec<T> {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        T::write_batch_into(self, target);
-    }
-}
-
-impl<T: Serializable> Serializable for &[T] {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        T::write_batch_into(self, target);
-    }
-}
-
 impl<T: Serializable, const C: usize> Serializable for [T; C] {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        T::write_batch_into(self, target);
+        target.write_many(self)
     }
 }
 
@@ -246,30 +224,6 @@ pub trait Deserializable: Sized {
     /// returned.
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         Self::read_from(&mut SliceReader::new(bytes))
-    }
-
-    /// Reads a sequence of bytes from the provided `source`, attempts to deserialize these bytes
-    /// into a vector with the specified number of `Self` elements, and returns the result.
-    ///
-    /// # Errors
-    /// Returns an error if:
-    /// * The `source` does not contain enough bytes to deserialize the specified number of
-    ///   elements.
-    /// * Bytes read from the `source` do not represent a valid value for `Self` for any of the
-    ///   elements.
-    ///
-    /// Note: if the error occurs, the reader is not rolled back to the state prior to calling
-    /// this function.
-    fn read_batch_from<R: ByteReader>(
-        source: &mut R,
-        num_elements: usize,
-    ) -> Result<Vec<Self>, DeserializationError> {
-        let mut result = Vec::with_capacity(num_elements);
-        for _ in 0..num_elements {
-            let element = Self::read_from(source)?;
-            result.push(element)
-        }
-        Ok(result)
     }
 }
 
@@ -393,6 +347,12 @@ impl Deserializable for u64 {
     }
 }
 
+impl Deserializable for u128 {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u128()
+    }
+}
+
 impl Deserializable for usize {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         source.read_usize()
@@ -412,7 +372,7 @@ impl<T: Deserializable> Deserializable for Option<T> {
 
 impl<T: Deserializable, const C: usize> Deserializable for [T; C] {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let data: Vec<T> = T::read_batch_from(source, C)?;
+        let data: Vec<T> = source.read_many(C)?;
 
         // SAFETY: the call above only returns a Vec if there are `C` elements, this conversion
         // always succeeds

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -92,12 +92,6 @@ fn read_u8_vec() {
 // SERIALIZATION TESTS
 // ================================================================================================
 
-impl Serializable for u128 {
-    fn write_into<W: crate::ByteWriter>(&self, target: &mut W) {
-        target.write_bytes(&self.to_le_bytes());
-    }
-}
-
 #[test]
 fn write_serializable() {
     let mut target: Vec<u8> = Vec::new();
@@ -141,11 +135,11 @@ fn write_serializable_batch() {
     let mut target: Vec<u8> = Vec::new();
 
     let batch1 = vec![1u128, 2, 3, 4];
-    batch1.write_into(&mut target);
+    target.write_many(&batch1);
     assert_eq!(64, target.len());
 
     let batch2 = [5u128, 6, 7, 8];
-    target.write(&batch2[..]);
+    target.write_many(&batch2);
     assert_eq!(128, target.len());
 
     let mut reader = SliceReader::new(&target);
@@ -159,11 +153,11 @@ fn write_serializable_array_batch() {
     let mut target: Vec<u8> = Vec::new();
 
     let batch1 = vec![[1u128, 2], [3, 4]];
-    batch1.write_into(&mut target);
+    target.write_many(&batch1);
     assert_eq!(64, target.len());
 
     let batch2 = [[5u128, 6], [7, 8]];
-    target.write(&batch2[..]);
+    target.write_many(&batch2);
     assert_eq!(128, target.len());
 
     let mut reader = SliceReader::new(&target);


### PR DESCRIPTION
This PR removes current implementations of `Serializable` and `Deserilizable` traits from slices and vectors. The motivation for this is that the way sterilization worked for these structs was somewhat confusing (slices and vectors were serialized without their lengths). Instead, we can use explicit calls to `write_batch()` and `read_batch()` methods to accomplish the same thing.

In the future, we can reimplement `Serializable` and `Deserializable` on slices and vecs, but this time we would serialize them together with the number of elements (for which we can use `usize` serialization implemented in #238).