### PR TITLE
Fix vec string warnings

### DIFF
--- a/air/src/air/assertions/mod.rs
+++ b/air/src/air/assertions/mod.rs
@@ -5,11 +5,11 @@
 
 use crate::errors::AssertionError;
 use core::{
-    cmp::{Ord, Ordering, PartialOrd},
+    cmp::Ordering,
     fmt::{Display, Formatter},
 };
 use math::FieldElement;
-use utils::collections::Vec;
+use utils::collections::*;
 
 #[cfg(test)]
 mod tests;

--- a/air/src/air/assertions/tests.rs
+++ b/air/src/air/assertions/tests.rs
@@ -6,7 +6,7 @@
 use super::{Assertion, AssertionError};
 use math::{fields::f128::BaseElement, FieldElement};
 use rand_utils::{rand_value, rand_vector};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // SINGLE ASSERTIONS
 // ================================================================================================

--- a/air/src/air/boundary/constraint.rs
+++ b/air/src/air/boundary/constraint.rs
@@ -3,8 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{Assertion, BTreeMap, ExtensionOf, FieldElement, Vec};
+use super::{Assertion, ExtensionOf, FieldElement};
 use math::{fft, polynom};
+use utils::collections::*;
 
 // BOUNDARY CONSTRAINT
 // ================================================================================================

--- a/air/src/air/boundary/constraint_group.rs
+++ b/air/src/air/boundary/constraint_group.rs
@@ -3,9 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{
-    Assertion, BTreeMap, BoundaryConstraint, ConstraintDivisor, ExtensionOf, FieldElement, Vec,
-};
+use super::{Assertion, BoundaryConstraint, ConstraintDivisor, ExtensionOf, FieldElement};
+use utils::collections::*;
 
 // BOUNDARY CONSTRAINT GROUP
 // ================================================================================================

--- a/air/src/air/boundary/mod.rs
+++ b/air/src/air/boundary/mod.rs
@@ -5,7 +5,7 @@
 
 use super::{AirContext, Assertion, ConstraintDivisor};
 use math::{ExtensionOf, FieldElement};
-use utils::collections::{BTreeMap, BTreeSet, Vec};
+use utils::collections::*;
 
 mod constraint;
 pub use constraint::BoundaryConstraint;

--- a/air/src/air/boundary/tests.rs
+++ b/air/src/air/boundary/tests.rs
@@ -10,7 +10,7 @@ use super::{
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin};
 use math::{fields::f64::BaseElement, polynom, FieldElement, StarkField};
 use rand_utils::{rand_value, rand_vector, shuffle};
-use utils::collections::{BTreeMap, Vec};
+use utils::collections::*;
 
 // BOUNDARY CONSTRAINT TESTS
 // ================================================================================================

--- a/air/src/air/coefficients.rs
+++ b/air/src/air/coefficients.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use math::FieldElement;
-use utils::collections::Vec;
+use utils::collections::*;
 
 // AUXILIARY TRACE SEGMENT RANDOMNESS
 // ================================================================================================

--- a/air/src/air/context.rs
+++ b/air/src/air/context.rs
@@ -6,7 +6,7 @@
 use crate::{air::TransitionConstraintDegree, ProofOptions, TraceInfo};
 use core::cmp;
 use math::StarkField;
-use utils::collections::Vec;
+use utils::collections::*;
 
 // AIR CONTEXT
 // ================================================================================================

--- a/air/src/air/divisor.rs
+++ b/air/src/air/divisor.rs
@@ -6,7 +6,7 @@
 use crate::air::Assertion;
 use core::fmt::{Display, Formatter};
 use math::{FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // CONSTRAINT DIVISOR
 // ================================================================================================

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -6,7 +6,7 @@
 use crate::ProofOptions;
 use crypto::{RandomCoin, RandomCoinError};
 use math::{fft, ExtensibleField, ExtensionOf, FieldElement, StarkField, ToElements};
-use utils::collections::{BTreeMap, Vec};
+use utils::collections::*;
 
 mod trace_info;
 pub use trace_info::{TraceInfo, TraceLayout};

--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{AuxTraceRandElements, FieldExtension};
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin};
 use math::{fields::f64::BaseElement, get_power_series, polynom, FieldElement, StarkField};
-use utils::collections::{BTreeMap, Vec};
+use utils::collections::*;
 
 // PERIODIC COLUMNS
 // ================================================================================================

