### PR TITLE
Implementation of Tracing logger

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ doc = false
 [features]
 concurrent = ["winterfell/concurrent", "std"]
 default = ["std"]
+tree = ["std", "tracing-forest"]
 std = ["core-utils/std", "hex/std", "rand-utils", "winterfell/std"]
 
 [dependencies]
@@ -33,7 +34,7 @@ rand-utils = { version = "0.7", path = "../utils/rand", package = "winter-rand-u
 structopt = { version = "0.3", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
-tracing-forest = { version = "0.1", features = ["ansi", "smallvec"] }
+tracing-forest = { version = "0.1", features = ["ansi", "smallvec"], optional = true }
 winterfell = { version="0.7", path = "../winterfell", default-features = false }
 
 [dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,7 +23,6 @@ doc = false
 [features]
 concurrent = ["winterfell/concurrent", "std"]
 default = ["std"]
-tree = ["std", "tracing-forest"]
 std = ["core-utils/std", "hex/std", "rand-utils", "winterfell/std"]
 
 [dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,17 +23,17 @@ doc = false
 [features]
 concurrent = ["winterfell/concurrent", "std"]
 default = ["std"]
-std = ["hex/std", "winterfell/std", "core-utils/std", "rand-utils"]
+std = ["core-utils/std", "hex/std", "rand-utils", "winterfell/std"]
 
 [dependencies]
-winterfell = { version="0.7", path = "../winterfell", default-features = false }
-core-utils = { version = "0.7", path = "../utils/core", package = "winter-utils", default-features = false }
-rand-utils = { version = "0.7", path = "../utils/rand", package = "winter-rand-utils", optional = true }
-hex = { version = "0.4", optional = true }
-log = { version = "0.4", default-features = false }
 blake3 = { version = "1.5", default-features = false }
-env_logger = { version = "0.10", default-features = false }
+core-utils = { version = "0.7", path = "../utils/core", package = "winter-utils", default-features = false }
+hex = { version = "0.4", optional = true }
+rand-utils = { version = "0.7", path = "../utils/rand", package = "winter-rand-utils", optional = true }
 structopt = { version = "0.3", default-features = false }
+tracing = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
+winterfell = { version="0.7", path = "../winterfell", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -33,6 +33,7 @@ rand-utils = { version = "0.7", path = "../utils/rand", package = "winter-rand-u
 structopt = { version = "0.3", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
+tracing-forest = { version = "0.1", features = ["ansi", "smallvec"] }
 winterfell = { version="0.7", path = "../winterfell", default-features = false }
 
 [dev-dependencies]

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -97,35 +97,13 @@ where
         let prover = FibProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(self.sequence_length);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
-
-        // let span = info_span!("Generating execution trace", registers_num = field::Empty, steps = field::Empty);
-        // let trace = prover.build_trace(self.sequence_length);
-        // span.record("registers_num", &format!("{}", trace.width()));
-        // span.record("steps", &format!("2^{} steps", trace.length().ilog2()));
-
-        // let trace = info_span!("Generating execution trace").in_scope(|| {
-        //     let trace = prover.build_trace(self.sequence_length);
-        //     let trace_width = trace.width();
-        //     let trace_length = trace.length();
-        //     event!(
-        //         Level::DEBUG,
-        //         "Generated execution trace of {} registers and 2^{} steps",
-        //         trace_width,
-        //         trace_length.ilog2(),
-        //     );
-        //     trace
-        // });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(self.sequence_length);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -6,8 +6,8 @@
 use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -65,7 +65,8 @@ impl<H: ElementHasher> FibExample<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_fib_term(sequence_length);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -88,7 +89,8 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing Fibonacci sequence (2 terms per step) up to {}th term\n\
             ---------------------",
             self.sequence_length
@@ -103,7 +105,8 @@ where
 
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, Level};
+use tracing::{debug_span, event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -65,8 +65,7 @@ impl<H: ElementHasher> FibExample<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_fib_term(sequence_length);
-        event!(
-            Level::DEBUG,
+        println!(
             "Computed Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -91,8 +90,7 @@ where
     fn prove(&self) -> StarkProof {
         event!(
             Level::DEBUG,
-            "Generating proof for computing Fibonacci sequence (2 terms per step) up to {}th term\n\
-            ---------------------",
+            "Generating proof for computing Fibonacci sequence (2 terms per step) up to {}th term",
             self.sequence_length
         );
 
@@ -100,18 +98,18 @@ where
         let prover = FibProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let now = Instant::now();
-        let trace = prover.build_trace(self.sequence_length);
-
-        let trace_width = trace.width();
-        let trace_length = trace.length();
-        event!(
-            Level::DEBUG,
-            "Generated execution trace of {} registers and 2^{} steps in {} ms",
-            trace_width,
-            trace_length.ilog2(),
-            now.elapsed().as_millis()
-        );
+        let trace = debug_span!("Generating execution trace").in_scope(|| {
+            let trace = prover.build_trace(self.sequence_length);
+            let trace_width = trace.width();
+            let trace_length = trace.length();
+            event!(
+                Level::TRACE,
+                "Generated execution trace of {} registers and 2^{} steps",
+                trace_width,
+                trace_length.ilog2(),
+            );
+            trace
+        });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/fibonacci/fib2/mod.rs
+++ b/examples/src/fibonacci/fib2/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -88,8 +88,7 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for computing Fibonacci sequence (2 terms per step) up to {}th term",
             self.sequence_length
         );
@@ -98,12 +97,12 @@ where
         let prover = FibProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(self.sequence_length);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -88,8 +88,7 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for computing Fibonacci sequence (8 terms per step) up to {}th term",
             self.sequence_length
         );
@@ -98,12 +97,12 @@ where
         let prover = Fib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(self.sequence_length);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, Level};
+use tracing::{debug_span, event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -65,8 +65,7 @@ impl<H: ElementHasher> Fib8Example<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_fib_term(sequence_length);
-        event!(
-            Level::DEBUG,
+        println!(
             "Computed Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -91,8 +90,7 @@ where
     fn prove(&self) -> StarkProof {
         event!(
             Level::DEBUG,
-            "Generating proof for computing Fibonacci sequence (8 terms per step) up to {}th term\n\
-            ---------------------",
+            "Generating proof for computing Fibonacci sequence (8 terms per step) up to {}th term",
             self.sequence_length
         );
 
@@ -100,17 +98,18 @@ where
         let prover = Fib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let now = Instant::now();
-        let trace = prover.build_trace(self.sequence_length);
-        let trace_width = trace.width();
-        let trace_length = trace.length();
-        event!(
-            Level::DEBUG,
-            "Generated execution trace of {} registers and 2^{} steps in {} ms",
-            trace_width,
-            trace_length.ilog2(),
-            now.elapsed().as_millis()
-        );
+        let trace = debug_span!("Generating execution trace").in_scope(|| {
+            let trace = prover.build_trace(self.sequence_length);
+            let trace_width = trace.width();
+            let trace_length = trace.length();
+            event!(
+                Level::TRACE,
+                "Generated execution trace of {} registers and 2^{} steps",
+                trace_width,
+                trace_length.ilog2(),
+            );
+            trace
+        });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -6,8 +6,8 @@
 use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -65,7 +65,8 @@ impl<H: ElementHasher> Fib8Example<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_fib_term(sequence_length);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -88,7 +89,8 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing Fibonacci sequence (8 terms per step) up to {}th term\n\
             ---------------------",
             self.sequence_length
@@ -102,7 +104,8 @@ where
         let trace = prover.build_trace(self.sequence_length);
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -97,17 +97,13 @@ where
         let prover = Fib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(self.sequence_length);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(self.sequence_length);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/fibonacci/fib8/mod.rs
+++ b/examples/src/fibonacci/fib8/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_fib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -97,16 +97,15 @@ where
         let prover = Fib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!(
+            "Generated execution trace",
+            registers_num = field::Empty,
+            steps = field::Empty
+        )
+        .in_scope(|| {
             let trace = prover.build_trace(self.sequence_length);
-            let trace_width = trace.width();
-            let trace_length = trace.length();
-            event!(
-                Level::DEBUG,
-                "Generated execution trace of {} registers and 2^{} steps",
-                trace_width,
-                trace_length.ilog2(),
-            );
+            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
+            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
             trace
         });
 

--- a/examples/src/fibonacci/fib_small/mod.rs
+++ b/examples/src/fibonacci/fib_small/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_fib_term;
 use crate::{Example, ExampleOptions, HashFunction};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f64::BaseElement, FieldElement},
@@ -103,8 +103,7 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for computing Fibonacci sequence (2 terms per step) up to {}th term",
             self.sequence_length
         );
@@ -113,12 +112,12 @@ where
         let prover = FibSmallProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(self.sequence_length);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/fibonacci/fib_small/mod.rs
+++ b/examples/src/fibonacci/fib_small/mod.rs
@@ -6,8 +6,8 @@
 use super::utils::compute_fib_term;
 use crate::{Example, ExampleOptions, HashFunction};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f64::BaseElement, FieldElement},
@@ -80,7 +80,8 @@ impl<H: ElementHasher> FibExample<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_fib_term::<BaseElement>(sequence_length);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -103,7 +104,8 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing Fibonacci sequence (2 terms per step) up to {}th term\n\
             ---------------------",
             self.sequence_length
@@ -118,7 +120,8 @@ where
 
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/fibonacci/fib_small/mod.rs
+++ b/examples/src/fibonacci/fib_small/mod.rs
@@ -112,17 +112,13 @@ where
         let prover = FibSmallProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(self.sequence_length);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(self.sequence_length);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()
@@ -131,6 +127,7 @@ where
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {
         let acceptable_options =
             winterfell::AcceptableOptions::OptionSet(vec![proof.options().clone()]);
+
         winterfell::verify::<FibSmall, H, DefaultRandomCoin<H>>(
             proof,
             self.result,

--- a/examples/src/fibonacci/mulfib2/air.rs
+++ b/examples/src/fibonacci/mulfib2/air.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use super::TRACE_WIDTH;
 use crate::utils::are_equal;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
@@ -12,8 +13,6 @@ use winterfell::{
 
 // FIBONACCI AIR
 // ================================================================================================
-
-const TRACE_WIDTH: usize = 2;
 
 pub struct MulFib2Air {
     context: AirContext<BaseElement>,

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -83,8 +83,7 @@ where
 {
     fn prove(&self) -> StarkProof {
         let sequence_length = self.sequence_length;
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for computing multiplicative Fibonacci sequence (2 terms per step) up to {}th term",
             sequence_length
         );
@@ -93,12 +92,12 @@ where
         let prover = MulFib2Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(sequence_length);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -23,6 +23,11 @@ use prover::MulFib2Prover;
 #[cfg(test)]
 mod tests;
 
+// CONSTANTS
+// ================================================================================================
+
+const TRACE_WIDTH: usize = 2;
+
 // FIBONACCI EXAMPLE
 // ================================================================================================
 
@@ -92,17 +97,13 @@ where
         let prover = MulFib2Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(sequence_length);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(sequence_length);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -92,16 +92,15 @@ where
         let prover = MulFib2Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!(
+            "Generated execution trace",
+            registers_num = field::Empty,
+            steps = field::Empty
+        )
+        .in_scope(|| {
             let trace = prover.build_trace(sequence_length);
-            let trace_width = trace.width();
-            let trace_length = trace.length();
-            event!(
-                Level::DEBUG,
-                "Generated execution trace of {} registers and 2^{} steps",
-                trace_width,
-                trace_length.ilog2(),
-            );
+            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
+            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
             trace
         });
 

--- a/examples/src/fibonacci/mulfib2/mod.rs
+++ b/examples/src/fibonacci/mulfib2/mod.rs
@@ -6,8 +6,8 @@
 use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -59,7 +59,8 @@ impl<H: ElementHasher> MulFib2Example<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_mulfib_term(sequence_length);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed multiplicative Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -83,7 +84,8 @@ where
 {
     fn prove(&self) -> StarkProof {
         let sequence_length = self.sequence_length;
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing multiplicative Fibonacci sequence (8 terms per step) up to {}th term\n\
             ---------------------",
             sequence_length
@@ -97,7 +99,8 @@ where
         let trace = prover.build_trace(sequence_length);
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/fibonacci/mulfib8/air.rs
+++ b/examples/src/fibonacci/mulfib8/air.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use super::TRACE_WIDTH;
 use crate::utils::are_equal;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
@@ -12,8 +13,6 @@ use winterfell::{
 
 // FIBONACCI AIR
 // ================================================================================================
-
-const TRACE_WIDTH: usize = 8;
 
 pub struct MulFib8Air {
     context: AirContext<BaseElement>,

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, Level};
+use tracing::{debug_span, event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -60,8 +60,7 @@ impl<H: ElementHasher> MulFib8Example<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_mulfib_term(sequence_length);
-        event!(
-            Level::DEBUG,
+        println!(
             "Computed multiplicative Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -87,8 +86,7 @@ where
         let sequence_length = self.sequence_length;
         event!(
             Level::DEBUG,
-            "Generating proof for computing multiplicative Fibonacci sequence (2 terms per step) up to {}th term\n\
-            ---------------------",
+            "Generating proof for computing multiplicative Fibonacci sequence (8 terms per step) up to {}th term",
             sequence_length
         );
 
@@ -96,17 +94,18 @@ where
         let prover = MulFib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let now = Instant::now();
-        let trace = prover.build_trace(sequence_length);
-        let trace_width = trace.width();
-        let trace_length = trace.length();
-        event!(
-            Level::DEBUG,
-            "Generated execution trace of {} registers and 2^{} steps in {} ms",
-            trace_width,
-            trace_length.ilog2(),
-            now.elapsed().as_millis()
-        );
+        let trace = debug_span!("Generating execution trace").in_scope(|| {
+            let trace = prover.build_trace(sequence_length);
+            let trace_width = trace.width();
+            let trace_length = trace.length();
+            event!(
+                Level::TRACE,
+                "Generated execution trace of {} registers and 2^{} steps",
+                trace_width,
+                trace_length.ilog2(),
+            );
+            trace
+        });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -84,8 +84,7 @@ where
 {
     fn prove(&self) -> StarkProof {
         let sequence_length = self.sequence_length;
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for computing multiplicative Fibonacci sequence (8 terms per step) up to {}th term",
             sequence_length
         );
@@ -94,12 +93,12 @@ where
         let prover = MulFib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(sequence_length);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -7,7 +7,7 @@ use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -93,16 +93,15 @@ where
         let prover = MulFib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!(
+            "Generated execution trace",
+            registers_num = field::Empty,
+            steps = field::Empty
+        )
+        .in_scope(|| {
             let trace = prover.build_trace(sequence_length);
-            let trace_width = trace.width();
-            let trace_length = trace.length();
-            event!(
-                Level::DEBUG,
-                "Generated execution trace of {} registers and 2^{} steps",
-                trace_width,
-                trace_length.ilog2(),
-            );
+            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
+            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
             trace
         });
 

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -6,8 +6,8 @@
 use super::utils::compute_mulfib_term;
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -60,7 +60,8 @@ impl<H: ElementHasher> MulFib8Example<H> {
         // compute Fibonacci sequence
         let now = Instant::now();
         let result = compute_mulfib_term(sequence_length);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed multiplicative Fibonacci sequence up to {}th term in {} ms",
             sequence_length,
             now.elapsed().as_millis()
@@ -84,7 +85,8 @@ where
 {
     fn prove(&self) -> StarkProof {
         let sequence_length = self.sequence_length;
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing multiplicative Fibonacci sequence (2 terms per step) up to {}th term\n\
             ---------------------",
             sequence_length
@@ -98,7 +100,8 @@ where
         let trace = prover.build_trace(sequence_length);
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/fibonacci/mulfib8/mod.rs
+++ b/examples/src/fibonacci/mulfib8/mod.rs
@@ -23,6 +23,11 @@ use prover::MulFib8Prover;
 #[cfg(test)]
 mod tests;
 
+// CONSTANTS
+// ================================================================================================
+
+const TRACE_WIDTH: usize = 8;
+
 // FIBONACCI EXAMPLE
 // ================================================================================================
 
@@ -93,17 +98,13 @@ where
         let prover = MulFib8Prover::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(sequence_length);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(sequence_length);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -123,17 +123,13 @@ where
             LamportAggregateProver::<H>::new(&self.pub_keys, &self.messages, self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(&self.messages, &self.signatures);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(&self.messages, &self.signatures);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{Blake3_192, Blake3_256, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, get_power_series, FieldElement, StarkField},
@@ -116,21 +116,17 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        event!(
-            Level::DEBUG,
-            "Generating proof for verifying {} Lamport+ signatures",
-            self.signatures.len(),
-        );
+        println!("Generating proof for verifying {} Lamport+ signatures", self.signatures.len());
 
         // create a prover
         let prover =
             LamportAggregateProver::<H>::new(&self.pub_keys, &self.messages, self.options.clone());
 
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(&self.messages, &self.signatures);
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace.width(),
                 trace_length.ilog2(),

--- a/examples/src/lamport/aggregate/mod.rs
+++ b/examples/src/lamport/aggregate/mod.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{Blake3_192, Blake3_256, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, get_power_series, FieldElement, StarkField},
@@ -122,15 +122,16 @@ where
         let prover =
             LamportAggregateProver::<H>::new(&self.pub_keys, &self.messages, self.options.clone());
 
-        let trace = info_span!("Generating execution trace").in_scope(|| {
+        // generate execution trace
+        let trace = info_span!(
+            "Generated execution trace",
+            registers_num = field::Empty,
+            steps = field::Empty
+        )
+        .in_scope(|| {
             let trace = prover.build_trace(&self.messages, &self.signatures);
-            let trace_length = trace.length();
-            event!(
-                Level::DEBUG,
-                "Generated execution trace of {} registers and 2^{} steps",
-                trace.width(),
-                trace_length.ilog2(),
-            );
+            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
+            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
             trace
         });
 

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{Blake3_192, Blake3_256, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, get_power_series, FieldElement, StarkField},
@@ -114,8 +114,7 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for verifying {}-of-{} signature",
             self.signatures.len(),
             self.pub_key.num_keys(),
@@ -130,11 +129,11 @@ where
         );
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(&self.pub_key, self.message, &self.signatures);
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace.width(),
                 trace_length.ilog2(),

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -9,8 +9,8 @@ use super::{
 };
 use crate::{Blake3_192, Blake3_256, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, get_power_series, FieldElement, StarkField},
@@ -72,7 +72,8 @@ impl<H: ElementHasher> LamportThresholdExample<H> {
         // generate private/public key pairs for the specified number of signatures
         let now = Instant::now();
         let private_keys = build_keys(num_signers);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated {} private-public key pairs in {} ms",
             num_signers,
             now.elapsed().as_millis()
@@ -91,7 +92,7 @@ impl<H: ElementHasher> LamportThresholdExample<H> {
         // build the aggregated public key
         let now = Instant::now();
         let pub_key = AggPublicKey::new(public_keys);
-        debug!("Built aggregated public key in {} ms", now.elapsed().as_millis());
+        event!(Level::DEBUG, "Built aggregated public key in {} ms", now.elapsed().as_millis());
 
         let (options, _) = options.to_proof_options(28, 8);
 
@@ -114,7 +115,8 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for verifying {}-of-{} signature \n\
             ---------------------",
             self.signatures.len(),
@@ -133,7 +135,8 @@ where
         let now = Instant::now();
         let trace = prover.build_trace(&self.pub_key, self.message, &self.signatures);
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
             trace_length.ilog2(),

--- a/examples/src/lamport/threshold/mod.rs
+++ b/examples/src/lamport/threshold/mod.rs
@@ -129,17 +129,13 @@ where
         );
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(&self.pub_key, self.message, &self.signatures);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(&self.pub_key, self.message, &self.signatures);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -6,9 +6,9 @@
 use std::time::Instant;
 use structopt::StructOpt;
 use tracing::info_span;
-#[cfg(feature = "tree")]
+#[cfg(feature = "tracing-forest")]
 use tracing_forest::ForestLayer;
-#[cfg(not(feature = "tree"))]
+#[cfg(not(feature = "tracing-forest"))]
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use winterfell::StarkProof;
@@ -28,10 +28,10 @@ fn main() {
     let registry =
         tracing_subscriber::registry::Registry::default().with(EnvFilter::from_env("WINTER_LOG"));
 
-    #[cfg(feature = "tree")]
+    #[cfg(feature = "tracing-forest")]
     registry.with(ForestLayer::default()).init();
 
-    #[cfg(not(feature = "tree"))]
+    #[cfg(not(feature = "tracing-forest"))]
     {
         let format = tracing_subscriber::fmt::layer()
             .with_level(false)
@@ -87,7 +87,7 @@ fn main() {
 
     // generate proof
     let now = Instant::now();
-    let proof = info_span!("Generating proof").in_scope(|| example.as_ref().prove());
+    let proof = info_span!("generate_proof").in_scope(|| example.as_ref().prove());
     println!("---------------------\nProof generated in {} ms", now.elapsed().as_millis());
 
     let proof_bytes = proof.to_bytes();

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -12,9 +12,9 @@ use crate::{
     Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256,
 };
 use core::marker::PhantomData;
-use log::debug;
 use rand_utils::{rand_value, rand_vector};
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, Digest, ElementHasher, MerkleTree},
     math::{fields::f128::BaseElement, FieldElement, StarkField},
@@ -77,12 +77,18 @@ impl<H: ElementHasher> MerkleExample<H> {
         // build Merkle tree of the specified depth
         let now = Instant::now();
         let tree = build_merkle_tree(tree_depth, value, index);
-        debug!("Built Merkle tree of depth {} in {} ms", tree_depth, now.elapsed().as_millis(),);
+        event!(
+            Level::DEBUG,
+            "Built Merkle tree of depth {} in {} ms",
+            tree_depth,
+            now.elapsed().as_millis(),
+        );
 
         // compute Merkle path form the leaf specified by the index
         let now = Instant::now();
         let path = tree.prove(index).unwrap();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed Merkle path from leaf {} to root {} in {} ms",
             index,
             hex::encode(tree.root().as_bytes()),
@@ -109,7 +115,8 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for proving membership in a Merkle tree of depth {}\n\
             ---------------------",
             self.path.len()
@@ -121,7 +128,8 @@ where
         let now = Instant::now();
         let trace = prover.build_trace(self.value, &self.path, self.index);
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
             trace_length.ilog2(),

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 use core::marker::PhantomData;
 use rand_utils::{rand_value, rand_vector};
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, Digest, ElementHasher, MerkleTree},
     math::{fields::f128::BaseElement, FieldElement, StarkField},
@@ -109,8 +109,7 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        event!(
-            Level::DEBUG,
+        println!(
             "Generating proof for proving membership in a Merkle tree of depth {}",
             self.path.len()
         );
@@ -118,11 +117,11 @@ where
         let prover = MerkleProver::<H>::new(self.options.clone());
 
         // generate the execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(self.value, &self.path, self.index);
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace.width(),
                 trace_length.ilog2(),

--- a/examples/src/merkle/mod.rs
+++ b/examples/src/merkle/mod.rs
@@ -117,17 +117,13 @@ where
         let prover = MerkleProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(self.value, &self.path, self.index);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(self.value, &self.path, self.index);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -71,7 +71,8 @@ impl<H: ElementHasher> RescueExample<H> {
         // compute the sequence of hashes using external implementation of Rescue hash
         let now = Instant::now();
         let result = compute_hash_chain(seed, chain_length);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed a chain of {} Rescue hashes in {} ms",
             chain_length,
             now.elapsed().as_millis(),
@@ -96,7 +97,8 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing a chain of {} Rescue hashes\n\
             ---------------------",
             self.chain_length
@@ -109,7 +111,8 @@ where
         let now = Instant::now();
         let trace = prover.build_trace(self.seed, self.chain_length);
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
             trace_length.ilog2(),

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -6,7 +6,7 @@
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -96,21 +96,17 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        event!(
-            Level::DEBUG,
-            "Generating proof for computing a chain of {} Rescue hashes",
-            self.chain_length
-        );
+        println!("Generating proof for computing a chain of {} Rescue hashes", self.chain_length);
 
         // create a prover
         let prover = RescueProver::<H>::new(self.options.clone());
 
         // generate the execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(self.seed, self.chain_length);
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace.width(),
                 trace_length.ilog2(),

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -102,17 +102,13 @@ where
         let prover = RescueProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(self.seed, self.chain_length);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(self.seed, self.chain_length);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/rescue/mod.rs
+++ b/examples/src/rescue/mod.rs
@@ -6,7 +6,7 @@
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -101,16 +101,16 @@ where
         // create a prover
         let prover = RescueProver::<H>::new(self.options.clone());
 
-        // generate the execution trace
-        let trace = info_span!("Generating execution trace").in_scope(|| {
+        // generate execution trace
+        let trace = info_span!(
+            "Generated execution trace",
+            registers_num = field::Empty,
+            steps = field::Empty
+        )
+        .in_scope(|| {
             let trace = prover.build_trace(self.seed, self.chain_length);
-            let trace_length = trace.length();
-            event!(
-                Level::DEBUG,
-                "Generated execution trace of {} registers and 2^{} steps",
-                trace.width(),
-                trace_length.ilog2(),
-            );
+            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
+            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
             trace
         });
 

--- a/examples/src/rescue_raps/mod.rs
+++ b/examples/src/rescue_raps/mod.rs
@@ -7,7 +7,7 @@ use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_
 use core::marker::PhantomData;
 use rand_utils::rand_array;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, ExtensionOf, FieldElement},
@@ -109,21 +109,17 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        event!(
-            Level::DEBUG,
-            "Generating proof for computing a chain of {} Rescue hashes",
-            self.chain_length
-        );
+        println!("Generating proof for computing a chain of {} Rescue hashes", self.chain_length);
 
         // create a prover
         let prover = RescueRapsProver::<H>::new(self.options.clone());
 
         // generate the execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = prover.build_trace(&self.seeds, &self.permuted_seeds, self.result);
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace.width(),
                 trace_length.ilog2(),

--- a/examples/src/rescue_raps/mod.rs
+++ b/examples/src/rescue_raps/mod.rs
@@ -5,9 +5,9 @@
 
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use rand_utils::rand_array;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, ExtensionOf, FieldElement},
@@ -83,7 +83,8 @@ impl<H: ElementHasher> RescueRapsExample<H> {
         // compute the sequence of hashes using external implementation of Rescue hash
         let now = Instant::now();
         let result = compute_permuted_hash_chains(&seeds, &permuted_seeds);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Computed two permuted chains of {} Rescue hashes in {} ms",
             chain_length,
             now.elapsed().as_millis(),
@@ -109,7 +110,8 @@ where
 {
     fn prove(&self) -> StarkProof {
         // generate the execution trace
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for computing a chain of {} Rescue hashes\n\
             ---------------------",
             self.chain_length
@@ -122,7 +124,8 @@ where
         let now = Instant::now();
         let trace = prover.build_trace(&self.seeds, &self.permuted_seeds, self.result);
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace.width(),
             trace_length.ilog2(),

--- a/examples/src/rescue_raps/mod.rs
+++ b/examples/src/rescue_raps/mod.rs
@@ -115,17 +115,13 @@ where
         let prover = RescueRapsProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = prover.build_trace(&self.seeds, &self.permuted_seeds, self.result);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = prover.build_trace(&self.seeds, &self.permuted_seeds, self.result);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/vdf/exempt/air.rs
+++ b/examples/src/vdf/exempt/air.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO};
+use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO, TRACE_WIDTH};
 use winterfell::{
     math::ToElements, Air, AirContext, Assertion, EvaluationFrame, TraceInfo,
     TransitionConstraintDegree,
@@ -39,6 +39,7 @@ impl Air for VdfAir {
 
     fn new(trace_info: TraceInfo, pub_inputs: VdfInputs, options: ProofOptions) -> Self {
         let degrees = vec![TransitionConstraintDegree::new(3)];
+        assert_eq!(TRACE_WIDTH, trace_info.width());
         // make sure the last two rows are excluded from transition constraints as we populate
         // values in the last row with garbage
         let context =

--- a/examples/src/vdf/exempt/mod.rs
+++ b/examples/src/vdf/exempt/mod.rs
@@ -28,6 +28,7 @@ mod tests;
 const ALPHA: u64 = 3;
 const INV_ALPHA: u128 = 226854911280625642308916371969163307691;
 const FORTY_TWO: BaseElement = BaseElement::new(42);
+const TRACE_WIDTH: usize = 1;
 
 // VDF EXAMPLE
 // ================================================================================================
@@ -92,17 +93,13 @@ where
         let prover = VdfProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps + 1);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps + 1);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/vdf/exempt/mod.rs
+++ b/examples/src/vdf/exempt/mod.rs
@@ -6,7 +6,7 @@
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -86,22 +86,18 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        event!(
-            Level::DEBUG,
-            "Generating proof for executing a VDF function for {} steps",
-            self.num_steps
-        );
+        println!("Generating proof for executing a VDF function for {} steps", self.num_steps);
 
         // create a prover
         let prover = VdfProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps + 1);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/vdf/exempt/mod.rs
+++ b/examples/src/vdf/exempt/mod.rs
@@ -6,7 +6,7 @@
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, Level};
+use tracing::{debug_span, event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -62,8 +62,7 @@ impl<H: ElementHasher> VdfExample<H> {
         let now = Instant::now();
         let seed = BaseElement::new(123);
         let result = execute_vdf(seed, num_steps);
-        event!(
-            Level::DEBUG,
+        println!(
             "Executed the VDF function for {} steps in {} ms",
             num_steps,
             now.elapsed().as_millis()
@@ -89,8 +88,7 @@ where
     fn prove(&self) -> StarkProof {
         event!(
             Level::DEBUG,
-            "Generating proof for executing a VDF function for {} steps\n\
-            ---------------------",
+            "Generating proof for executing a VDF function for {} steps",
             self.num_steps
         );
 
@@ -98,18 +96,18 @@ where
         let prover = VdfProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let now = Instant::now();
-        let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps + 1);
-
-        let trace_width = trace.width();
-        let trace_length = trace.length();
-        event!(
-            Level::DEBUG,
-            "Generated execution trace of {} registers and 2^{} steps in {} ms",
-            trace_width,
-            trace_length.ilog2(),
-            now.elapsed().as_millis()
-        );
+        let trace = debug_span!("Generating execution trace").in_scope(|| {
+            let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps + 1);
+            let trace_width = trace.width();
+            let trace_length = trace.length();
+            event!(
+                Level::TRACE,
+                "Generated execution trace of {} registers and 2^{} steps",
+                trace_width,
+                trace_length.ilog2(),
+            );
+            trace
+        });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/vdf/exempt/mod.rs
+++ b/examples/src/vdf/exempt/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -62,7 +62,8 @@ impl<H: ElementHasher> VdfExample<H> {
         let now = Instant::now();
         let seed = BaseElement::new(123);
         let result = execute_vdf(seed, num_steps);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Executed the VDF function for {} steps in {} ms",
             num_steps,
             now.elapsed().as_millis()
@@ -86,7 +87,8 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for executing a VDF function for {} steps\n\
             ---------------------",
             self.num_steps
@@ -101,7 +103,8 @@ where
 
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/vdf/regular/air.rs
+++ b/examples/src/vdf/regular/air.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO};
+use super::{BaseElement, FieldElement, ProofOptions, ALPHA, FORTY_TWO, TRACE_WIDTH};
 use winterfell::{
     math::ToElements, Air, AirContext, Assertion, EvaluationFrame, TraceInfo,
     TransitionConstraintDegree,
@@ -39,6 +39,7 @@ impl Air for VdfAir {
 
     fn new(trace_info: TraceInfo, pub_inputs: VdfInputs, options: ProofOptions) -> Self {
         let degrees = vec![TransitionConstraintDegree::new(3)];
+        assert_eq!(TRACE_WIDTH, trace_info.width());
         Self {
             context: AirContext::new(trace_info, degrees, 2, options),
             seed: pub_inputs.seed,

--- a/examples/src/vdf/regular/mod.rs
+++ b/examples/src/vdf/regular/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
-use log::debug;
 use std::time::Instant;
+use tracing::{event, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -59,7 +59,8 @@ impl<H: ElementHasher> VdfExample<H> {
         let now = Instant::now();
         let seed = BaseElement::new(123);
         let result = execute_vdf(seed, num_steps);
-        debug!(
+        event!(
+            Level::DEBUG,
             "Executed the VDF function for {} steps in {} ms",
             num_steps,
             now.elapsed().as_millis()
@@ -83,7 +84,8 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generating proof for executing a VDF function for {} steps\n\
             ---------------------",
             self.num_steps
@@ -98,7 +100,8 @@ where
 
         let trace_width = trace.width();
         let trace_length = trace.length();
-        debug!(
+        event!(
+            Level::DEBUG,
             "Generated execution trace of {} registers and 2^{} steps in {} ms",
             trace_width,
             trace_length.ilog2(),

--- a/examples/src/vdf/regular/mod.rs
+++ b/examples/src/vdf/regular/mod.rs
@@ -6,7 +6,7 @@
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -83,22 +83,18 @@ where
     H: ElementHasher<BaseField = BaseElement>,
 {
     fn prove(&self) -> StarkProof {
-        event!(
-            Level::DEBUG,
-            "Generating proof for executing a VDF function for {} steps",
-            self.num_steps
-        );
+        println!("Generating proof for executing a VDF function for {} steps", self.num_steps);
 
         // create a prover
         let prover = VdfProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = debug_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!("Generating execution trace").in_scope(|| {
             let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps);
             let trace_width = trace.width();
             let trace_length = trace.length();
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 "Generated execution trace of {} registers and 2^{} steps",
                 trace_width,
                 trace_length.ilog2(),

--- a/examples/src/vdf/regular/mod.rs
+++ b/examples/src/vdf/regular/mod.rs
@@ -28,6 +28,7 @@ mod tests;
 const ALPHA: u64 = 3;
 const INV_ALPHA: u128 = 226854911280625642308916371969163307691;
 const FORTY_TWO: BaseElement = BaseElement::new(42);
+const TRACE_WIDTH: usize = 1;
 
 // VDF EXAMPLE
 // ================================================================================================
@@ -89,17 +90,13 @@ where
         let prover = VdfProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!(
-            "Generated execution trace",
-            registers_num = field::Empty,
-            steps = field::Empty
-        )
-        .in_scope(|| {
-            let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps);
-            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
-            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
-            trace
-        });
+        let trace =
+            info_span!("generate_execution_trace", num_cols = TRACE_WIDTH, steps = field::Empty)
+                .in_scope(|| {
+                    let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps);
+                    tracing::Span::current().record("steps", trace.length());
+                    trace
+                });
 
         // generate the proof
         prover.prove(trace).unwrap()

--- a/examples/src/vdf/regular/mod.rs
+++ b/examples/src/vdf/regular/mod.rs
@@ -6,7 +6,7 @@
 use crate::{Blake3_192, Blake3_256, Example, ExampleOptions, HashFunction, Sha3_256};
 use core::marker::PhantomData;
 use std::time::Instant;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 use winterfell::{
     crypto::{DefaultRandomCoin, ElementHasher},
     math::{fields::f128::BaseElement, FieldElement},
@@ -89,16 +89,15 @@ where
         let prover = VdfProver::<H>::new(self.options.clone());
 
         // generate execution trace
-        let trace = info_span!("Generating execution trace").in_scope(|| {
+        let trace = info_span!(
+            "Generated execution trace",
+            registers_num = field::Empty,
+            steps = field::Empty
+        )
+        .in_scope(|| {
             let trace = VdfProver::<H>::build_trace(self.seed, self.num_steps);
-            let trace_width = trace.width();
-            let trace_length = trace.length();
-            event!(
-                Level::DEBUG,
-                "Generated execution trace of {} registers and 2^{} steps",
-                trace_width,
-                trace_length.ilog2(),
-            );
+            tracing::Span::current().record("registers_num", &format!("{}", trace.width()));
+            tracing::Span::current().record("steps", &format!("2^{}", trace.length().ilog2()));
             trace
         });
 

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -28,8 +28,8 @@ std = ["air/std", "crypto/std", "fri/std", "math/std", "utils/std"]
 air = { version = "0.7", path = "../air", package = "winter-air", default-features = false }
 crypto = { version = "0.7", path = "../crypto", package = "winter-crypto", default-features = false }
 fri = { version = "0.7", path = '../fri', package = "winter-fri", default-features = false }
-log = { version = "0.4", default-features = false }
 math = { version = "0.7", path = "../math", package = "winter-math", default-features = false }
+tracing = { version = "0.1", default-features = false }
 utils = { version = "0.7", path = "../utils/core", package = "winter-utils", default-features = false }
 
 [dev-dependencies]

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{RowMatrix, DEFAULT_SEGMENT_WIDTH};
 use crypto::MerkleTree;
-use tracing::{debug_span, event, Level};
+use tracing::{event, info_span, Level};
 
 #[cfg(test)]
 mod tests;
@@ -230,12 +230,12 @@ where
     H: ElementHasher<BaseField = E::BaseField>,
 {
     // extend the execution trace
-    let (trace_lde, trace_polys) = debug_span!("Extending execution trace").in_scope(|| {
+    let (trace_lde, trace_polys) = info_span!("Extending execution trace").in_scope(|| {
         let trace_polys = trace.interpolate_columns();
         let trace_lde =
             RowMatrix::evaluate_polys_over::<DEFAULT_SEGMENT_WIDTH>(&trace_polys, domain);
         event!(
-            Level::TRACE,
+            Level::DEBUG,
             "Extended execution trace of {} columns from 2^{} to 2^{} steps ({}x blowup)",
             trace_lde.num_cols(),
             trace_polys.num_rows().ilog2(),
@@ -246,10 +246,10 @@ where
     });
 
     // build trace commitment
-    let trace_tree = debug_span!("Computed execution trace commitment").in_scope(|| {
+    let trace_tree = info_span!("Computing execution trace commitment").in_scope(|| {
         let trace_tree = trace_lde.commit_to_rows();
         event!(
-            Level::TRACE,
+            Level::DEBUG,
             "Computed execution trace commitment (Merkle tree of depth {})",
             trace_tree.depth(),
         );

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{RowMatrix, DEFAULT_SEGMENT_WIDTH};
 use crypto::MerkleTree;
-use tracing::{event, info_span, Level};
+use tracing::{field, info_span};
 
 #[cfg(test)]
 mod tests;
@@ -230,31 +230,35 @@ where
     H: ElementHasher<BaseField = E::BaseField>,
 {
     // extend the execution trace
-    let (trace_lde, trace_polys) = info_span!("Extending execution trace").in_scope(|| {
+    let (trace_lde, trace_polys) = info_span!(
+        "Extended execution trace",
+        columns_number = field::Empty,
+        from = field::Empty,
+        to = field::Empty,
+        blowup = field::Empty
+    )
+    .in_scope(|| {
         let trace_polys = trace.interpolate_columns();
         let trace_lde =
             RowMatrix::evaluate_polys_over::<DEFAULT_SEGMENT_WIDTH>(&trace_polys, domain);
-        event!(
-            Level::DEBUG,
-            "Extended execution trace of {} columns from 2^{} to 2^{} steps ({}x blowup)",
-            trace_lde.num_cols(),
-            trace_polys.num_rows().ilog2(),
-            trace_lde.num_rows().ilog2(),
-            domain.trace_to_lde_blowup(),
-        );
+
+        tracing::Span::current().record("columns_number", &format!("{}", trace_lde.num_cols()));
+        tracing::Span::current().record("from", &format!("2^{}", trace_polys.num_rows().ilog2()));
+        tracing::Span::current().record("to", &format!("2^{}", trace_lde.num_rows().ilog2()));
+        tracing::Span::current().record("blowup", &format!("{}x", domain.trace_to_lde_blowup()));
+
         (trace_lde, trace_polys)
     });
 
     // build trace commitment
-    let trace_tree = info_span!("Computing execution trace commitment").in_scope(|| {
-        let trace_tree = trace_lde.commit_to_rows();
-        event!(
-            Level::DEBUG,
-            "Computed execution trace commitment (Merkle tree of depth {})",
-            trace_tree.depth(),
-        );
-        trace_tree
-    });
+    let trace_tree =
+        info_span!("Computed execution trace commitment", merkle_tree_depth = field::Empty)
+            .in_scope(|| {
+                let trace_tree = trace_lde.commit_to_rows();
+                tracing::Span::current()
+                    .record("merkle_tree_depth", &format!("{}", trace_tree.depth()));
+                trace_tree
+            });
 
     (trace_lde, trace_tree, trace_polys)
 }

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -11,9 +11,9 @@ use crate::{RowMatrix, DEFAULT_SEGMENT_WIDTH};
 use crypto::MerkleTree;
 
 #[cfg(feature = "std")]
-use log::debug;
-#[cfg(feature = "std")]
 use std::time::Instant;
+#[cfg(feature = "std")]
+use tracing::{event, Level};
 
 #[cfg(test)]
 mod tests;
@@ -239,7 +239,8 @@ where
     let trace_polys = trace.interpolate_columns();
     let trace_lde = RowMatrix::evaluate_polys_over::<DEFAULT_SEGMENT_WIDTH>(&trace_polys, domain);
     #[cfg(feature = "std")]
-    debug!(
+    event!(
+        Level::DEBUG,
         "Extended execution trace of {} columns from 2^{} to 2^{} steps ({}x blowup) in {} ms",
         trace_lde.num_cols(),
         trace_polys.num_rows().ilog2(),
@@ -253,7 +254,8 @@ where
     let now = Instant::now();
     let trace_tree = trace_lde.commit_to_rows();
     #[cfg(feature = "std")]
-    debug!(
+    event!(
+        Level::DEBUG,
         "Computed execution trace commitment (Merkle tree of depth {}) in {} ms",
         trace_tree.depth(),
         now.elapsed().as_millis()

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -231,7 +231,7 @@ where
 {
     // extend the execution trace
     let (trace_lde, trace_polys) = {
-        let _ = info_span!(
+        let span = info_span!(
             "extend_execution_trace",
             num_cols = trace.num_cols(),
             blowup = domain.trace_to_lde_blowup()
@@ -240,6 +240,7 @@ where
         let trace_polys = trace.interpolate_columns();
         let trace_lde =
             RowMatrix::evaluate_polys_over::<DEFAULT_SEGMENT_WIDTH>(&trace_polys, domain);
+        drop(span);
 
         (trace_lde, trace_polys)
     };

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -30,9 +30,9 @@ let min_sec = AcceptableOptions::MinConjecturedSecurity(95);
 let fib_result = BaseElement::new(226333832811148522147755045522163790995);
 match verifier::verify::<FibAir, Blake3, DefaultRandomCoin<Blake3>>(proof, fib_result, &min_sec) {
     Ok(_) => event!(
-            Level::DEBUG,"Proof verified!"),
+            Level::TRACE,"Proof verified!"),
     Err(err) => event!(
-            Level::DEBUG,"Failed to verify proof: {}", err),
+            Level::TRACE,"Failed to verify proof: {}", err),
 }
 ```
 where, `226333832811148522147755045522163790995` is the 1,048,576th term of the Fibonacci sequence when the sequence is computed in a 128-bit field with modulus 2<sup>128</sup> - 45 * 2<sup>40</sup>.

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -29,10 +29,8 @@ For example, if we have a struct `FibAir` which implements the `Air` trait and d
 let min_sec = AcceptableOptions::MinConjecturedSecurity(95);
 let fib_result = BaseElement::new(226333832811148522147755045522163790995);
 match verifier::verify::<FibAir, Blake3, DefaultRandomCoin<Blake3>>(proof, fib_result, &min_sec) {
-    Ok(_) => event!(
-            Level::TRACE,"Proof verified!"),
-    Err(err) => event!(
-            Level::TRACE,"Failed to verify proof: {}", err),
+    Ok(_) => println!("Proof verified!"),
+    Err(err) => println!("Failed to verify proof: {}", err),
 }
 ```
 where, `226333832811148522147755045522163790995` is the 1,048,576th term of the Fibonacci sequence when the sequence is computed in a 128-bit field with modulus 2<sup>128</sup> - 45 * 2<sup>40</sup>.

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -29,8 +29,10 @@ For example, if we have a struct `FibAir` which implements the `Air` trait and d
 let min_sec = AcceptableOptions::MinConjecturedSecurity(95);
 let fib_result = BaseElement::new(226333832811148522147755045522163790995);
 match verifier::verify::<FibAir, Blake3, DefaultRandomCoin<Blake3>>(proof, fib_result, &min_sec) {
-    Ok(_) => debug!("Proof verified!"),
-    Err(err) => debug!("Failed to verify proof: {}", err),
+    Ok(_) => event!(
+            Level::DEBUG,"Proof verified!"),
+    Err(err) => event!(
+            Level::DEBUG,"Failed to verify proof: {}", err),
 }
 ```
 where, `226333832811148522147755045522163790995` is the 1,048,576th term of the Fibonacci sequence when the sequence is computed in a 128-bit field with modulus 2<sup>128</sup> - 45 * 2<sup>40</sup>.


### PR DESCRIPTION
This PR changes the logger implementation from default [log](https://crates.io/crates/log) to [Tracing](https://crates.io/crates/tracing), which allows to implement informative tree-like log.