### PR TITLE
Remove `From` impls resulting in silent field element conversions

### DIFF
--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -326,7 +326,7 @@ mod tests {
         ]);
         let expected = vec![
             BaseElement::from(ext_fri),
-            BaseElement::from(grinding_factor as u32),
+            BaseElement::from(grinding_factor),
             BaseElement::from(blowup_factor as u32),
             BaseElement::from(num_queries as u32),
         ];

--- a/crypto/benches/merkle.rs
+++ b/crypto/benches/merkle.rs
@@ -12,6 +12,7 @@ use winter_crypto::{build_merkle_nodes, concurrent, hashers::Blake3_256, Hasher}
 type Blake3 = Blake3_256<BaseElement>;
 type Blake3Digest = <Blake3 as Hasher>::Digest;
 
+#[allow(clippy::needless_range_loop)]
 pub fn merkle_tree_construction(c: &mut Criterion) {
     let mut merkle_group = c.benchmark_group("merkle tree construction");
 
@@ -26,10 +27,10 @@ pub fn merkle_tree_construction(c: &mut Criterion) {
             res
         };
         merkle_group.bench_with_input(BenchmarkId::new("sequential", size), &data, |b, i| {
-            b.iter(|| build_merkle_nodes::<Blake3>(&i))
+            b.iter(|| build_merkle_nodes::<Blake3>(i))
         });
         merkle_group.bench_with_input(BenchmarkId::new("concurrent", size), &data, |b, i| {
-            b.iter(|| concurrent::build_merkle_nodes::<Blake3>(&i))
+            b.iter(|| concurrent::build_merkle_nodes::<Blake3>(i))
         });
     }
 }

--- a/crypto/src/hash/griffin/griffin64_256_jive/digest.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/digest.rs
@@ -5,7 +5,7 @@
 
 use super::{Digest, DIGEST_SIZE};
 use core::slice;
-use math::{fields::f64::BaseElement, StarkField};
+use math::fields::f64::BaseElement;
 use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // DIGEST TRAIT IMPLEMENTATIONS

--- a/crypto/src/hash/griffin/griffin64_256_jive/tests.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/tests.rs
@@ -12,6 +12,7 @@ use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};
 
