### PR TITLE
Change fri remainder max degree to 127 for the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ pub fn prove_work() -> (BaseElement, StarkProof) {
         0,  // grinding factor
         FieldExtension::None,
         8,   // FRI folding factor
-        128, // FRI max remainder length
+        127, // FRI max remainder length
     );
 
     // Instantiate the prover and generate the proof.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ pub fn prove_work() -> (BaseElement, StarkProof) {
         0,  // grinding factor
         FieldExtension::None,
         8,   // FRI folding factor
-        127, // FRI max remainder length
+        127, // FRI remainder max degree
     );
 
     // Instantiate the prover and generate the proof.


### PR DESCRIPTION
The example outlined in the README gives an error (FRI polynomial remainder degree must be one less than a power of two).

This is caused by using wrong value of 128 for the fri_remainder_max_degree, the fri remainder has to have a number of coefficients that is power of two (therefore polynomial degree has to be one less than that) so value 127 works well.