--- a/air/src/air/trace_info.rs
+++ b/air/src/air/trace_info.rs
@@ -5,8 +5,8 @@
 
 use math::{StarkField, ToElements};
 use utils::{
-    collections::Vec, string::ToString, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Serializable,
+    collections::*, string::*, ByteReader, ByteWriter, Deserializable, DeserializationError,
+    Serializable,
 };
 
 // CONSTANTS

--- a/air/src/air/transition/degree.rs
+++ b/air/src/air/transition/degree.rs
@@ -3,8 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{super::super::ProofOptions, Vec, MIN_CYCLE_LENGTH};
+use super::{super::super::ProofOptions, MIN_CYCLE_LENGTH};
 use core::cmp;
+use utils::collections::*;
 
 // TRANSITION CONSTRAINT DEGREE
 // ================================================================================================

--- a/air/src/air/transition/frame.rs
+++ b/air/src/air/transition/frame.rs
@@ -3,7 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{FieldElement, Vec};
+use super::FieldElement;
+use utils::collections::*;
 
 // EVALUATION FRAME
 // ================================================================================================

--- a/air/src/air/transition/mod.rs
+++ b/air/src/air/transition/mod.rs
@@ -3,7 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{AirContext, ConstraintDivisor, ExtensionOf, FieldElement, Vec};
+use super::{AirContext, ConstraintDivisor, ExtensionOf, FieldElement};
+use utils::collections::*;
 
 mod frame;
 pub use frame::EvaluationFrame;

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -6,7 +6,7 @@
 use fri::FriOptions;
 use math::{StarkField, ToElements};
 use utils::{
-    collections::Vec, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 
 // CONSTANTS

--- a/air/src/proof/commitments.rs
+++ b/air/src/proof/commitments.rs
@@ -5,7 +5,7 @@
 
 use crypto::Hasher;
 use utils::{
-    collections::Vec, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     SliceReader,
 };
 

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -6,8 +6,8 @@
 use crate::{ProofOptions, TraceInfo, TraceLayout};
 use math::{StarkField, ToElements};
 use utils::{
-    collections::Vec, string::ToString, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Serializable,
+    collections::*, string::*, ByteReader, ByteWriter, Deserializable, DeserializationError,
+    Serializable,
 };
 
 // PROOF CONTEXT

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -11,7 +11,7 @@ use crypto::Hasher;
 use fri::FriProof;
 use math::FieldElement;
 use utils::{
-    collections::Vec, ByteReader, Deserializable, DeserializationError, Serializable, SliceReader,
+    collections::*, ByteReader, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 mod context;

--- a/air/src/proof/ood_frame.rs
+++ b/air/src/proof/ood_frame.rs
@@ -5,7 +5,7 @@
 
 use math::FieldElement;
 use utils::{
-    collections::Vec, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     SliceReader,
 };
 

--- a/air/src/proof/queries.rs
+++ b/air/src/proof/queries.rs
@@ -7,7 +7,7 @@ use super::Table;
 use crypto::{BatchMerkleProof, ElementHasher, Hasher};
 use math::FieldElement;
 use utils::{
-    collections::Vec, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     SliceReader,
 };
 

--- a/air/src/proof/table.rs
+++ b/air/src/proof/table.rs
@@ -3,9 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{DeserializationError, SliceReader, Vec};
+use super::{DeserializationError, SliceReader};
 use core::iter::FusedIterator;
 use math::FieldElement;
+use utils::collections::*;
 use utils::ByteReader;
 
 // CONSTANTS

--- a/crypto/src/hash/blake/mod.rs
+++ b/crypto/src/hash/blake/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ByteDigest, ElementHasher, Hasher};
-use core::{convert::TryInto, fmt::Debug, marker::PhantomData};
+use core::{fmt::Debug, marker::PhantomData};
 use math::{FieldElement, StarkField};
 use utils::ByteWriter;
 

--- a/crypto/src/hash/griffin/griffin64_256_jive/mod.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/mod.rs
@@ -5,7 +5,6 @@
 
 use super::super::mds::mds_f64_8x8::mds_multiply;
 use super::{Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use core::ops::Range;
 use math::{fields::f64::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/griffin/griffin64_256_jive/tests.rs
+++ b/crypto/src/hash/griffin/griffin64_256_jive/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, GriffinJive64_256, Hasher, StarkField,
     INV_MDS, MDS, STATE_WIDTH,
 };
-use core::convert::TryInto;
 use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};

--- a/crypto/src/hash/rescue/rp62_248/mod.rs
+++ b/crypto/src/hash/rescue/rp62_248/mod.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{exp_acc, Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use math::{fields::f62::BaseElement, FieldElement, StarkField};
 
 mod digest;

--- a/crypto/src/hash/rescue/rp62_248/tests.rs
+++ b/crypto/src/hash/rescue/rp62_248/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, Rp62_248, ALPHA, INV_ALPHA,
     STATE_WIDTH,
 };
-use core::convert::TryInto;
 use math::StarkField;
 use rand_utils::{rand_array, rand_value};
 

--- a/crypto/src/hash/rescue/rp64_256/mod.rs
+++ b/crypto/src/hash/rescue/rp64_256/mod.rs
@@ -5,7 +5,6 @@
 
 use super::super::mds::mds_f64_12x12::mds_multiply;
 use super::{exp_acc, Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use core::ops::Range;
 use math::{fields::f64::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/rescue/rp64_256/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, Rp64_256, StarkField, ALPHA,
     INV_ALPHA, INV_MDS, MDS, STATE_WIDTH,
 };
-use core::convert::TryInto;
 use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};

--- a/crypto/src/hash/rescue/rp64_256_jive/mod.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/mod.rs
@@ -5,7 +5,6 @@
 
 use super::super::mds::mds_f64_8x8::mds_multiply;
 use super::{exp_acc, Digest, ElementHasher, Hasher};
-use core::convert::TryInto;
 use core::ops::Range;
 use math::{fields::f64::BaseElement, FieldElement, StarkField};
 

--- a/crypto/src/hash/rescue/rp64_256_jive/tests.rs
+++ b/crypto/src/hash/rescue/rp64_256_jive/tests.rs
@@ -7,7 +7,6 @@ use super::{
     BaseElement, ElementDigest, ElementHasher, FieldElement, Hasher, RpJive64_256, StarkField,
     ALPHA, INV_ALPHA, INV_MDS, MDS, STATE_WIDTH,
 };
-use core::convert::TryInto;
 use proptest::prelude::*;
 
 use rand_utils::{rand_array, rand_value};

--- a/crypto/src/merkle/concurrent.rs
+++ b/crypto/src/merkle/concurrent.rs
@@ -5,7 +5,7 @@
 
 use crate::Hasher;
 use core::slice;
-use utils::{collections::Vec, iterators::*, rayon};
+use utils::{collections::*, iterators::*, rayon};
 
 // CONSTANTS
 // ================================================================================================

--- a/crypto/src/merkle/mod.rs
+++ b/crypto/src/merkle/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::{errors::MerkleTreeError, hash::Hasher};
 use core::slice;
-use utils::collections::{BTreeMap, BTreeSet, Vec};
+use utils::collections::*;
 
 mod proofs;
 pub use proofs::BatchMerkleProof;

--- a/crypto/src/merkle/proofs.rs
+++ b/crypto/src/merkle/proofs.rs
@@ -4,11 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::MerkleTreeError, Hasher};
-use utils::{
-    collections::{BTreeMap, Vec},
-    string::ToString,
-    ByteReader, DeserializationError, Serializable,
-};
+use utils::{collections::*, string::*, ByteReader, DeserializationError, Serializable};
 
 // CONSTANTS
 // ================================================================================================