+#[allow(clippy::needless_range_loop)]
 #[test]
 fn mds_inv_test() {
     let mut mul_result = [[BaseElement::new(0); STATE_WIDTH]; STATE_WIDTH];
@@ -196,15 +197,15 @@ fn apply_mds_naive(state: &mut [BaseElement; STATE_WIDTH]) {
 
 proptest! {
     #[test]
-    fn mds_freq_proptest(a in any::<[u64;STATE_WIDTH]>()) {
+    fn mds_freq_proptest(a in any::<[u64; STATE_WIDTH]>()) {
 
-        let mut v1 = [BaseElement::ZERO;STATE_WIDTH];
+        let mut v1 = [BaseElement::ZERO; STATE_WIDTH];
         let mut v2;
 
         for i in 0..STATE_WIDTH {
             v1[i] = BaseElement::new(a[i]);
         }
-        v2 = v1.clone();
+        v2 = v1;
 
         apply_mds_naive(&mut v1);
         GriffinJive64_256::apply_linear(&mut v2);

--- a/crypto/src/hash/rescue/rp64_256/digest.rs
+++ b/crypto/src/hash/rescue/rp64_256/digest.rs
@@ -5,7 +5,7 @@
 
 use super::{Digest, DIGEST_SIZE};
 use core::slice;
-use math::{fields::f64::BaseElement, StarkField};
+use math::fields::f64::BaseElement;
 use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // DIGEST TRAIT IMPLEMENTATIONS

--- a/crypto/src/hash/rescue/rp64_256/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256/tests.rs
@@ -191,15 +191,15 @@ fn apply_mds_naive(state: &mut [BaseElement; STATE_WIDTH]) {
 
 proptest! {
     #[test]
-    fn mds_freq_proptest(a in any::<[u64;STATE_WIDTH]>()) {
+    fn mds_freq_proptest(a in any::<[u64; STATE_WIDTH]>()) {
 
-        let mut v1 = [BaseElement::ZERO;STATE_WIDTH];
+        let mut v1 = [BaseElement::ZERO; STATE_WIDTH];
         let mut v2;
 
         for i in 0..STATE_WIDTH {
             v1[i] = BaseElement::new(a[i]);
         }
-        v2 = v1.clone();
+        v2 = v1;
 
         apply_mds_naive(&mut v1);
         Rp64_256::apply_mds(&mut v2);

--- a/crypto/src/hash/rescue/rp64_256_jive/digest.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/digest.rs
@@ -5,7 +5,7 @@
 
 use super::{Digest, DIGEST_SIZE};
 use core::slice;
-use math::{fields::f64::BaseElement, StarkField};
+use math::fields::f64::BaseElement;
 use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // DIGEST TRAIT IMPLEMENTATIONS

--- a/crypto/src/hash/rescue/rp64_256_jive/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/tests.rs
@@ -12,6 +12,7 @@ use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};
 
+#[allow(clippy::needless_range_loop)]
 #[test]
 fn mds_inv_test() {
     let mut mul_result = [[BaseElement::new(0); STATE_WIDTH]; STATE_WIDTH];
@@ -36,7 +37,7 @@ fn mds_inv_test() {
 #[test]
 fn test_alphas() {
     let e: BaseElement = rand_value();
-    let e_exp = e.exp(ALPHA.into());
+    let e_exp = e.exp(ALPHA);
     assert_eq!(e, e_exp.exp(INV_ALPHA));
 }
 
@@ -189,15 +190,15 @@ fn apply_mds_naive(state: &mut [BaseElement; STATE_WIDTH]) {
 
 proptest! {
     #[test]
-    fn mds_freq_proptest(a in any::<[u64;STATE_WIDTH]>()) {
+    fn mds_freq_proptest(a in any::<[u64; STATE_WIDTH]>()) {
 
-        let mut v1 = [BaseElement::ZERO;STATE_WIDTH];
+        let mut v1 = [BaseElement::ZERO; STATE_WIDTH];
         let mut v2;
 
         for i in 0..STATE_WIDTH {
             v1[i] = BaseElement::new(a[i]);
         }
-        v2 = v1.clone();
+        v2 = v1;
 
         apply_mds_naive(&mut v1);
         RpJive64_256::apply_mds(&mut v2);

--- a/crypto/src/merkle/concurrent.rs
+++ b/crypto/src/merkle/concurrent.rs
@@ -82,7 +82,7 @@ mod tests {
     proptest! {
         #[test]
         fn build_merkle_nodes_concurrent(ref data in vec(any::<[u8; 32]>(), 256..257).no_shrink()) {
-            let leaves = ByteDigest::bytes_as_digests(&data).to_vec();
+            let leaves = ByteDigest::bytes_as_digests(data).to_vec();
             let sequential = super::super::build_merkle_nodes::<Sha3_256<BaseElement>>(&leaves);
             let concurrent = super::build_merkle_nodes::<Sha3_256<BaseElement>>(&leaves);
             assert_eq!(concurrent, sequential);

--- a/examples/src/lamport/aggregate/prover.rs
+++ b/examples/src/lamport/aggregate/prover.rs
@@ -232,8 +232,8 @@ fn apply_message_acc(
     let m0_bit = state[0];
     let m1_bit = state[1];
 
-    state[0] = BaseElement::from((m0 >> (cycle_num + 1)) & 1);
-    state[1] = BaseElement::from((m1 >> (cycle_num + 1)) & 1);
+    state[0] = BaseElement::new((m0 >> (cycle_num + 1)) & 1);
+    state[1] = BaseElement::new((m1 >> (cycle_num + 1)) & 1);
     state[2] += power_of_two * m0_bit;
     state[3] += power_of_two * m1_bit;
 }

--- a/examples/src/lamport/signature.rs
+++ b/examples/src/lamport/signature.rs
@@ -187,7 +187,7 @@ pub fn message_to_elements(message: &[u8]) -> [BaseElement; 2] {
     let checksum = m0.count_zeros() + m1.count_zeros();
     let m1 = m1 | ((checksum as u128) << 119);
 
-    [BaseElement::from(m0), BaseElement::from(m1)]
+    [BaseElement::new(m0), BaseElement::new(m1)]
 }
 
 /// Reduces a list of public key elements to a single 32-byte value. The reduction is done

--- a/examples/src/lamport/threshold/air.rs
+++ b/examples/src/lamport/threshold/air.rs
@@ -228,8 +228,8 @@ impl Air for LamportThresholdAir {
         let mut m1_bits = Vec::with_capacity(SIG_CYCLE_LEN);
         for i in 0..SIG_CYCLE_LEN {
             let cycle_num = i / HASH_CYCLE_LEN;
-            m0_bits.push(BaseElement::from((m0 >> cycle_num) & 1));
-            m1_bits.push(BaseElement::from((m1 >> cycle_num) & 1));
+            m0_bits.push(BaseElement::new((m0 >> cycle_num) & 1));
+            m1_bits.push(BaseElement::new((m1 >> cycle_num) & 1));
         }
         result.push(m0_bits);
         result.push(m1_bits);

--- a/examples/src/lamport/threshold/prover.rs
+++ b/examples/src/lamport/threshold/prover.rs
@@ -245,8 +245,8 @@ fn update_sig_verification_state(
     } else {
         // for the 8th step of very cycle do the following:
 
-        let m0_bit = BaseElement::from((sig_info.m0 >> cycle_num) & 1);
-        let m1_bit = BaseElement::from((sig_info.m1 >> cycle_num) & 1);
+        let m0_bit = BaseElement::new((sig_info.m0 >> cycle_num) & 1);
+        let m1_bit = BaseElement::new((sig_info.m1 >> cycle_num) & 1);
         let mp_bit = merkle_path_idx[0];
 
         // copy next set of public keys into the registers computing hash of the public key
@@ -345,7 +345,7 @@ fn update_merkle_path_index(
     let index_bit = state[0];
     // the cycle is offset by +1 because the first node in the Merkle path is redundant and we
     // get it by hashing the public key
-    state[0] = BaseElement::from((index >> (cycle_num + 1)) & 1);
+    state[0] = BaseElement::new((index >> (cycle_num + 1)) & 1);
     state[1] += power_of_two * index_bit;
 }
 

--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -90,7 +90,7 @@ where
     // build offset inverses and twiddles used during polynomial interpolation
     let inv_offsets = get_inv_offsets(values.len(), domain_offset, N);
     let inv_twiddles = get_inv_twiddles::<B>(N);
-    let len_offset = E::inv((N as u64).into());
+    let len_offset = E::inv((N as u32).into());
 
     let mut result = unsafe { uninit_vector(values.len()) };
     iter_mut!(result)

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -57,12 +57,16 @@ where
 
 /// Interpolates `evaluations` over a domain of length `evaluations.len()` in the field specified
 /// `B` into a polynomial in coefficient form using the FFT algorithm.
+///
+/// # Panics
+/// Panics if the length of `evaluations` is greater than [u32::MAX].
 pub fn interpolate_poly<B, E>(evaluations: &mut [E], inv_twiddles: &[B])
 where
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
-    let inv_length = B::inv((evaluations.len() as u64).into());
+    assert!(evaluations.len() <= u32::MAX as usize, "too many evaluations");
+    let inv_length = B::inv((evaluations.len() as u32).into());
     evaluations.fft_in_place(inv_twiddles);
     evaluations.shift_by(inv_length);
     evaluations.permute();
@@ -71,6 +75,9 @@ where
 /// Interpolates `evaluations` over a domain of length `evaluations.len()` and shifted by
 /// `domain_offset` in the field specified by `B` into a polynomial in coefficient form using
 /// the FFT algorithm.
+///
+/// # Panics
+/// Panics if the length of `evaluations` is greater than [u32::MAX].
 pub fn interpolate_poly_with_offset<B, E>(
     evaluations: &mut [E],
     inv_twiddles: &[B],
@@ -79,11 +86,13 @@ pub fn interpolate_poly_with_offset<B, E>(
     B: StarkField,
     E: FieldElement<BaseField = B>,
 {
+    assert!(evaluations.len() <= u32::MAX as usize, "too many evaluations");
+
     evaluations.fft_in_place(inv_twiddles);
     evaluations.permute();
 
     let domain_offset = B::inv(domain_offset);
-    let offset = B::inv((evaluations.len() as u64).into());
+    let offset = B::inv((evaluations.len() as u32).into());
 
     evaluations.shift_by_series(offset, domain_offset);
 }

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -301,18 +301,6 @@ impl<B: ExtensibleField<3>> From<B> for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> From<u128> for CubeExtension<B> {
-    fn from(value: u128) -> Self {
-        Self(B::from(value), B::ZERO, B::ZERO)
-    }
-}
-
-impl<B: ExtensibleField<3>> From<u64> for CubeExtension<B> {
-    fn from(value: u64) -> Self {
-        Self(B::from(value), B::ZERO, B::ZERO)
-    }
-}
-
 impl<B: ExtensibleField<3>> From<u32> for CubeExtension<B> {
     fn from(value: u32) -> Self {
         Self(B::from(value), B::ZERO, B::ZERO)

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -295,18 +295,6 @@ impl<B: ExtensibleField<2>> From<B> for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> From<u128> for QuadExtension<B> {
-    fn from(value: u128) -> Self {
-        Self(B::from(value), B::ZERO)
-    }
-}
-
-impl<B: ExtensibleField<2>> From<u64> for QuadExtension<B> {
-    fn from(value: u64) -> Self {
-        Self(B::from(value), B::ZERO)
-    }
-}
-
 impl<B: ExtensibleField<2>> From<u32> for QuadExtension<B> {
     fn from(value: u32) -> Self {
         Self(B::from(value), B::ZERO)

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -327,14 +327,6 @@ impl ExtensibleField<3> for BaseElement {
 // TYPE CONVERSIONS
 // ================================================================================================
 
-impl From<u128> for BaseElement {
-    /// Converts a 128-bit value into a field element. If the value is greater than or equal to
-    /// the field modulus, modular reduction is silently performed.
-    fn from(value: u128) -> Self {
-        BaseElement::new(value)
-    }
-}
-
 impl From<u64> for BaseElement {
     /// Converts a 64-bit value into a field element.
     fn from(value: u64) -> Self {
@@ -360,16 +352,6 @@ impl From<u8> for BaseElement {
     /// Converts an 8-bit value into a field element.
     fn from(value: u8) -> Self {
         BaseElement(value as u128)
-    }
-}
-
-impl From<[u8; 16]> for BaseElement {
-    /// Converts the value encoded in an array of 16 bytes into a field element. The bytes
-    /// are assumed to be in little-endian byte order. If the value is greater than or equal
-    /// to the field modulus, modular reduction is silently performed.
-    fn from(bytes: [u8; 16]) -> Self {
-        let value = u128::from_le_bytes(bytes);
-        BaseElement::from(value)
     }
 }
 

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -8,7 +8,6 @@ use super::{
     StarkField, Vec, M,
 };
 use crate::field::{ExtensionOf, QuadExtension};
-use core::convert::TryFrom;
 use num_bigint::BigUint;
 use rand_utils::{rand_value, rand_vector};
 use utils::SliceReader;
@@ -26,7 +25,7 @@ fn add() {
     assert_eq!(BaseElement::from(5u8), BaseElement::from(2u8) + BaseElement::from(3u8));
 
     // test overflow
-    let t = BaseElement::from(BaseElement::MODULUS - 1);
+    let t = BaseElement::new(BaseElement::MODULUS - 1);
     assert_eq!(BaseElement::ZERO, t + BaseElement::ONE);
     assert_eq!(BaseElement::ONE, t + BaseElement::from(2u8));
 
@@ -49,7 +48,7 @@ fn sub() {
     assert_eq!(BaseElement::from(2u8), BaseElement::from(5u8) - BaseElement::from(3u8));
 
     // test underflow
-    let expected = BaseElement::from(BaseElement::MODULUS - 2);
+    let expected = BaseElement::new(BaseElement::MODULUS - 2);
     assert_eq!(expected, BaseElement::from(3u8) - BaseElement::from(5u8));
 }
 
@@ -65,13 +64,13 @@ fn mul() {
 
     // test overflow
     let m = BaseElement::MODULUS;
-    let t = BaseElement::from(m - 1);
+    let t = BaseElement::new(m - 1);
     assert_eq!(BaseElement::ONE, t * t);
-    assert_eq!(BaseElement::from(m - 2), t * BaseElement::from(2u8));
-    assert_eq!(BaseElement::from(m - 4), t * BaseElement::from(4u8));
+    assert_eq!(BaseElement::new(m - 2), t * BaseElement::from(2u8));
+    assert_eq!(BaseElement::new(m - 4), t * BaseElement::from(4u8));
 
     let t = (m + 1) / 2;
-    assert_eq!(BaseElement::ONE, BaseElement::from(t) * BaseElement::from(2u8));
+    assert_eq!(BaseElement::ONE, BaseElement::new(t) * BaseElement::from(2u8));
 
     // test random values
     let v1: Vec<BaseElement> = rand_vector(1000);
@@ -116,7 +115,7 @@ fn conjugate() {
 #[test]
 fn get_root_of_unity() {
     let root_40 = BaseElement::get_root_of_unity(40);
-    assert_eq!(BaseElement::from(23953097886125630542083529559205016746u128), root_40);
+    assert_eq!(BaseElement::new(23953097886125630542083529559205016746u128), root_40);
     assert_eq!(BaseElement::ONE, root_40.exp(u128::pow(2, 40)));
 
     let root_39 = BaseElement::get_root_of_unity(39);
@@ -251,7 +250,8 @@ impl BaseElement {
     pub fn from_big_uint(value: BigUint) -> Self {
         let bytes = value.to_bytes_le();
         let mut buffer = [0u8; 16];
-        buffer[0..bytes.len()].copy_from_slice(&bytes);
-        BaseElement::try_from(buffer).unwrap()
+        buffer[..bytes.len()].copy_from_slice(&bytes);
+        let value = u128::from_le_bytes(buffer);
+        BaseElement::new(value)
     }
 }

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -23,7 +23,7 @@ fn add() {
     assert_eq!(BaseElement::from(5u8), BaseElement::from(2u8) + BaseElement::from(3u8));
 
     // test overflow
-    let t = BaseElement::from(BaseElement::MODULUS - 1);
+    let t = BaseElement::new(BaseElement::MODULUS - 1);
     assert_eq!(BaseElement::ZERO, t + BaseElement::ONE);
     assert_eq!(BaseElement::ONE, t + BaseElement::from(2u8));
 }
@@ -38,7 +38,7 @@ fn sub() {
     assert_eq!(BaseElement::from(2u8), BaseElement::from(5u8) - BaseElement::from(3u8));
 
     // test underflow
-    let expected = BaseElement::from(BaseElement::MODULUS - 2);
+    let expected = BaseElement::new(BaseElement::MODULUS - 2);
     assert_eq!(expected, BaseElement::from(3u8) - BaseElement::from(5u8));
 }
 
@@ -54,13 +54,13 @@ fn mul() {
 
     // test overflow
     let m = BaseElement::MODULUS;
-    let t = BaseElement::from(m - 1);
+    let t = BaseElement::new(m - 1);
     assert_eq!(BaseElement::ONE, t * t);
-    assert_eq!(BaseElement::from(m - 2), t * BaseElement::from(2u8));
-    assert_eq!(BaseElement::from(m - 4), t * BaseElement::from(4u8));
+    assert_eq!(BaseElement::new(m - 2), t * BaseElement::from(2u8));
+    assert_eq!(BaseElement::new(m - 4), t * BaseElement::from(4u8));
 
     let t = (m + 1) / 2;
-    assert_eq!(BaseElement::ONE, BaseElement::from(t) * BaseElement::from(2u8));
+    assert_eq!(BaseElement::ONE, BaseElement::new(t) * BaseElement::from(2u8));
 }
 
 #[test]
@@ -213,13 +213,6 @@ fn get_root_of_unity() {
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn from_u128() {
-    let v = u128::MAX;
-    let e = BaseElement::from(v);
-    assert_eq!((v % super::M as u128) as u64, e.as_int());
-}
-
-#[test]
 fn try_from_slice() {
     let bytes = vec![1, 0, 0, 0, 0, 0, 0, 0];
     let result = BaseElement::try_from(bytes.as_slice());
@@ -303,8 +296,8 @@ proptest! {
 
     #[test]
     fn add_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let v1 = BaseElement::from(a);
-        let v2 = BaseElement::from(b);
+        let v1 = BaseElement::new(a);
+        let v2 = BaseElement::new(b);
         let result = v1 + v2;
 
         let expected = (a % super::M + b % super::M) % super::M;
@@ -313,8 +306,8 @@ proptest! {
 
     #[test]
     fn sub_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let v1 = BaseElement::from(a);
-        let v2 = BaseElement::from(b);
+        let v1 = BaseElement::new(a);
+        let v2 = BaseElement::new(b);
         let result = v1 - v2;
 
         let a = a % super::M;
@@ -326,8 +319,8 @@ proptest! {
 
     #[test]
     fn mul_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let v1 = BaseElement::from(a);
-        let v2 = BaseElement::from(b);
+        let v1 = BaseElement::new(a);
+        let v2 = BaseElement::new(b);
         let result = v1 * v2;
 
         let expected = (((a as u128) * (b as u128)) % super::M as u128) as u64;
@@ -336,7 +329,7 @@ proptest! {
 
     #[test]
     fn exp_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let result = BaseElement::from(a).exp(b);
+        let result = BaseElement::new(a).exp(b);
 
         let b = BigUint::from(b);
         let m = BigUint::from(super::M);
@@ -346,7 +339,7 @@ proptest! {
 
     #[test]
     fn inv_proptest(a in any::<u64>()) {
-        let a = BaseElement::from(a);
+        let a = BaseElement::new(a);
         let b = a.inv();
 
         let expected = if a == BaseElement::ZERO { BaseElement::ZERO } else { BaseElement::ONE };
@@ -359,17 +352,11 @@ proptest! {
         prop_assert_eq!(a % super::M, e.as_int());
     }
 
-    #[test]
-    fn from_u128_proptest(v in any::<u128>()) {
-        let e = BaseElement::from(v);
-        assert_eq!((v % super::M as u128) as u64, e.as_int());
-    }
-
     // QUADRATIC EXTENSION
     // --------------------------------------------------------------------------------------------
     #[test]
     fn quad_mul_inv_proptest(a0 in any::<u64>(), a1 in any::<u64>()) {
-        let a = QuadExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1));
+        let a = QuadExtension::<BaseElement>::new(BaseElement::new(a0), BaseElement::new(a1));
         let b = a.inv();
 
         let expected = if a == QuadExtension::<BaseElement>::ZERO {
@@ -384,7 +371,7 @@ proptest! {
     // --------------------------------------------------------------------------------------------
     #[test]
     fn cube_mul_inv_proptest(a0 in any::<u64>(), a1 in any::<u64>(), a2 in any::<u64>()) {
-        let a = CubeExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1), BaseElement::from(a2));
+        let a = CubeExtension::<BaseElement>::new(BaseElement::new(a0), BaseElement::new(a1), BaseElement::new(a2));
         let b = a.inv();
 
         let expected = if a == CubeExtension::<BaseElement>::ZERO {

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -45,7 +45,7 @@ fn sub() {
 #[test]
 fn neg() {
     assert_eq!(BaseElement::ZERO, -BaseElement::ZERO);
-    assert_eq!(BaseElement::from(super::M - 1), -BaseElement::ONE);
+    assert_eq!(BaseElement::new(super::M - 1), -BaseElement::ONE);
 
     let r: BaseElement = rand_value();
     assert_eq!(r, -(-r));
@@ -63,20 +63,20 @@ fn mul() {
 
     // test overflow
     let m = BaseElement::MODULUS;
-    let t = BaseElement::from(m - 1);
+    let t = BaseElement::new(m - 1);
     assert_eq!(BaseElement::ONE, t * t);
-    assert_eq!(BaseElement::from(m - 2), t * BaseElement::from(2u8));
-    assert_eq!(BaseElement::from(m - 4), t * BaseElement::from(4u8));
+    assert_eq!(BaseElement::new(m - 2), t * BaseElement::from(2u8));
+    assert_eq!(BaseElement::new(m - 4), t * BaseElement::from(4u8));
 
     let t = (m + 1) / 2;
-    assert_eq!(BaseElement::ONE, BaseElement::from(t) * BaseElement::from(2u8));
+    assert_eq!(BaseElement::ONE, BaseElement::new(t) * BaseElement::from(2u8));
 }
 
 #[test]
 fn mul_small() {
     // test overflow
     let m = BaseElement::MODULUS;
-    let t = BaseElement::from(m - 1);
+    let t = BaseElement::new(m - 1);
     let a = u32::MAX;
     let expected = BaseElement::new(a as u64) * t;
 
@@ -148,13 +148,6 @@ fn get_root_of_unity() {
 
 // SERIALIZATION AND DESERIALIZATION
 // ------------------------------------------------------------------------------------------------
-
-#[test]
-fn from_u128() {
-    let v = u128::MAX;
-    let e = BaseElement::from(v);
-    assert_eq!((v % super::M as u128) as u64, e.as_int());
-}
 
 #[test]
 fn try_from_slice() {
@@ -380,8 +373,8 @@ proptest! {
 
     #[test]
     fn add_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let v1 = BaseElement::from(a);
-        let v2 = BaseElement::from(b);
+        let v1 = BaseElement::new(a);
+        let v2 = BaseElement::new(b);
         let result = v1 + v2;
 
         let expected = (((a as u128) + (b as u128)) % (super::M as u128)) as u64;
@@ -390,8 +383,8 @@ proptest! {
 
     #[test]
     fn sub_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let v1 = BaseElement::from(a);
-        let v2 = BaseElement::from(b);
+        let v1 = BaseElement::new(a);
+        let v2 = BaseElement::new(b);
         let result = v1 - v2;
 
         let a = a % super::M;
@@ -403,7 +396,7 @@ proptest! {
 
     #[test]
     fn neg_proptest(a in any::<u64>()) {
-        let v = BaseElement::from(a);
+        let v = BaseElement::new(a);
         let expected = super::M - (a % super::M);
 
         prop_assert_eq!(expected, (-v).as_int());
@@ -411,8 +404,8 @@ proptest! {
 
     #[test]
     fn mul_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let v1 = BaseElement::from(a);
-        let v2 = BaseElement::from(b);
+        let v1 = BaseElement::new(a);
+        let v2 = BaseElement::new(b);
         let result = v1 * v2;
 
         let expected = (((a as u128) * (b as u128)) % super::M as u128) as u64;
@@ -421,7 +414,7 @@ proptest! {
 
     #[test]
     fn mul_small_proptest(a in any::<u64>(), b in any::<u32>()) {
-        let v1 = BaseElement::from(a);
+        let v1 = BaseElement::new(a);
         let v2 = b;
         let result = v1.mul_small(v2);
 
@@ -431,7 +424,7 @@ proptest! {
 
     #[test]
     fn double_proptest(x in any::<u64>()) {
-        let v = BaseElement::from(x);
+        let v = BaseElement::new(x);
         let result = v.double();
 
         let expected = (((x as u128) * 2) % super::M as u128) as u64;
@@ -440,7 +433,7 @@ proptest! {
 
     #[test]
     fn exp_proptest(a in any::<u64>(), b in any::<u64>()) {
-        let result = BaseElement::from(a).exp(b);
+        let result = BaseElement::new(a).exp(b);
 
         let b = BigUint::from(b);
         let m = BigUint::from(super::M);
@@ -450,7 +443,7 @@ proptest! {
 
     #[test]
     fn inv_proptest(a in any::<u64>()) {
-        let a = BaseElement::from(a);
+        let a = BaseElement::new(a);
         let b = a.inv();
 
         let expected = if a == BaseElement::ZERO { BaseElement::ZERO } else { BaseElement::ONE };
@@ -463,17 +456,11 @@ proptest! {
         prop_assert_eq!(a % super::M, e.as_int());
     }
 
-    #[test]
-    fn from_u128_proptest(v in any::<u128>()) {
-        let e = BaseElement::from(v);
-        assert_eq!((v % super::M as u128) as u64, e.as_int());
-    }
-
     // QUADRATIC EXTENSION
     // --------------------------------------------------------------------------------------------
     #[test]
     fn quad_mul_inv_proptest(a0 in any::<u64>(), a1 in any::<u64>()) {
-        let a = QuadExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1));
+        let a = QuadExtension::<BaseElement>::new(BaseElement::new(a0), BaseElement::new(a1));
         let b = a.inv();
 
         let expected = if a == QuadExtension::<BaseElement>::ZERO {
@@ -486,7 +473,7 @@ proptest! {
 
     #[test]
     fn quad_square_proptest(a0 in any::<u64>(), a1 in any::<u64>()) {
-        let a = QuadExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1));
+        let a = QuadExtension::<BaseElement>::new(BaseElement::new(a0), BaseElement::new(a1));
         let expected = a * a;
 
         prop_assert_eq!(expected, a.square());
@@ -496,7 +483,7 @@ proptest! {
     // --------------------------------------------------------------------------------------------
     #[test]
     fn cube_mul_inv_proptest(a0 in any::<u64>(), a1 in any::<u64>(), a2 in any::<u64>()) {
-        let a = CubeExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1), BaseElement::from(a2));
+        let a = CubeExtension::<BaseElement>::new(BaseElement::new(a0), BaseElement::new(a1), BaseElement::new(a2));
         let b = a.inv();
 
         let expected = if a == CubeExtension::<BaseElement>::ZERO {
@@ -509,7 +496,7 @@ proptest! {
 
     #[test]
     fn cube_square_proptest(a0 in any::<u64>(), a1 in any::<u64>(), a2 in any::<u64>()) {
-        let a = CubeExtension::<BaseElement>::new(BaseElement::from(a0), BaseElement::from(a1), BaseElement::from(a2));
+        let a = CubeExtension::<BaseElement>::new(BaseElement::new(a0), BaseElement::new(a1), BaseElement::new(a2));
         let expected = a * a;
 
         prop_assert_eq!(expected, a.square());

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -46,8 +46,6 @@ pub trait FieldElement:
     + MulAssign<Self>
     + DivAssign<Self>
     + Neg<Output = Self>
-    + From<u128>
-    + From<u64>
     + From<u32>
     + From<u16>
     + From<u8>

--- a/math/src/polynom/tests.rs
+++ b/math/src/polynom/tests.rs
@@ -12,12 +12,12 @@ use utils::collections::Vec;
 
 #[test]
 fn eval() {
-    let x = BaseElement::from(11269864713250585702u128);
+    let x = BaseElement::new(11269864713250585702u128);
     let poly: [BaseElement; 4] = [
-        BaseElement::from(384863712573444386u128),
-        BaseElement::from(7682273369345308472u128),
-        BaseElement::from(13294661765012277990u128),
-        BaseElement::from(16234810094004944758u128),
+        BaseElement::new(384863712573444386u128),
+        BaseElement::new(7682273369345308472u128),
+        BaseElement::new(13294661765012277990u128),
+        BaseElement::new(16234810094004944758u128),
     ];
 
     assert_eq!(BaseElement::ZERO, super::eval(&poly[..0], x));
@@ -40,14 +40,14 @@ fn eval() {
 #[test]
 fn add() {
     let poly1: [BaseElement; 3] = [
-        BaseElement::from(384863712573444386u128),
-        BaseElement::from(7682273369345308472u128),
-        BaseElement::from(13294661765012277990u128),
+        BaseElement::new(384863712573444386u128),
+        BaseElement::new(7682273369345308472u128),
+        BaseElement::new(13294661765012277990u128),
     ];
     let poly2: [BaseElement; 3] = [
-        BaseElement::from(9918505539874556741u128),
-        BaseElement::from(16401861429499852246u128),
-        BaseElement::from(12181445947541805654u128),
+        BaseElement::new(9918505539874556741u128),
+        BaseElement::new(16401861429499852246u128),
+        BaseElement::new(12181445947541805654u128),
     ];
 
     // same degree
@@ -66,14 +66,14 @@ fn add() {
 #[test]
 fn sub() {
     let poly1: [BaseElement; 3] = [
-        BaseElement::from(384863712573444386u128),
-        BaseElement::from(7682273369345308472u128),
-        BaseElement::from(13294661765012277990u128),
+        BaseElement::new(384863712573444386u128),
+        BaseElement::new(7682273369345308472u128),
+        BaseElement::new(13294661765012277990u128),
     ];
     let poly2: [BaseElement; 3] = [
-        BaseElement::from(9918505539874556741u128),
-        BaseElement::from(16401861429499852246u128),
-        BaseElement::from(12181445947541805654u128),
+        BaseElement::new(9918505539874556741u128),
+        BaseElement::new(16401861429499852246u128),
+        BaseElement::new(12181445947541805654u128),
     ];
 
     // same degree
@@ -92,14 +92,14 @@ fn sub() {
 #[test]
 fn mul() {
     let poly1: [BaseElement; 3] = [
-        BaseElement::from(384863712573444386u128),
-        BaseElement::from(7682273369345308472u128),
-        BaseElement::from(13294661765012277990u128),
+        BaseElement::new(384863712573444386u128),
+        BaseElement::new(7682273369345308472u128),
+        BaseElement::new(13294661765012277990u128),
     ];
     let poly2: [BaseElement; 3] = [
-        BaseElement::from(9918505539874556741u128),
-        BaseElement::from(16401861429499852246u128),
-        BaseElement::from(12181445947541805654u128),
+        BaseElement::new(9918505539874556741u128),
+        BaseElement::new(16401861429499852246u128),
+        BaseElement::new(12181445947541805654u128),
     ];
 
     // same degree
@@ -134,14 +134,14 @@ fn mul() {
 #[test]
 fn div() {
     let poly1 = vec![
-        BaseElement::from(384863712573444386u128),
-        BaseElement::from(7682273369345308472u128),
-        BaseElement::from(13294661765012277990u128),
+        BaseElement::new(384863712573444386u128),
+        BaseElement::new(7682273369345308472u128),
+        BaseElement::new(13294661765012277990u128),
     ];
     let poly2 = vec![
-        BaseElement::from(9918505539874556741u128),
-        BaseElement::from(16401861429499852246u128),
-        BaseElement::from(12181445947541805654u128),
+        BaseElement::new(9918505539874556741u128),
+        BaseElement::new(16401861429499852246u128),
+        BaseElement::new(12181445947541805654u128),
     ];
 
     // divide degree 4 by degree 2
@@ -153,8 +153,8 @@ fn div() {
     assert_eq!(poly1[..2].to_vec(), super::div(&poly3, &poly2));
 
     // divide degree 3 by degree 3
-    let poly3 = super::mul_by_scalar(&poly1, BaseElement::from(11269864713250585702u128));
-    assert_eq!(vec![BaseElement::from(11269864713250585702u128)], super::div(&poly3, &poly1));
+    let poly3 = super::mul_by_scalar(&poly1, BaseElement::new(11269864713250585702u128));
+    assert_eq!(vec![BaseElement::new(11269864713250585702u128)], super::div(&poly3, &poly1));
 }
 
 #[test]

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -229,6 +229,7 @@ mod concurrent {
 
     /// In-place recursive FFT with permuted output.
     /// Adapted from: https://github.com/0xProject/OpenZKP/tree/master/algebra/primefield/src/fft
+    #[allow(clippy::needless_range_loop)]
     pub fn split_radix_fft<B: StarkField, const N: usize>(data: &mut [[B; N]], twiddles: &[B]) {
         // generator of the domain should be in the middle of twiddles
         let n = data.len();
@@ -246,7 +247,7 @@ mod concurrent {
 
         // apply inner FFTs
         data.par_chunks_mut(outer_len)
-            .for_each(|row| row.fft_in_place_raw(&twiddles, stretch, stretch, 0));
+            .for_each(|row| row.fft_in_place_raw(twiddles, stretch, stretch, 0));
 
         // transpose inner x inner x stretch square matrix
         transpose_square_stretch(data, inner_len, stretch);
@@ -259,12 +260,12 @@ mod concurrent {
                 let mut outer_twiddle = inner_twiddle;
                 for element in row.iter_mut().skip(1) {
                     for col_idx in 0..N {
-                        element[col_idx] = element[col_idx] * outer_twiddle;
+                        element[col_idx] *= outer_twiddle;
                     }
-                    outer_twiddle = outer_twiddle * inner_twiddle;
+                    outer_twiddle *= inner_twiddle;
                 }
             }
-            row.fft_in_place(&twiddles)
+            row.fft_in_place(twiddles)
         });
     }
 


### PR DESCRIPTION
This PR addresses #230 and also does the same for `f62` and `f128` field.

Other changes in this PR:
- Cleaned up code as per clippy suggestions.
- Made some functions `const` for `f64` field.
- Added `as_int()` implementation to the `f64` field struct.