### PR TITLE
Support into iterator

### DIFF
--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -100,7 +100,11 @@ pub trait ByteWriter: Sized {
     /// Serializes all `elements` and writes the resulting bytes into `self`.
     ///
     /// This method does not write any metadata (e.g. number of serialized elements) into `self`.
-    fn write_many<S: Serializable>(&mut self, elements: &[S]) {
+    fn write_many<S, T>(&mut self, elements: T)
+    where
+        T: IntoIterator<Item = S>,
+        S: Serializable,
+    {
         for element in elements {
             element.write_into(self);
         }

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -16,7 +16,7 @@ pub use byte_writer::ByteWriter;
 // ================================================================================================
 
 /// Defines how to serialize `Self` into bytes.
-pub trait Serializable: Sized {
+pub trait Serializable {
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
     /// Serializes `self` into bytes and writes these bytes into the `target`.
@@ -37,6 +37,12 @@ pub trait Serializable: Sized {
     /// The default implementation returns zero.
     fn get_size_hint(&self) -> usize {
         0
+    }
+}
+
+impl<T: Serializable> Serializable for &T {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        (*self).write_into(target)
     }
 }
 
@@ -165,18 +171,6 @@ impl Serializable for usize {
 }
 
 impl<T: Serializable> Serializable for Option<T> {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        match self {
-            Some(v) => {
-                target.write_bool(true);
-                v.write_into(target);
-            }
-            None => target.write_bool(false),
-        }
-    }
-}
-
-impl<T: Serializable> Serializable for &Option<T> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         match self {
             Some(v) => {


### PR DESCRIPTION
Removes the `Sized` bound, it is no longer necessary, since https://github.com/facebook/winterfell/pull/239 .
The change above allows for `impl<T: Serializable> Serializable for &T`.
The change above allows to change `write_many` to be generic and receive a `IntoIterator` without breaking the serialization for `[T; C]`

The removal of the `Sized` bound also makes the trait object save, and allows for type erasure.