--- a/crypto/src/random/default.rs
+++ b/crypto/src/random/default.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::RandomCoinError, Digest, ElementHasher, RandomCoin};
-use core::convert::TryInto;
 use math::{FieldElement, StarkField};
 use utils::collections::Vec;
 

--- a/crypto/src/random/default.rs
+++ b/crypto/src/random/default.rs
@@ -5,7 +5,7 @@
 
 use crate::{errors::RandomCoinError, Digest, ElementHasher, RandomCoin};
 use math::{FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // DEFAULT RANDOM COIN IMPLEMENTATION
 // ================================================================================================

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::{errors::RandomCoinError, ElementHasher, Hasher};
 use math::{FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 mod default;
 pub use default::DefaultRandomCoin;

--- a/examples/src/lamport/signature.rs
+++ b/examples/src/lamport/signature.rs
@@ -5,7 +5,7 @@
 
 use super::rescue::Rescue128;
 use rand_utils::prng_vector;
-use std::{cmp::Ordering, convert::TryInto};
+use std::cmp::Ordering;
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement, StarkField},
     Serializable,

--- a/examples/src/rescue_raps/custom_trace_table.rs
+++ b/examples/src/rescue_raps/custom_trace_table.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use core_utils::{collections::Vec, uninit_vector};
+use core_utils::{collections::*, uninit_vector};
 use winterfell::{
     math::{FieldElement, StarkField},
     matrix::ColMatrix,

--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -15,7 +15,7 @@ use math::{
     fft::{get_inv_twiddles, serial_fft},
     get_power_series_with_offset, polynom, FieldElement, StarkField,
 };
-use utils::{collections::Vec, iter_mut, uninit_vector};
+use utils::{collections::*, iter_mut, uninit_vector};
 
 // DEGREE-RESPECTING PROJECTION
 // ================================================================================================

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -6,8 +6,8 @@
 use crypto::{BatchMerkleProof, ElementHasher, Hasher};
 use math::FieldElement;
 use utils::{
-    collections::Vec, string::ToString, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Serializable, SliceReader,
+    collections::*, string::*, ByteReader, ByteWriter, Deserializable, DeserializationError,
+    Serializable, SliceReader,
 };
 
 // FRI PROOF

--- a/fri/src/prover/channel.rs
+++ b/fri/src/prover/channel.rs
@@ -6,7 +6,7 @@
 use core::marker::PhantomData;
 use crypto::{ElementHasher, Hasher, RandomCoin};
 use math::FieldElement;
-use utils::collections::Vec;
+use utils::collections::*;
 
 // PROVER CHANNEL TRAIT
 // ================================================================================================

--- a/fri/src/prover/mod.rs
+++ b/fri/src/prover/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use core::marker::PhantomData;
 use crypto::{ElementHasher, Hasher, MerkleTree};
 use math::{fft, FieldElement, StarkField};
-use utils::{collections::Vec, flatten_vector_elements, group_slice_elements, transpose_slice};
+use utils::{collections::*, flatten_vector_elements, group_slice_elements, transpose_slice};
 
 mod channel;
 pub use channel::{DefaultProverChannel, ProverChannel};

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, Hasher, RandomCoin};
 use math::{fft, fields::f128::BaseElement, FieldElement};
-use utils::{collections::Vec, Deserializable, Serializable, SliceReader};
+use utils::{collections::*, Deserializable, Serializable, SliceReader};
 
 type Blake3 = Blake3_256<BaseElement>;
 

--- a/fri/src/utils.rs
+++ b/fri/src/utils.rs
@@ -5,7 +5,7 @@
 
 use crypto::ElementHasher;
 use math::FieldElement;
-use utils::{collections::Vec, iter_mut, uninit_vector};
+use utils::{collections::*, iter_mut, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/fri/src/verifier/channel.rs
+++ b/fri/src/verifier/channel.rs
@@ -6,7 +6,7 @@
 use crate::{FriProof, VerifierError};
 use crypto::{BatchMerkleProof, ElementHasher, Hasher, MerkleTree};
 use math::FieldElement;
-use utils::{collections::Vec, group_vector_elements, DeserializationError};
+use utils::{collections::*, group_vector_elements, DeserializationError};
 
 // VERIFIER CHANNEL TRAIT
 // ================================================================================================

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -9,7 +9,7 @@ use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions
 use core::{marker::PhantomData, mem};
 use crypto::{ElementHasher, RandomCoin};
 use math::{polynom, FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 mod channel;
 pub use channel::{DefaultVerifierChannel, VerifierChannel};

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -6,7 +6,7 @@
 //! Contains an implementation of FRI verifier and associated components.
 
 use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierError};
-use core::{convert::TryInto, marker::PhantomData, mem};
+use core::{marker::PhantomData, mem};
 use crypto::{ElementHasher, RandomCoin};
 use math::{polynom, FieldElement, StarkField};
 use utils::collections::Vec;

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -5,7 +5,7 @@
 
 use super::fft_inputs::FftInputs;
 use crate::field::{FieldElement, StarkField};
-use utils::{collections::Vec, iterators::*, rayon, uninit_vector};
+use utils::{collections::*, iterators::*, rayon, uninit_vector};
 
 // POLYNOMIAL EVALUATION
 // ================================================================================================

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -24,7 +24,7 @@ mod serial;
 #[cfg(feature = "concurrent")]
 mod concurrent;
 
-use utils::collections::Vec;
+use utils::collections::*;
 
 #[cfg(test)]
 mod tests;

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -5,7 +5,7 @@
 
 use super::fft_inputs::FftInputs;
 use crate::{field::StarkField, FieldElement};
-use utils::{collections::Vec, uninit_vector};
+use utils::{collections::*, uninit_vector};
 
 // POLYNOMIAL EVALUATION
 // ================================================================================================

--- a/math/src/fft/tests.rs
+++ b/math/src/fft/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::get_power_series,
 };
 use rand_utils::rand_vector;
-use utils::collections::Vec;
+use utils::collections::*;
 
 // CORE ALGORITHMS
 // ================================================================================================

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -10,10 +10,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::Vec,
-    string::{String, ToString},
-    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
-    Serializable, SliceReader,
+    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Randomizable, Serializable, SliceReader,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -5,7 +5,6 @@
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
 use core::{
-    convert::TryFrom,
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -10,10 +10,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::Vec,
-    string::{String, ToString},
-    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
-    Serializable, SliceReader,
+    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Randomizable, Serializable, SliceReader,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -5,7 +5,6 @@
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
 use core::{
-    convert::TryFrom,
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -12,7 +12,6 @@
 
 use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
     mem,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -18,10 +18,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::Vec,
-    string::{String, ToString},
-    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
-    Serializable,
+    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Randomizable, Serializable,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -11,7 +11,6 @@
 
 use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
     mem,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -17,10 +17,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::Vec,
-    string::{String, ToString},
-    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
-    Serializable,
+    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Randomizable, Serializable,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -5,7 +5,6 @@
 
 use super::{AsBytes, BaseElement, DeserializationError, FieldElement, Serializable, StarkField};
 use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
-use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
 use rand_utils::rand_value;

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -16,7 +16,6 @@
 
 use super::{ExtensibleField, FieldElement, StarkField};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{Debug, Display, Formatter},
     mem,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -22,10 +22,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::Vec,
-    string::{String, ToString},
-    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
-    Serializable,
+    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Randomizable, Serializable,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -5,7 +5,6 @@
 
 use super::{BaseElement, DeserializationError, FieldElement, Serializable, StarkField, M};
 use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
-use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
 use rand_utils::rand_value;

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use core::{
-    convert::TryFrom,
     fmt::{Debug, Display},
     ops::{
         Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Shl, Shr, ShrAssign, Sub,

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -11,7 +11,7 @@ use core::{
     },
 };
 use utils::{
-    collections::Vec, AsBytes, Deserializable, DeserializationError, Randomizable, Serializable,
+    collections::*, AsBytes, Deserializable, DeserializationError, Randomizable, Serializable,
 };
 
 // FIELD ELEMENT

--- a/math/src/polynom/mod.rs
+++ b/math/src/polynom/mod.rs
@@ -149,7 +149,6 @@ where
 ///
 /// # Examples
 /// ```
-/// # use core::convert::TryInto;
 /// # use winter_math::polynom::*;
 /// # use winter_math::{fields::{f128::BaseElement}, FieldElement};
 /// # use rand_utils::rand_array;
@@ -164,7 +163,7 @@ where
 ///
 /// let polys = interpolate_batch(&x_batches, &y_batches);
 /// for ((p, xs), ys) in polys.iter().zip(x_batches).zip(y_batches) {
-///     assert_eq!(ys.to_vec(), eval_many(p, &xs));   
+///     assert_eq!(ys.to_vec(), eval_many(p, &xs));
 /// }
 /// ```
 pub fn interpolate_batch<E, const N: usize>(xs: &[[E; N]], ys: &[[E; N]]) -> Vec<[E; N]>

--- a/math/src/polynom/mod.rs
+++ b/math/src/polynom/mod.rs
@@ -26,7 +26,7 @@
 
 use crate::{field::FieldElement, utils::batch_inversion};
 use core::mem;
-use utils::{collections::Vec, group_vector_elements};
+use utils::{collections::*, group_vector_elements};
 
 #[cfg(test)]
 mod tests;

--- a/math/src/polynom/tests.rs
+++ b/math/src/polynom/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     field::{f128::BaseElement, FieldElement, StarkField},
     utils::get_power_series,
 };
-use utils::collections::Vec;
+use utils::collections::*;
 
 #[test]
 fn eval() {

--- a/math/src/utils/mod.rs
+++ b/math/src/utils/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{field::FieldElement, ExtensionOf};
-use utils::{batch_iter_mut, collections::Vec, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, collections::*, iter_mut, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/channel.rs
+++ b/prover/src/channel.rs
@@ -9,9 +9,9 @@ use air::{
 };
 use core::marker::PhantomData;
 use crypto::{ElementHasher, RandomCoin};
-use fri::{self, FriProof};
+use fri::FriProof;
 use math::{FieldElement, ToElements};
-use utils::collections::Vec;
+use utils::collections::*;
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/composer/mod.rs
+++ b/prover/src/composer/mod.rs
@@ -6,7 +6,7 @@
 use super::{constraints::CompositionPoly, StarkDomain, TracePolyTable};
 use air::DeepCompositionCoefficients;
 use math::{add_in_place, fft, mul_acc, polynom, ExtensionOf, FieldElement, StarkField};
-use utils::{collections::Vec, iter_mut};
+use utils::{collections::*, iter_mut};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/constraints/commitment.rs
+++ b/prover/src/constraints/commitment.rs
@@ -7,7 +7,7 @@ use super::RowMatrix;
 use air::proof::Queries;
 use crypto::{ElementHasher, MerkleTree};
 use math::FieldElement;
-use utils::collections::Vec;
+use utils::collections::*;
 
 // CONSTRAINT COMMITMENT
 // ================================================================================================

--- a/prover/src/constraints/composition_poly.rs
+++ b/prover/src/constraints/composition_poly.rs
@@ -5,7 +5,7 @@
 
 use super::{ColMatrix, StarkDomain};
 use math::{fft, polynom::degree_of, FieldElement};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // CONSTRAINT COMPOSITION POLYNOMIAL TRACE
 // ================================================================================================
@@ -139,7 +139,7 @@ fn segment<E: FieldElement>(
 mod tests {
 
     use math::fields::f128::BaseElement;
-    use utils::collections::Vec;
+    use utils::collections::*;
 
     #[test]
     fn segment() {

--- a/prover/src/constraints/evaluation_table.rs
+++ b/prover/src/constraints/evaluation_table.rs
@@ -5,7 +5,7 @@
 
 use super::{CompositionPolyTrace, ConstraintDivisor, StarkDomain};
 use math::{batch_inversion, FieldElement, StarkField};
-use utils::{batch_iter_mut, collections::Vec, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, collections::*, iter_mut, uninit_vector};
 
 #[cfg(debug_assertions)]
 use math::fft;

--- a/prover/src/constraints/evaluator/boundary.rs
+++ b/prover/src/constraints/evaluator/boundary.rs
@@ -6,7 +6,7 @@
 use super::StarkDomain;
 use air::{Air, AuxTraceRandElements, ConstraintDivisor};
 use math::{fft, ExtensionOf, FieldElement};
-use utils::collections::{BTreeMap, Vec};
+use utils::collections::*;
 
 // CONSTANTS
 // ================================================================================================

--- a/prover/src/constraints/evaluator/periodic_table.rs
+++ b/prover/src/constraints/evaluator/periodic_table.rs
@@ -5,10 +5,7 @@
 
 use air::Air;
 use math::{fft, StarkField};
-use utils::{
-    collections::{BTreeMap, Vec},
-    uninit_vector,
-};
+use utils::{collections::*, uninit_vector};
 
 pub struct PeriodicValueTable<B: StarkField> {
     values: Vec<B>,
@@ -100,7 +97,7 @@ mod tests {
     use math::{
         fields::f128::BaseElement, get_power_series_with_offset, polynom, FieldElement, StarkField,
     };
-    use utils::collections::Vec;
+    use utils::collections::*;
 
     #[test]
     fn periodic_value_table() {

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -5,7 +5,7 @@
 
 use air::Air;
 use math::{fft, get_power_series, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // TYPES AND INTERFACES
 // ================================================================================================

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -56,7 +56,7 @@ pub use utils::{
 };
 
 use fri::FriProver;
-use utils::collections::Vec;
+use utils::collections::*;
 
 pub use math;
 use math::{

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -7,7 +7,7 @@ use crate::StarkDomain;
 use core::{iter::FusedIterator, slice};
 use crypto::{ElementHasher, MerkleTree};
 use math::{fft, polynom, FieldElement};
-use utils::{batch_iter_mut, collections::Vec, iter, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, collections::*, iter, iter_mut, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -7,7 +7,7 @@ use super::{ColMatrix, Segment};
 use crate::StarkDomain;
 use crypto::{ElementHasher, MerkleTree};
 use math::{fft, FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 use utils::{batch_iter_mut, flatten_vector_elements, uninit_vector};
 
 #[cfg(feature = "concurrent")]

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -6,7 +6,7 @@
 use super::ColMatrix;
 use core::ops::Deref;
 use math::{fft::fft_inputs::FftInputs, FieldElement, StarkField};
-use utils::{collections::Vec, group_vector_elements, uninit_vector};
+use utils::{collections::*, group_vector_elements, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/matrix/tests.rs
+++ b/prover/src/matrix/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     ColMatrix, RowMatrix,
 };
 use rand_utils::rand_vector;
-use utils::collections::Vec;
+use utils::collections::*;
 
 #[test]
 fn test_eval_poly_with_offset_matrix() {

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -9,7 +9,7 @@ use air::{
     TransitionConstraintDegree,
 };
 use math::{fields::f128::BaseElement, FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // FIBONACCI TRACE BUILDER
 // ================================================================================================

--- a/prover/src/trace/poly_table.rs
+++ b/prover/src/trace/poly_table.rs
@@ -8,7 +8,7 @@ use crate::{
     ColMatrix,
 };
 use math::{FieldElement, StarkField};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // TRACE POLYNOMIAL TABLE
 // ================================================================================================

--- a/prover/src/trace/tests.rs
+++ b/prover/src/trace/tests.rs
@@ -5,7 +5,7 @@
 
 use crate::{tests::build_fib_trace, Trace};
 use math::fields::f128::BaseElement;
-use utils::collections::Vec;
+use utils::collections::*;
 
 #[test]
 fn new_trace_table() {

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -5,11 +5,12 @@
 
 use super::{
     ColMatrix, ElementHasher, EvaluationFrame, FieldElement, Hasher, Queries, StarkDomain,
-    TraceInfo, TraceLayout, TraceLde, TracePolyTable, Vec,
+    TraceInfo, TraceLayout, TraceLde, TracePolyTable,
 };
 use crate::{RowMatrix, DEFAULT_SEGMENT_WIDTH};
 use crypto::MerkleTree;
 use tracing::info_span;
+use utils::collections::*;
 
 #[cfg(test)]
 mod tests;

--- a/prover/src/trace/trace_lde/default/tests.rs
+++ b/prover/src/trace/trace_lde/default/tests.rs
@@ -12,7 +12,7 @@ use math::{
     fields::f128::BaseElement, get_power_series, get_power_series_with_offset, polynom,
     FieldElement, StarkField,
 };
-use utils::collections::Vec;
+use utils::collections::*;
 
 type Blake3 = Blake3_256<BaseElement>;
 

--- a/prover/src/trace/trace_lde/mod.rs
+++ b/prover/src/trace/trace_lde/mod.rs
@@ -7,7 +7,7 @@ use super::{ColMatrix, EvaluationFrame, FieldElement, TracePolyTable};
 use crate::StarkDomain;
 use air::{proof::Queries, TraceInfo, TraceLayout};
 use crypto::{ElementHasher, Hasher};
-use utils::collections::Vec;
+use utils::collections::*;
 
 mod default;
 pub use default::DefaultTraceLde;

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -6,10 +6,7 @@
 use super::{ColMatrix, Trace};
 use air::{EvaluationFrame, TraceInfo, TraceLayout};
 use math::{FieldElement, StarkField};
-use utils::{collections::Vec, uninit_vector};
-
-#[cfg(not(feature = "concurrent"))]
-use utils::collections::vec;
+use utils::{collections::*, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::{iterators::*, rayon};

--- a/utils/core/src/errors.rs
+++ b/utils/core/src/errors.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::string::String;
+use crate::string::*;
 use core::fmt;
 
 // DESERIALIZATION ERROR

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -17,7 +17,7 @@ pub mod iterators;
 pub mod string;
 
 use collections::Vec;
-use core::{convert::TryInto, mem, slice};
+use core::{mem, slice};
 
 mod serde;
 pub use serde::{ByteReader, ByteWriter, Deserializable, Serializable, SliceReader};

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod collections;
 pub mod iterators;
 pub mod string;
 
-use collections::Vec;
+use collections::*;
 use core::{mem, slice};
 
 mod serde;

--- a/utils/core/src/serde/byte_reader.rs
+++ b/utils/core/src/serde/byte_reader.rs
@@ -3,7 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{Deserializable, DeserializationError, String, Vec};
+use super::{Deserializable, DeserializationError};
+use crate::collections::*;
+use crate::string::*;
 
 // BYTE READER TRAIT
 // ================================================================================================

--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -3,7 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{Serializable, Vec};
+use super::Serializable;
+use crate::collections::*;
 
 // BYTE WRITER TRAIT
 // ================================================================================================

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -3,7 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{string::String, DeserializationError, Vec};
+use super::DeserializationError;
+use crate::collections::*;
 
 mod byte_reader;
 pub use byte_reader::{ByteReader, SliceReader};

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{collections::Vec, ByteReader, ByteWriter, Serializable, SliceReader};
+use super::{collections::*, ByteReader, ByteWriter, Serializable, SliceReader};
 use proptest::prelude::{any, proptest};
 
 // VECTOR UTILS TESTS

--- a/utils/rand/src/lib.rs
+++ b/utils/rand/src/lib.rs
@@ -12,7 +12,7 @@ pub use internal::*;
 
 #[cfg(not(target_family = "wasm"))]
 mod internal {
-    use core::{convert::TryInto, fmt::Debug};
+    use core::fmt::Debug;
     use rand::prelude::*;
     use utils::Randomizable;
 

--- a/verifier/src/channel.rs
+++ b/verifier/src/channel.rs
@@ -11,7 +11,7 @@ use air::{
 use crypto::{BatchMerkleProof, ElementHasher, MerkleTree};
 use fri::VerifierChannel as FriVerifierChannel;
 use math::{FieldElement, StarkField};
-use utils::{collections::Vec, string::ToString};
+use utils::{collections::*, string::*};
 
 // VERIFIER CHANNEL
 // ================================================================================================

--- a/verifier/src/composer.rs
+++ b/verifier/src/composer.rs
@@ -5,7 +5,7 @@
 
 use air::{proof::Table, Air, DeepCompositionCoefficients, EvaluationFrame};
 use math::{batch_inversion, FieldElement};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // DEEP COMPOSER
 // ================================================================================================

--- a/verifier/src/errors.rs
+++ b/verifier/src/errors.rs
@@ -6,7 +6,7 @@
 //! Contains common error types for prover and verifier.
 
 use core::fmt;
-use utils::string::String;
+use utils::string::*;
 
 // VERIFIER ERROR
 // ================================================================================================

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -5,7 +5,7 @@
 
 use air::{Air, AuxTraceRandElements, ConstraintCompositionCoefficients, EvaluationFrame};
 use math::{polynom, FieldElement};
-use utils::collections::Vec;
+use utils::collections::*;
 
 // CONSTRAINT EVALUATION
 // ================================================================================================

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -46,7 +46,7 @@ use math::{
 };
 
 pub use utils::{
-    collections::Vec, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     SliceReader,
 };
 
@@ -71,7 +71,7 @@ pub use errors::VerifierError;
 // ================================================================================================
 /// Verifies that the specified computation was executed correctly against the specified inputs.
 ///
-/// Specifically, for a computation specified by `AIR` and `HashFn` type parameter, verifies that 
+/// Specifically, for a computation specified by `AIR` and `HashFn` type parameter, verifies that
 /// the provided `proof` attests to the correct execution of the computation against public inputs
 /// specified by `pub_inputs`. If the verification is successful, `Ok(())` is returned.
 ///
@@ -86,9 +86,9 @@ pub fn verify<AIR, HashFn, RandCoin>(
     proof: StarkProof,
     pub_inputs: AIR::PublicInputs,
     acceptable_options: &AcceptableOptions,
-) -> Result<(), VerifierError> 
-where 
-    AIR: Air, 
+) -> Result<(), VerifierError>
+where
+    AIR: Air,
     HashFn: ElementHasher<BaseField = AIR::BaseField>,
     RandCoin: RandomCoin<BaseField = AIR::BaseField, Hasher = HashFn>,
 {
@@ -101,7 +101,7 @@ where
     // received from the prover
     let mut public_coin_seed = proof.context.to_elements();
     public_coin_seed.append(&mut pub_inputs.to_elements());
-    
+
     // create AIR instance for the computation specified in the proof
     let air = AIR::new(proof.get_trace_info(), pub_inputs, proof.options().clone());
 


### PR DESCRIPTION
This builds on #248 

It changes the explicit import by a wildcard. The explicit imports raised warnings:


```
error: the item `String` is imported redundantly
   --> utils/core/src/serde/byte_reader.rs:6:51
    |
6   | use super::{Deserializable, DeserializationError, String, Vec};
    |                                                   ^^^^^^
    |
   ::: /Users/hack/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:125:13
    |
125 |     pub use super::v1::*;
    |             --------- the item `String` is already defined here
    |
    = note: `-D unused-imports` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_imports)]`
```

