### PR TITLE
clippy: Fix lint about TryFrom & TryInto

### DIFF
--- a/crypto/src/hash/blake/mod.rs
+++ b/crypto/src/hash/blake/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ByteDigest, ElementHasher, Hasher};
-use core::{convert::TryInto, fmt::Debug, marker::PhantomData};
+use core::{fmt::Debug, marker::PhantomData};
 use math::{FieldElement, StarkField};
 use utils::ByteWriter;
 

--- a/crypto/src/hash/griffin/griffin64_256_jive/mod.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/mod.rs
@@ -5,7 +5,6 @@
 
 use super::super::mds::mds_f64_8x8::mds_multiply;
 use super::{Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use core::ops::Range;
 use math::{fields::f64::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/griffin/griffin64_256_jive/tests.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, GriffinJive64_256, Hasher, StarkField,
     INV_MDS, MDS, STATE_WIDTH,
 };
-use core::convert::TryInto;
 use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};

--- a/crypto/src/hash/rescue/rp62_248/mod.rs
+++ b/crypto/src/hash/rescue/rp62_248/mod.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{exp_acc, Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use math::{fields::f62::BaseElement, FieldElement, StarkField};
 
 mod digest;

--- a/crypto/src/hash/rescue/rp62_248/tests.rs
+++ b/crypto/src/hash/rescue/rp62_248/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, Rp62_248, ALPHA, INV_ALPHA,
     STATE_WIDTH,
 };
-use core::convert::TryInto;
 use math::StarkField;
 use rand_utils::{rand_array, rand_value};
 

--- a/crypto/src/hash/rescue/rp64_256/mod.rs
+++ b/crypto/src/hash/rescue/rp64_256/mod.rs
@@ -5,7 +5,6 @@
 
 use super::super::mds::mds_f64_12x12::mds_multiply;
 use super::{exp_acc, Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use core::ops::Range;
 use math::{fields::f64::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/rescue/rp64_256/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, Rp64_256, StarkField, ALPHA,
     INV_ALPHA, INV_MDS, MDS, STATE_WIDTH,
 };
-use core::convert::TryInto;
 use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};

--- a/crypto/src/hash/rescue/rp64_256_jive/mod.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/mod.rs
@@ -5,7 +5,6 @@
 
 use super::super::mds::mds_f64_8x8::mds_multiply;
 use super::{exp_acc, Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use core::ops::Range;
 use math::{fields::f64::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/rescue/rp64_256_jive/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, RpJive64_256, StarkField,
     ALPHA, INV_ALPHA, INV_MDS, MDS, STATE_WIDTH,
 };
-use core::convert::TryInto;
 use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};

--- a/crypto/src/random/default.rs
+++ b/crypto/src/random/default.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::RandomCoinError, Digest, ElementHasher, RandomCoin};
-use core::convert::TryInto;
 use math::{FieldElement, StarkField};
 use utils::collections::Vec;
 

--- a/examples/src/lamport/signature.rs
+++ b/examples/src/lamport/signature.rs
@@ -5,7 +5,7 @@
 
 use super::rescue::Rescue128;
 use rand_utils::prng_vector;
-use std::{cmp::Ordering, convert::TryInto};
+use std::cmp::Ordering;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement, StarkField},
     Serializable,

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -6,7 +6,7 @@
 //! Contains an implementation of FRI verifier and associated components.
 
 use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierError};
-use core::{convert::TryInto, marker::PhantomData, mem};
+use core::{marker::PhantomData, mem};
 use crypto::{ElementHasher, RandomCoin};
 use math::{polynom, FieldElement, StarkField};
 use utils::collections::Vec;

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -5,7 +5,6 @@
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
 use core::{
-    convert::TryFrom,
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -5,7 +5,6 @@
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
 use core::{
-    convert::TryFrom,
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -12,7 +12,6 @@
 
 use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
     mem,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -11,7 +11,6 @@
 
 use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
     mem,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -5,7 +5,6 @@
 
 use super::{AsBytes, BaseElement, DeserializationError, FieldElement, Serializable, StarkField};
 use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
-use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
 use rand_utils::rand_value;

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -16,7 +16,6 @@
 
 use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
     mem,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -5,7 +5,6 @@
 
 use super::{BaseElement, DeserializationError, FieldElement, Serializable, StarkField, M};
 use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
-use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
 use rand_utils::rand_value;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use core::{
-    convert::TryFrom,
     fmt::{Debug, Display},
     ops::{
         Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Shl, Shr, ShrAssign, Sub,

--- a/math/src/polynom/mod.rs
+++ b/math/src/polynom/mod.rs
@@ -149,7 +149,6 @@ where
 ///
 /// # Examples
 /// ```
-/// # use core::convert::TryInto;
 /// # use winter_math::polynom::*;
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement};
 /// # use rand_utils::rand_array;
@@ -164,7 +163,7 @@ where
 ///
 /// let polys = interpolate_batch(&x_batches, &y_batches);
 /// for ((p, xs), ys) in polys.iter().zip(x_batches).zip(y_batches) {
-///     assert_eq!(ys.to_vec(), eval_many(p, &xs));   
+///     assert_eq!(ys.to_vec(), eval_many(p, &xs));
 /// }
 /// ```
 pub fn interpolate_batch<E, const N: usize>(xs: &[[E; N]], ys: &[[E; N]]) -> Vec<[E; N]>

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -17,7 +17,7 @@ pub mod iterators;
 pub mod string;
 
 use collections::Vec;
-use core::{convert::TryInto, mem, slice};
+use core::{mem, slice};
 
 mod serde;
 pub use serde::{ByteReader, ByteWriter, Deserializable, Serializable, SliceReader};

--- a/utils/rand/src/lib.rs
+++ b/utils/rand/src/lib.rs
@@ -12,7 +12,7 @@ pub use internal::*;
 
 #[cfg(not(target_family = "wasm"))]
 mod internal {
-    use core::{convert::TryInto, fmt::Debug};
+    use core::fmt::Debug;
     use rand::prelude::*;
     use utils::Randomizable;
 


### PR DESCRIPTION
The 2021 prelude includes TryFrom and TryInto [1]. And recently the nigtlhy channel started linting for this duplicated imports and emitting warnings. This removes the redundant imports.

1: https://doc.rust-lang.org/core/prelude/rust_2021/index.html

---

Here is an example warning:

```
warning: the item `TryInto` is imported redundantly
   --> examples/src/lamport/signature.rs:8:26
    |
8   | use std::{cmp::Ordering, convert::TryInto};
    |                          ^^^^^^^^^^^^^^^^
    |
   ::: /Users/hack/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `TryInto` is already defined here
    |
    = note: `#[warn(unused_imports)]` on by default
```