### PR TITLE
feat: extend range of possible implementations of bytereader/bytewriter 

### DIFF
--- a/air/src/air/assertions/mod.rs
+++ b/air/src/air/assertions/mod.rs
@@ -4,12 +4,12 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::errors::AssertionError;
+use alloc::vec::Vec;
 use core::{
     cmp::Ordering,
     fmt::{Display, Formatter},
 };
 use math::FieldElement;
-use utils::collections::*;
 
 #[cfg(test)]
 mod tests;

--- a/air/src/air/assertions/tests.rs
+++ b/air/src/air/assertions/tests.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{Assertion, AssertionError};
+use alloc::vec::Vec;
 use math::{fields::f128::BaseElement, FieldElement};
 use rand_utils::{rand_value, rand_vector};
-use utils::collections::*;
 
 // SINGLE ASSERTIONS
 // ================================================================================================

--- a/air/src/air/boundary/constraint.rs
+++ b/air/src/air/boundary/constraint.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{Assertion, ExtensionOf, FieldElement};
+use alloc::{collections::BTreeMap, vec::Vec};
 use math::{fft, polynom};
-use utils::collections::*;
 
 // BOUNDARY CONSTRAINT
 // ================================================================================================

--- a/air/src/air/boundary/constraint_group.rs
+++ b/air/src/air/boundary/constraint_group.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{Assertion, BoundaryConstraint, ConstraintDivisor, ExtensionOf, FieldElement};
-use utils::collections::*;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 // BOUNDARY CONSTRAINT GROUP
 // ================================================================================================

--- a/air/src/air/boundary/mod.rs
+++ b/air/src/air/boundary/mod.rs
@@ -4,8 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{AirContext, Assertion, ConstraintDivisor};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use math::{ExtensionOf, FieldElement};
-use utils::collections::*;
 
 mod constraint;
 pub use constraint::BoundaryConstraint;

--- a/air/src/air/boundary/tests.rs
+++ b/air/src/air/boundary/tests.rs
@@ -7,10 +7,10 @@ use super::{
     super::tests::{build_prng, build_sequence_poly},
     Assertion, BoundaryConstraint,
 };
+use alloc::{collections::BTreeMap, vec::Vec};
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin};
 use math::{fields::f64::BaseElement, polynom, FieldElement, StarkField};
 use rand_utils::{rand_value, rand_vector, shuffle};
-use utils::collections::*;
 
 // BOUNDARY CONSTRAINT TESTS
 // ================================================================================================

--- a/air/src/air/coefficients.rs
+++ b/air/src/air/coefficients.rs
@@ -3,8 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use math::FieldElement;
-use utils::collections::*;
 
 // AUXILIARY TRACE SEGMENT RANDOMNESS
 // ================================================================================================

--- a/air/src/air/context.rs
+++ b/air/src/air/context.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{air::TransitionConstraintDegree, ProofOptions, TraceInfo};
+use alloc::vec::Vec;
 use core::cmp;
 use math::StarkField;
-use utils::collections::*;
 
 // AIR CONTEXT
 // ================================================================================================

--- a/air/src/air/divisor.rs
+++ b/air/src/air/divisor.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::air::Assertion;
+use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
 use math::{FieldElement, StarkField};
-use utils::collections::*;
 
 // CONSTRAINT DIVISOR
 // ================================================================================================

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::ProofOptions;
+use alloc::{collections::BTreeMap, vec::Vec};
 use crypto::{RandomCoin, RandomCoinError};
 use math::{fft, ExtensibleField, ExtensionOf, FieldElement, StarkField, ToElements};
-use utils::collections::*;
 
 mod trace_info;
 pub use trace_info::{TraceInfo, TraceLayout};

--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -8,9 +8,9 @@ use super::{
     TransitionConstraintDegree,
 };
 use crate::{AuxTraceRandElements, FieldExtension};
+use alloc::{collections::BTreeMap, vec::Vec};
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin};
 use math::{fields::f64::BaseElement, get_power_series, polynom, FieldElement, StarkField};
-use utils::collections::*;
 
 // PERIODIC COLUMNS
 // ================================================================================================

--- a/air/src/air/trace_info.rs
+++ b/air/src/air/trace_info.rs
@@ -3,11 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::{string::ToString, vec::Vec};
 use math::{StarkField, ToElements};
-use utils::{
-    collections::*, string::*, ByteReader, ByteWriter, Deserializable, DeserializationError,
-    Serializable,
-};
+use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // CONSTANTS
 // ================================================================================================

--- a/air/src/air/transition/degree.rs
+++ b/air/src/air/transition/degree.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{super::super::ProofOptions, MIN_CYCLE_LENGTH};
+use alloc::vec::Vec;
 use core::cmp;
-use utils::collections::*;
 
 // TRANSITION CONSTRAINT DEGREE
 // ================================================================================================

--- a/air/src/air/transition/frame.rs
+++ b/air/src/air/transition/frame.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::FieldElement;
-use utils::collections::*;
+use alloc::vec::Vec;
 
 // EVALUATION FRAME
 // ================================================================================================

--- a/air/src/air/transition/mod.rs
+++ b/air/src/air/transition/mod.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{AirContext, ConstraintDivisor, ExtensionOf, FieldElement};
-use utils::collections::*;
+use alloc::vec::Vec;
 
 mod frame;
 pub use frame::EvaluationFrame;

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -27,9 +27,8 @@
 //! This crate also contains components describing STARK protocol parameters ([ProofOptions]) and
 //! proof structure ([StarkProof](proof::StarkProof)).
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -3,11 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use fri::FriOptions;
 use math::{StarkField, ToElements};
-use utils::{
-    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-};
+use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // CONSTANTS
 // ================================================================================================

--- a/air/src/proof/commitments.rs
+++ b/air/src/proof/commitments.rs
@@ -3,10 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use crypto::Hasher;
 use utils::{
-    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-    SliceReader,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 // COMMITMENTS

--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -4,11 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{ProofOptions, TraceInfo, TraceLayout};
+use alloc::{string::ToString, vec::Vec};
 use math::{StarkField, ToElements};
-use utils::{
-    collections::*, string::*, ByteReader, ByteWriter, Deserializable, DeserializationError,
-    Serializable,
-};
+use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // PROOF CONTEXT
 // ================================================================================================

--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -6,13 +6,12 @@
 //! Contains STARK proof struct and associated components.
 
 use crate::{ProofOptions, TraceInfo, TraceLayout};
+use alloc::vec::Vec;
 use core::cmp;
 use crypto::Hasher;
 use fri::FriProof;
 use math::FieldElement;
-use utils::{
-    collections::*, ByteReader, Deserializable, DeserializationError, Serializable, SliceReader,
-};
+use utils::{ByteReader, Deserializable, DeserializationError, Serializable, SliceReader};
 
 mod context;
 pub use context::Context;

--- a/air/src/proof/ood_frame.rs
+++ b/air/src/proof/ood_frame.rs
@@ -3,10 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use math::FieldElement;
 use utils::{
-    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-    SliceReader,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 // TYPE ALIASES

--- a/air/src/proof/queries.rs
+++ b/air/src/proof/queries.rs
@@ -4,11 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Table;
+use alloc::vec::Vec;
 use crypto::{BatchMerkleProof, ElementHasher, Hasher};
 use math::FieldElement;
 use utils::{
-    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-    SliceReader,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 // QUERIES

--- a/air/src/proof/table.rs
+++ b/air/src/proof/table.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{DeserializationError, SliceReader};
+use alloc::vec::Vec;
 use core::iter::FusedIterator;
 use math::FieldElement;
-use utils::collections::*;
 use utils::ByteReader;
 
 // CONSTANTS

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -16,9 +16,8 @@
 //!   [RandomCoin] implementation uses a cryptographic hash function to generate pseudo-random
 //!   elements form a seed.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 

--- a/crypto/src/merkle/concurrent.rs
+++ b/crypto/src/merkle/concurrent.rs
@@ -4,8 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::Hasher;
+use alloc::vec::Vec;
 use core::slice;
-use utils::{collections::*, iterators::*, rayon};
+use utils::{iterators::*, rayon};
 
 // CONSTANTS
 // ================================================================================================

--- a/crypto/src/merkle/mod.rs
+++ b/crypto/src/merkle/mod.rs
@@ -4,8 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::MerkleTreeError, hash::Hasher};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::slice;
-use utils::collections::*;
 
 mod proofs;
 pub use proofs::BatchMerkleProof;

--- a/crypto/src/merkle/proofs.rs
+++ b/crypto/src/merkle/proofs.rs
@@ -4,7 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::MerkleTreeError, Hasher};
-use utils::{collections::*, string::*, ByteReader, DeserializationError, Serializable};
+use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+use utils::{ByteReader, DeserializationError, Serializable};
 
 // CONSTANTS
 // ================================================================================================

--- a/crypto/src/random/default.rs
+++ b/crypto/src/random/default.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::RandomCoinError, Digest, ElementHasher, RandomCoin};
+use alloc::vec::Vec;
 use math::{FieldElement, StarkField};
-use utils::collections::*;
 
 // DEFAULT RANDOM COIN IMPLEMENTATION
 // ================================================================================================

--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{errors::RandomCoinError, ElementHasher, Hasher};
+use alloc::vec::Vec;
 use math::{FieldElement, StarkField};
-use utils::collections::*;
 
 mod default;
 pub use default::DefaultRandomCoin;

--- a/examples/src/rescue_raps/custom_trace_table.rs
+++ b/examples/src/rescue_raps/custom_trace_table.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use core_utils::{collections::*, uninit_vector};
+use core_utils::uninit_vector;
 use winterfell::{
     math::{FieldElement, StarkField},
     matrix::ColMatrix,

--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -11,11 +11,12 @@
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;
 
+use alloc::vec::Vec;
 use math::{
     fft::{get_inv_twiddles, serial_fft},
     get_power_series_with_offset, polynom, FieldElement, StarkField,
 };
-use utils::{collections::*, iter_mut, uninit_vector};
+use utils::{iter_mut, uninit_vector};
 
 // DEGREE-RESPECTING PROJECTION
 // ================================================================================================

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -61,9 +61,8 @@
 //! * [DEEP-FRI: Sampling Outside the Box Improves Soundness](https://eprint.iacr.org/2019/336)
 //! * Swastik Kooparty's [talk on DEEP-FRI](https://www.youtube.com/watch?v=txo_kPSn59Y&list=PLcIyXLwiPilWvjvNkhMn283LV370Pk5CT&index=6)
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -3,11 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::{string::ToString, vec::Vec};
 use crypto::{BatchMerkleProof, ElementHasher, Hasher};
 use math::FieldElement;
 use utils::{
-    collections::*, string::*, ByteReader, ByteWriter, Deserializable, DeserializationError,
-    Serializable, SliceReader,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 // FRI PROOF

--- a/fri/src/prover/channel.rs
+++ b/fri/src/prover/channel.rs
@@ -3,10 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use crypto::{ElementHasher, Hasher, RandomCoin};
 use math::FieldElement;
-use utils::collections::*;
 
 // PROVER CHANNEL TRAIT
 // ================================================================================================

--- a/fri/src/prover/mod.rs
+++ b/fri/src/prover/mod.rs
@@ -9,10 +9,11 @@ use crate::{
     utils::hash_values,
     FriOptions,
 };
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use crypto::{ElementHasher, Hasher, MerkleTree};
 use math::{fft, FieldElement, StarkField};
-use utils::{collections::*, flatten_vector_elements, group_slice_elements, transpose_slice};
+use utils::{flatten_vector_elements, group_slice_elements, transpose_slice};
 
 mod channel;
 pub use channel::{DefaultProverChannel, ProverChannel};

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -8,9 +8,10 @@ use crate::{
     verifier::{DefaultVerifierChannel, FriVerifier},
     FriOptions, FriProof, VerifierError,
 };
+use alloc::vec::Vec;
 use crypto::{hashers::Blake3_256, DefaultRandomCoin, Hasher, RandomCoin};
 use math::{fft, fields::f128::BaseElement, FieldElement};
-use utils::{collections::*, Deserializable, Serializable, SliceReader};
+use utils::{Deserializable, Serializable, SliceReader};
 
 type Blake3 = Blake3_256<BaseElement>;
 

--- a/fri/src/utils.rs
+++ b/fri/src/utils.rs
@@ -3,9 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use crypto::ElementHasher;
 use math::FieldElement;
-use utils::{collections::*, iter_mut, uninit_vector};
+use utils::{iter_mut, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/fri/src/verifier/channel.rs
+++ b/fri/src/verifier/channel.rs
@@ -4,9 +4,10 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{FriProof, VerifierError};
+use alloc::vec::Vec;
 use crypto::{BatchMerkleProof, ElementHasher, Hasher, MerkleTree};
 use math::FieldElement;
-use utils::{collections::*, group_vector_elements, DeserializationError};
+use utils::{group_vector_elements, DeserializationError};
 
 // VERIFIER CHANNEL TRAIT
 // ================================================================================================

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -6,10 +6,10 @@
 //! Contains an implementation of FRI verifier and associated components.
 
 use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierError};
+use alloc::vec::Vec;
 use core::{marker::PhantomData, mem};
 use crypto::{ElementHasher, RandomCoin};
 use math::{polynom, FieldElement, StarkField};
-use utils::collections::*;
 
 mod channel;
 pub use channel::{DefaultVerifierChannel, VerifierChannel};

--- a/math/src/fft/concurrent.rs
+++ b/math/src/fft/concurrent.rs
@@ -5,7 +5,8 @@
 
 use super::fft_inputs::FftInputs;
 use crate::field::{FieldElement, StarkField};
-use utils::{collections::*, iterators::*, rayon, uninit_vector};
+use alloc::vec::Vec;
+use utils::{iterators::*, rayon, uninit_vector};
 
 // POLYNOMIAL EVALUATION
 // ================================================================================================

--- a/math/src/fft/mod.rs
+++ b/math/src/fft/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     field::{FieldElement, StarkField},
     utils::get_power_series,
 };
+use alloc::vec::Vec;
 
 pub mod fft_inputs;
 pub mod real_u64;
@@ -23,8 +24,6 @@ mod serial;
 
 #[cfg(feature = "concurrent")]
 mod concurrent;
-
-use utils::collections::*;
 
 #[cfg(test)]
 mod tests;

--- a/math/src/fft/serial.rs
+++ b/math/src/fft/serial.rs
@@ -5,7 +5,8 @@
 
 use super::fft_inputs::FftInputs;
 use crate::{field::StarkField, FieldElement};
-use utils::{collections::*, uninit_vector};
+use alloc::vec::Vec;
+use utils::uninit_vector;
 
 // POLYNOMIAL EVALUATION
 // ================================================================================================

--- a/math/src/fft/tests.rs
+++ b/math/src/fft/tests.rs
@@ -9,8 +9,8 @@ use crate::{
     polynom,
     utils::get_power_series,
 };
+use alloc::vec::Vec;
 use rand_utils::rand_vector;
-use utils::collections::*;
 
 // CORE ALGORITHMS
 // ================================================================================================

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -4,14 +4,18 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,
 };
 use utils::{
-    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Randomizable, Serializable, SliceReader,
+    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
+    Serializable, SliceReader,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -4,14 +4,18 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     slice,
 };
 use utils::{
-    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Randomizable, Serializable, SliceReader,
+    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
+    Serializable, SliceReader,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -11,6 +11,10 @@
 //! sub-optimal as well.
 
 use super::{ExtensibleField, FieldElement, StarkField};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     fmt::{Debug, Display, Formatter},
     mem,
@@ -18,8 +22,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Randomizable, Serializable,
+    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
+    Serializable,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -5,9 +5,9 @@
 
 use super::{AsBytes, BaseElement, ByteReader, DeserializationError, FieldElement, StarkField, M};
 use crate::field::{ExtensionOf, QuadExtension};
+use alloc::vec::Vec;
 use num_bigint::BigUint;
 use rand_utils::{rand_value, rand_vector};
-use utils::collections::*;
 use utils::SliceReader;
 
 // BASIC ALGEBRA

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -10,6 +10,10 @@
 //! stored in the Montgomery form using `u64` as the backing type.
 
 use super::{ExtensibleField, FieldElement, StarkField};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     fmt::{Debug, Display, Formatter},
     mem,
@@ -17,8 +21,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Randomizable, Serializable,
+    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
+    Serializable,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -15,6 +15,10 @@
 //! * $8$ is the 64th root of unity which opens up potential for optimized FFT implementations.
 
 use super::{ExtensibleField, FieldElement, StarkField};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     fmt::{Debug, Display, Formatter},
     mem,
@@ -22,8 +26,8 @@ use core::{
     slice,
 };
 use utils::{
-    collections::*, string::*, AsBytes, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Randomizable, Serializable,
+    AsBytes, ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable,
+    Serializable,
 };
 
 #[cfg(feature = "serde")]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
 use core::{
     fmt::{Debug, Display},
     ops::{
@@ -10,9 +11,7 @@ use core::{
         SubAssign,
     },
 };
-use utils::{
-    collections::*, AsBytes, Deserializable, DeserializationError, Randomizable, Serializable,
-};
+use utils::{AsBytes, Deserializable, DeserializationError, Randomizable, Serializable};
 
 // FIELD ELEMENT
 // ================================================================================================

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -87,9 +87,8 @@
 //!
 //! Number of threads can be configured via `RAYON_NUM_THREADS` environment variable
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 

--- a/math/src/polynom/mod.rs
+++ b/math/src/polynom/mod.rs
@@ -25,8 +25,9 @@
 //! ```
 
 use crate::{field::FieldElement, utils::batch_inversion};
+use alloc::vec::Vec;
 use core::mem;
-use utils::{collections::*, group_vector_elements};
+use utils::group_vector_elements;
 
 #[cfg(test)]
 mod tests;

--- a/math/src/polynom/tests.rs
+++ b/math/src/polynom/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     field::{f128::BaseElement, FieldElement, StarkField},
     utils::get_power_series,
 };
-use utils::collections::*;
+use alloc::vec::Vec;
 
 #[test]
 fn eval() {

--- a/math/src/utils/mod.rs
+++ b/math/src/utils/mod.rs
@@ -3,8 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::vec::Vec;
+
 use crate::{field::FieldElement, ExtensionOf};
-use utils::{batch_iter_mut, collections::*, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, iter_mut, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/channel.rs
+++ b/prover/src/channel.rs
@@ -7,11 +7,11 @@ use air::{
     proof::{Commitments, Context, OodFrame, Queries, StarkProof},
     Air, ConstraintCompositionCoefficients, DeepCompositionCoefficients,
 };
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use crypto::{ElementHasher, RandomCoin};
 use fri::FriProof;
 use math::{FieldElement, ToElements};
-use utils::collections::*;
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/composer/mod.rs
+++ b/prover/src/composer/mod.rs
@@ -5,8 +5,9 @@
 
 use super::{constraints::CompositionPoly, StarkDomain, TracePolyTable};
 use air::DeepCompositionCoefficients;
+use alloc::vec::Vec;
 use math::{add_in_place, fft, mul_acc, polynom, ExtensionOf, FieldElement, StarkField};
-use utils::{collections::*, iter_mut};
+use utils::iter_mut;
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/constraints/commitment.rs
+++ b/prover/src/constraints/commitment.rs
@@ -5,9 +5,9 @@
 
 use super::RowMatrix;
 use air::proof::Queries;
+use alloc::vec::Vec;
 use crypto::{ElementHasher, MerkleTree};
 use math::FieldElement;
-use utils::collections::*;
 
 // CONSTRAINT COMMITMENT
 // ================================================================================================

--- a/prover/src/constraints/composition_poly.rs
+++ b/prover/src/constraints/composition_poly.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ColMatrix, StarkDomain};
+use alloc::vec::Vec;
 use math::{fft, polynom::degree_of, FieldElement};
-use utils::collections::*;
 
 // CONSTRAINT COMPOSITION POLYNOMIAL TRACE
 // ================================================================================================
@@ -138,8 +138,8 @@ fn segment<E: FieldElement>(
 #[cfg(test)]
 mod tests {
 
+    use alloc::vec::Vec;
     use math::fields::f128::BaseElement;
-    use utils::collections::*;
 
     #[test]
     fn segment() {

--- a/prover/src/constraints/evaluation_table.rs
+++ b/prover/src/constraints/evaluation_table.rs
@@ -4,8 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{CompositionPolyTrace, ConstraintDivisor, StarkDomain};
+use alloc::vec::Vec;
 use math::{batch_inversion, FieldElement, StarkField};
-use utils::{batch_iter_mut, collections::*, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, iter_mut, uninit_vector};
 
 #[cfg(debug_assertions)]
 use math::fft;

--- a/prover/src/constraints/evaluator/boundary.rs
+++ b/prover/src/constraints/evaluator/boundary.rs
@@ -5,8 +5,8 @@
 
 use super::StarkDomain;
 use air::{Air, AuxTraceRandElements, ConstraintDivisor};
+use alloc::{collections::BTreeMap, vec::Vec};
 use math::{fft, ExtensionOf, FieldElement};
-use utils::collections::*;
 
 // CONSTANTS
 // ================================================================================================

--- a/prover/src/constraints/evaluator/periodic_table.rs
+++ b/prover/src/constraints/evaluator/periodic_table.rs
@@ -4,8 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use air::Air;
+use alloc::{collections::BTreeMap, vec::Vec};
 use math::{fft, StarkField};
-use utils::{collections::*, uninit_vector};
+use utils::uninit_vector;
 
 pub struct PeriodicValueTable<B: StarkField> {
     values: Vec<B>,
@@ -94,10 +95,10 @@ impl<B: StarkField> PeriodicValueTable<B> {
 mod tests {
     use crate::tests::MockAir;
     use air::Air;
+    use alloc::vec::Vec;
     use math::{
         fields::f128::BaseElement, get_power_series_with_offset, polynom, FieldElement, StarkField,
     };
-    use utils::collections::*;
 
     #[test]
     fn periodic_value_table() {

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use air::Air;
+use alloc::vec::Vec;
 use math::{fft, get_power_series, StarkField};
-use utils::collections::*;
 
 // TYPES AND INTERFACES
 // ================================================================================================

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -37,9 +37,8 @@
 //! also depends on the capabilities of the machine used to generate the proofs (i.e. on number
 //! of CPU cores and memory bandwidth).
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 
@@ -55,8 +54,8 @@ pub use utils::{
     SliceReader,
 };
 
+use alloc::vec::Vec;
 use fri::FriProver;
-use utils::collections::*;
 
 pub use math;
 use math::{

--- a/prover/src/matrix/col_matrix.rs
+++ b/prover/src/matrix/col_matrix.rs
@@ -4,10 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::StarkDomain;
+use alloc::vec::Vec;
 use core::{iter::FusedIterator, slice};
 use crypto::{ElementHasher, MerkleTree};
 use math::{fft, polynom, FieldElement};
-use utils::{batch_iter_mut, collections::*, iter, iter_mut, uninit_vector};
+use utils::{batch_iter_mut, iter, iter_mut, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/matrix/row_matrix.rs
+++ b/prover/src/matrix/row_matrix.rs
@@ -5,9 +5,9 @@
 
 use super::{ColMatrix, Segment};
 use crate::StarkDomain;
+use alloc::vec::Vec;
 use crypto::{ElementHasher, MerkleTree};
 use math::{fft, FieldElement, StarkField};
-use utils::collections::*;
 use utils::{batch_iter_mut, flatten_vector_elements, uninit_vector};
 
 #[cfg(feature = "concurrent")]

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -4,9 +4,10 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::ColMatrix;
+use alloc::vec::Vec;
 use core::ops::Deref;
 use math::{fft::fft_inputs::FftInputs, FieldElement, StarkField};
-use utils::{collections::*, group_vector_elements, uninit_vector};
+use utils::{group_vector_elements, uninit_vector};
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;

--- a/prover/src/matrix/tests.rs
+++ b/prover/src/matrix/tests.rs
@@ -7,8 +7,8 @@ use crate::{
     math::{fields::f64::BaseElement, get_power_series, polynom, StarkField},
     ColMatrix, RowMatrix,
 };
+use alloc::vec::Vec;
 use rand_utils::rand_vector;
-use utils::collections::*;
 
 #[test]
 fn test_eval_poly_with_offset_matrix() {

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -8,8 +8,8 @@ use air::{
     Air, AirContext, Assertion, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
+use alloc::vec::Vec;
 use math::{fields::f128::BaseElement, FieldElement, StarkField};
-use utils::collections::*;
 
 // FIBONACCI TRACE BUILDER
 // ================================================================================================

--- a/prover/src/trace/poly_table.rs
+++ b/prover/src/trace/poly_table.rs
@@ -7,8 +7,8 @@ use crate::{
     matrix::{ColumnIter, MultiColumnIter},
     ColMatrix,
 };
+use alloc::vec::Vec;
 use math::{FieldElement, StarkField};
-use utils::collections::*;
 
 // TRACE POLYNOMIAL TABLE
 // ================================================================================================

--- a/prover/src/trace/tests.rs
+++ b/prover/src/trace/tests.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{tests::build_fib_trace, Trace};
+use alloc::vec::Vec;
 use math::fields::f128::BaseElement;
-use utils::collections::*;
 
 #[test]
 fn new_trace_table() {

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -8,9 +8,9 @@ use super::{
     TraceInfo, TraceLayout, TraceLde, TracePolyTable,
 };
 use crate::{RowMatrix, DEFAULT_SEGMENT_WIDTH};
+use alloc::vec::Vec;
 use crypto::MerkleTree;
 use tracing::info_span;
-use utils::collections::*;
 
 #[cfg(test)]
 mod tests;

--- a/prover/src/trace/trace_lde/default/tests.rs
+++ b/prover/src/trace/trace_lde/default/tests.rs
@@ -7,12 +7,12 @@ use crate::{
     tests::{build_fib_trace, MockAir},
     DefaultTraceLde, StarkDomain, Trace, TraceLde,
 };
+use alloc::vec::Vec;
 use crypto::{hashers::Blake3_256, ElementHasher, MerkleTree};
 use math::{
     fields::f128::BaseElement, get_power_series, get_power_series_with_offset, polynom,
     FieldElement, StarkField,
 };
-use utils::collections::*;
 
 type Blake3 = Blake3_256<BaseElement>;
 

--- a/prover/src/trace/trace_lde/mod.rs
+++ b/prover/src/trace/trace_lde/mod.rs
@@ -6,8 +6,8 @@
 use super::{ColMatrix, EvaluationFrame, FieldElement, TracePolyTable};
 use crate::StarkDomain;
 use air::{proof::Queries, TraceInfo, TraceLayout};
+use alloc::vec::Vec;
 use crypto::{ElementHasher, Hasher};
-use utils::collections::*;
 
 mod default;
 pub use default::DefaultTraceLde;

--- a/prover/src/trace/trace_table.rs
+++ b/prover/src/trace/trace_table.rs
@@ -5,8 +5,9 @@
 
 use super::{ColMatrix, Trace};
 use air::{EvaluationFrame, TraceInfo, TraceLayout};
+use alloc::vec::Vec;
 use math::{FieldElement, StarkField};
-use utils::{collections::*, uninit_vector};
+use utils::uninit_vector;
 
 #[cfg(feature = "concurrent")]
 use utils::{iterators::*, rayon};
@@ -241,7 +242,10 @@ impl<B: StarkField> TraceTable<B> {
     /// Panics if `fragment_length` is smaller than 2, greater than the length of the trace,
     /// or is not a power of two.
     #[cfg(not(feature = "concurrent"))]
-    pub fn fragments(&mut self, fragment_length: usize) -> vec::IntoIter<TraceTableFragment<B>> {
+    pub fn fragments(
+        &mut self,
+        fragment_length: usize,
+    ) -> alloc::vec::IntoIter<TraceTableFragment<B>> {
         self.build_fragments(fragment_length).into_iter()
     }
 

--- a/utils/core/src/boxed.rs
+++ b/utils/core/src/boxed.rs
@@ -3,8 +3,4 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#[cfg(not(feature = "std"))]
 pub use alloc::boxed::Box;
-
-#[cfg(feature = "std")]
-pub use std::boxed::Box;

--- a/utils/core/src/collections.rs
+++ b/utils/core/src/collections.rs
@@ -4,19 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 //! Feature-based re-export of common collection components.
-//!
-//! When `std` feature is enabled, this module exports collections from the Rust standard library.
-//! When `alloc` feature is enabled, same collected are provided without relying on the Rust
-//! standard library.
 
-#[cfg(not(feature = "std"))]
 pub use alloc::collections::{btree_map, btree_set, BTreeMap, BTreeSet};
-
-#[cfg(not(feature = "std"))]
 pub use alloc::vec::{self as vec, Vec};
-
-#[cfg(feature = "std")]
-pub use std::collections::{btree_map, btree_set, BTreeMap, BTreeSet};
-
-#[cfg(feature = "std")]
-pub use std::vec::{self as vec, Vec};

--- a/utils/core/src/errors.rs
+++ b/utils/core/src/errors.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::string::*;
+use alloc::string::String;
 use core::fmt;
 
 // DESERIALIZATION ERROR

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -5,20 +5,21 @@
 
 //! This crate contains utility traits, functions, and macros used by other crates of Winterfell
 //! STARK prover and verifier.
+#![no_std]
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod boxed;
 pub mod collections;
 pub mod iterators;
 pub mod string;
 
+use alloc::vec::Vec;
 pub use boxed::*;
-use collections::*;
 use core::{mem, slice};
 
 mod serde;

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -23,6 +23,8 @@ pub use boxed::*;
 use core::{mem, slice};
 
 mod serde;
+#[cfg(feature = "std")]
+pub use serde::ReadAdapter;
 pub use serde::{ByteReader, ByteWriter, Deserializable, Serializable, SliceReader};
 
 mod errors;

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -13,13 +13,22 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[deprecated(since = "0.8.2", note = "You should prefer to import from `alloc::boxed::*`")]
 pub mod boxed;
+// TODO: Remove this when deprecation period for `boxed` module is over
+#[allow(deprecated)]
+pub use boxed::*;
+
+#[deprecated(
+    since = "0.8.2",
+    note = "You should prefer to import from `alloc::collections::*`"
+)]
 pub mod collections;
 pub mod iterators;
+#[deprecated(since = "0.8.2", note = "You should prefer to import from `alloc::string::*`")]
 pub mod string;
 
 use alloc::vec::Vec;
-pub use boxed::*;
 use core::{mem, slice};
 
 mod serde;

--- a/utils/core/src/serde/byte_reader.rs
+++ b/utils/core/src/serde/byte_reader.rs
@@ -3,9 +3,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use super::{Deserializable, DeserializationError};
-use crate::collections::*;
-use crate::string::*;
 
 // BYTE READER TRAIT
 // ================================================================================================

--- a/utils/core/src/serde/byte_reader.rs
+++ b/utils/core/src/serde/byte_reader.rs
@@ -7,6 +7,10 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+#[cfg(feature = "std")]
+use core::cell::{Ref, RefCell};
+#[cfg(feature = "std")]
+use std::io::BufRead;
 
 use super::{Deserializable, DeserializationError};
 
@@ -197,10 +201,432 @@ pub trait ByteReader {
     }
 }
 
+// STANDARD LIBRARY ADAPTER
+// ================================================================================================
+
+/// An adapter of [ByteReader] to any type that implements [std::io::Read]
+///
+/// In particular, this covers things like [std::fs::File], standard input, etc.
+#[cfg(feature = "std")]
+pub struct ReadAdapter<'a> {
+    // NOTE: The [ByteReader] trait does not currently support reader implementations that require
+    // mutation during `peek_u8`, `has_more_bytes`, and `check_eor`. These (or equivalent)
+    // operations on the standard library [std::io::BufRead] trait require a mutable reference, as
+    // it may be necessary to read from the underlying input to implement them.
+    //
+    // To handle this, we wrap the underlying reader in an [RefCell], this allows us to mutate the
+    // reader if necessary during a call to one of the above-mentioned trait methods, without
+    // sacrificing safety - at the cost of enforcing Rust's borrowing semantics dynamically.
+    //
+    // This should not be a problem in practice, except in the case where `read_slice` is called,
+    // and the reference returned is from `reader` directly, rather than `buf`. If a call to one
+    // of the above-mentioned methods is made while that reference is live, and we attempt to read
+    // from `reader`, a panic will occur.
+    //
+    // Ultimately, this should be addressed by making the [ByteReader] trait align with the standard
+    // library I/O traits, so this is a temporary solution.
+    reader: RefCell<std::io::BufReader<&'a mut dyn std::io::Read>>,
+    // A temporary buffer to store chunks read from `reader` that are larger than what is required for
+    // the higher-level [ByteReader] APIs.
+    //
+    // By default we attempt to satisfy reads from `reader` directly, but that is not always possible.
+    buf: alloc::vec::Vec<u8>,
+    // The position in `buf` at which we should start reading the next byte, when `buf` is non-empty.
+    pos: usize,
+    // This is set when we attempt to read from `reader` and get an empty buffer. This indicates that
+    // once we exhaust `buf`, we have truly reached end-of-file.
+    //
+    // We will use this to more accurately handle functions like `has_more_bytes` when this is set.
+    guaranteed_eof: bool,
+}
+
+#[cfg(feature = "std")]
+impl<'a> ReadAdapter<'a> {
+    /// Create a new [ByteReader] adapter for the given implementation of [std::io::Read]
+    pub fn new(reader: &'a mut dyn std::io::Read) -> Self {
+        Self {
+            reader: RefCell::new(std::io::BufReader::with_capacity(256, reader)),
+            buf: Default::default(),
+            pos: 0,
+            guaranteed_eof: false,
+        }
+    }
+
+    /// Get the internal adapter buffer as a (possibly empty) slice of bytes
+    #[inline(always)]
+    fn buffer(&self) -> &[u8] {
+        self.buf.get(self.pos..).unwrap_or(&[])
+    }
+
+    /// Get the internal adapter buffer as a slice of bytes, or `None` if the buffer is empty
+    #[inline(always)]
+    fn non_empty_buffer(&self) -> Option<&[u8]> {
+        self.buf.get(self.pos..).filter(|b| !b.is_empty())
+    }
+
+    /// Return the current reader buffer as a (possibly empty) slice of bytes.
+    ///
+    /// This buffer being empty _does not_ mean we're at EOF, you must call [non_empty_reader_buffer_mut] first.
+    #[inline(always)]
+    fn reader_buffer(&self) -> Ref<'_, [u8]> {
+        Ref::map(self.reader.borrow(), |r| r.buffer())
+    }
+
+    /// Return the current reader buffer, reading from the underlying reader
+    /// if the buffer is empty.
+    ///
+    /// Returns `Ok` only if the buffer is non-empty, and no errors occurred
+    /// while filling it (if filling was needed).
+    fn non_empty_reader_buffer_mut(&mut self) -> Result<&[u8], DeserializationError> {
+        use std::io::ErrorKind;
+        let buf = self.reader.get_mut().fill_buf().map_err(|e| match e.kind() {
+            ErrorKind::UnexpectedEof => DeserializationError::UnexpectedEOF,
+            e => DeserializationError::UnknownError(e.to_string()),
+        })?;
+        if buf.is_empty() {
+            self.guaranteed_eof = true;
+            Err(DeserializationError::UnexpectedEOF)
+        } else {
+            Ok(buf)
+        }
+    }
+
+    /// Same as [non_empty_reader_buffer_mut], but with dynamically-enforced
+    /// borrow check rules so that it can be called in functions like `peek_u8`.
+    ///
+    /// This comes with overhead for the dynamic checks, so you should prefer
+    /// to call [non_empty_reader_buffer_mut] if you already have a mutable
+    /// reference to `self`
+    fn non_empty_reader_buffer(&self) -> Result<Ref<'_, [u8]>, DeserializationError> {
+        use std::io::ErrorKind;
+        let mut reader = self.reader.borrow_mut();
+        let buf = reader.fill_buf().map_err(|e| match e.kind() {
+            ErrorKind::UnexpectedEof => DeserializationError::UnexpectedEOF,
+            e => DeserializationError::UnknownError(e.to_string()),
+        })?;
+        if buf.is_empty() {
+            Err(DeserializationError::UnexpectedEOF)
+        } else {
+            // Re-borrow immutably
+            drop(reader);
+            Ok(self.reader_buffer())
+        }
+    }
+
+    /// Returns true if there is sufficient capacity remaining in `buf` to hold `n` bytes
+    #[inline]
+    fn has_remaining_capacity(&self, n: usize) -> bool {
+        let remaining = self.buf.capacity() - self.buffer().len();
+        remaining >= n
+    }
+
+    /// Takes the next byte from the input, returning an error if the operation fails
+    fn pop(&mut self) -> Result<u8, DeserializationError> {
+        if let Some(byte) = self.non_empty_buffer().map(|b| b[0]) {
+            self.pos += 1;
+            return Ok(byte);
+        }
+        let result = self.non_empty_reader_buffer_mut().map(|b| b[0]);
+        if result.is_ok() {
+            self.reader.get_mut().consume(1);
+        } else {
+            self.guaranteed_eof = true;
+        }
+        result
+    }
+
+    /// Takes the next `N` bytes from the input as an array, returning an error if the operation fails
+    fn read_exact<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
+        let buf = self.buffer();
+        let mut output = [0; N];
+        match buf.len() {
+            0 => {
+                let buf = self.non_empty_reader_buffer_mut()?;
+                if buf.len() < N {
+                    return Err(DeserializationError::UnexpectedEOF);
+                }
+                // SAFETY: This copy is guaranteed to be safe, as we have validated above
+                // that `buf` has at least N bytes, and `output` is defined to be exactly
+                // N bytes.
+                unsafe {
+                    core::ptr::copy_nonoverlapping(buf.as_ptr(), output.as_mut_ptr(), N);
+                }
+                self.reader.get_mut().consume(N);
+            }
+            n if n >= N => {
+                // SAFETY: This copy is guaranteed to be safe, as we have validated above
+                // that `buf` has at least N bytes, and `output` is defined to be exactly
+                // N bytes.
+                unsafe {
+                    core::ptr::copy_nonoverlapping(buf.as_ptr(), output.as_mut_ptr(), N);
+                }
+                self.pos += N;
+            }
+            n => {
+                // We have to fill from both the local and reader buffers
+                self.non_empty_reader_buffer_mut()?;
+                let reader_buf = self.reader_buffer();
+                match reader_buf.len() {
+                    #[cfg(debug_assertions)]
+                    0 => unreachable!("expected reader buffer to be non-empty to reach here"),
+                    #[cfg(not(debug_assertions))]
+                    // SAFETY: The call to `non_empty_reader_buffer_mut` will return an error
+                    // if `reader_buffer` is non-empty, as a result is is impossible to reach
+                    // here with a length of 0.
+                    0 => unsafe { core::hint::unreachable_unchecked() },
+                    // We got enough in one request
+                    m if m + n >= N => {
+                        let needed = N - n;
+                        let dst = output.as_mut_ptr();
+                        // SAFETY: Both copies are guaranteed to be in-bounds:
+                        //
+                        // * `output` is defined to be exactly N bytes
+                        // * `buf` is guaranteed to be < N bytes
+                        // * `reader_buf` is guaranteed to have the remaining bytes needed,
+                        // and we only copy exactly that many bytes
+                        unsafe {
+                            core::ptr::copy_nonoverlapping(self.buffer().as_ptr(), dst, n);
+                            core::ptr::copy_nonoverlapping(reader_buf.as_ptr(), dst.add(n), needed);
+                            drop(reader_buf);
+                        }
+                        self.pos += n;
+                        self.reader.get_mut().consume(needed);
+                    }
+                    // We didn't get enough, but haven't necessarily reached eof yet, so fall back
+                    // to filling `self.buf`
+                    m => {
+                        let needed = N - (m + n);
+                        drop(reader_buf);
+                        self.buffer_at_least(needed)?;
+                        debug_assert!(self.buffer().len() >= N, "expected buffer to be at least {N} bytes after call to buffer_at_least");
+                        // SAFETY: This is guaranteed to be an in-bounds copy
+                        unsafe {
+                            core::ptr::copy_nonoverlapping(
+                                self.buffer().as_ptr(),
+                                output.as_mut_ptr(),
+                                N,
+                            );
+                        }
+                        self.pos += N;
+                        return Ok(output);
+                    }
+                }
+            }
+        }
+
+        // Check if we should reset our internal buffer
+        if self.buffer().is_empty() && self.pos > 0 {
+            unsafe {
+                self.buf.set_len(0);
+            }
+        }
+
+        Ok(output)
+    }
+
+    /// Fill `self.buf` with `count` bytes
+    ///
+    /// This should only be called when we can't read from the reader directly
+    fn buffer_at_least(&mut self, mut count: usize) -> Result<(), DeserializationError> {
+        // Read until we have at least `count` bytes, or until we reach end-of-file,
+        // which ever comes first.
+        loop {
+            // If we have succesfully read `count` bytes, we're done
+            if count == 0 || self.buf.len() >= count {
+                break Ok(());
+            }
+
+            // This operation will return an error if the underlying reader hits EOF
+            self.non_empty_reader_buffer_mut()?;
+
+            // Extend `self.buf` with the bytes read from the underlying reader.
+            //
+            // NOTE: We have to re-borrow the reader buffer here, since we can't get a mutable
+            // reference to `self.buf` while holding an immutable reference to the reader buffer.
+            let reader = self.reader.get_mut();
+            let buf = reader.buffer();
+            let consumed = buf.len();
+            self.buf.extend_from_slice(buf);
+            reader.consume(consumed);
+            count = count.saturating_sub(consumed);
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> ByteReader for ReadAdapter<'a> {
+    #[inline(always)]
+    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
+        self.pop()
+    }
+
+    /// NOTE: If we happen to not have any bytes buffered yet when this is called, then we will be
+    /// forced to try and read from the underlying reader. This requires a mutable reference, which
+    /// is obtained dynamically via [RefCell].
+    ///
+    /// <div class="warning">
+    /// Callers must ensure that they do not hold any immutable references to the buffer of this
+    /// reader when calling this function so as to avoid a situtation in which the dynamic borrow
+    /// check fails. Specifically, you must not be holding a reference to the result of
+    /// [Self::read_slice] when this function is called.
+    /// </div>
+    fn peek_u8(&self) -> Result<u8, DeserializationError> {
+        if let Some(byte) = self.buffer().first() {
+            return Ok(*byte);
+        }
+        self.non_empty_reader_buffer().map(|b| b[0])
+    }
+
+    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
+        // Edge case
+        if len == 0 {
+            return Ok(&[]);
+        }
+
+        // If we have unused buffer, and the consumed portion is
+        // large enough, we will move the unused portion of the buffer
+        // to the start, freeing up bytes at the end for more reads
+        // before forcing a reallocation
+        let should_optimize_storage = self.pos >= 16 && !self.has_remaining_capacity(len);
+        if should_optimize_storage {
+            // We're going to optimize storage first
+            let buf = self.buffer();
+            let src = buf.as_ptr();
+            let count = buf.len();
+            let dst = self.buf.as_mut_ptr();
+            unsafe {
+                core::ptr::copy(src, dst, count);
+                self.buf.set_len(count);
+                self.pos = 0;
+            }
+        }
+
+        // Fill the buffer so we have at least `len` bytes available,
+        // this will return an error if we hit EOF first
+        self.buffer_at_least(len)?;
+
+        Ok(&self.buffer()[0..len])
+    }
+
+    #[inline]
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
+        if N == 0 {
+            return Ok([0; N]);
+        }
+        self.read_exact()
+    }
+
+    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
+        // Do we have sufficient data in the local buffer?
+        let buffer_len = self.buffer().len();
+        if buffer_len >= num_bytes {
+            return Ok(());
+        }
+
+        // What about if we include what is in the local buffer and the reader's buffer?
+        let reader_buffer_len = self.non_empty_reader_buffer().map(|b| b.len())?;
+        let buffer_len = buffer_len + reader_buffer_len;
+        if buffer_len >= num_bytes {
+            return Ok(());
+        }
+
+        // We have no more input, thus can't fulfill a request of `num_bytes`
+        if self.guaranteed_eof {
+            return Err(DeserializationError::UnexpectedEOF);
+        }
+
+        // Because this function is read-only, we must optimistically assume we can read `num_bytes`
+        // from the input, and fail later if that does not hold. We know we're not at EOF yet, but
+        // that's all we can say without buffering more from the reader. We could make use of
+        // `buffer_at_least`, which would guarantee a correct result, but it would also impose
+        // additional restrictions on the use of this function, e.g. not using it while holding a
+        // reference returned from `read_slice`. Since it is not a memory safety violation to return
+        // an optimistic result here, it makes for a better tradeoff.
+        Ok(())
+    }
+
+    #[inline]
+    fn has_more_bytes(&self) -> bool {
+        !self.buffer().is_empty() || self.non_empty_reader_buffer().is_ok()
+    }
+}
+
+// CURSOR
+// ================================================================================================
+
+#[cfg(feature = "std")]
+macro_rules! cursor_remaining_buf {
+    ($cursor:ident) => {{
+        let buf = $cursor.get_ref().as_ref();
+        let start = $cursor.position().min(buf.len() as u64) as usize;
+        &buf[start..]
+    }};
+}
+
+#[cfg(feature = "std")]
+impl<T: AsRef<[u8]>> ByteReader for std::io::Cursor<T> {
+    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
+        let buf = cursor_remaining_buf!(self);
+        if buf.is_empty() {
+            Err(DeserializationError::UnexpectedEOF)
+        } else {
+            let byte = buf[0];
+            self.set_position(self.position() + 1);
+            Ok(byte)
+        }
+    }
+
+    fn peek_u8(&self) -> Result<u8, DeserializationError> {
+        cursor_remaining_buf!(self)
+            .first()
+            .copied()
+            .ok_or(DeserializationError::UnexpectedEOF)
+    }
+
+    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
+        let pos = self.position();
+        let size = self.get_ref().as_ref().len() as u64;
+        if size.saturating_sub(pos) < len as u64 {
+            Err(DeserializationError::UnexpectedEOF)
+        } else {
+            self.set_position(pos + len as u64);
+            let start = pos.min(size) as usize;
+            Ok(&self.get_ref().as_ref()[start..(start + len)])
+        }
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
+        self.read_slice(N).map(|bytes| {
+            let mut result = [0u8; N];
+            result.copy_from_slice(bytes);
+            result
+        })
+    }
+
+    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
+        if cursor_remaining_buf!(self).len() >= num_bytes {
+            Ok(())
+        } else {
+            Err(DeserializationError::UnexpectedEOF)
+        }
+    }
+
+    #[inline]
+    fn has_more_bytes(&self) -> bool {
+        let pos = self.position();
+        let size = self.get_ref().as_ref().len() as u64;
+        pos < size
+    }
+}
+
 // SLICE READER
 // ================================================================================================
 
 /// Implements [ByteReader] trait for a slice of bytes.
+///
+/// NOTE: If you are building with the `std` feature, you should probably prefer [std::io::Cursor]
+/// instead. However, [SliceReader] is still useful in no-std environments until stabilization of
+/// the `core_io_borrowed_buf` feature.
 pub struct SliceReader<'a> {
     source: &'a [u8],
     pos: usize,
@@ -250,5 +676,68 @@ impl<'a> ByteReader for SliceReader<'a> {
 
     fn has_more_bytes(&self) -> bool {
         self.pos < self.source.len()
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::ByteWriter;
+    use std::io::Cursor;
+
+    #[test]
+    fn read_adapter_empty() -> Result<(), DeserializationError> {
+        let mut reader = std::io::empty();
+        let mut adapter = ReadAdapter::new(&mut reader);
+        assert!(!adapter.has_more_bytes());
+        assert_eq!(adapter.check_eor(8), Err(DeserializationError::UnexpectedEOF));
+        assert_eq!(adapter.peek_u8(), Err(DeserializationError::UnexpectedEOF));
+        assert_eq!(adapter.read_u8(), Err(DeserializationError::UnexpectedEOF));
+        assert_eq!(adapter.read_slice(0), Ok([].as_slice()));
+        assert_eq!(adapter.read_slice(1), Err(DeserializationError::UnexpectedEOF));
+        assert_eq!(adapter.read_array(), Ok([]));
+        assert_eq!(adapter.read_array::<1>(), Err(DeserializationError::UnexpectedEOF));
+        Ok(())
+    }
+
+    #[test]
+    fn read_adapter_passthrough() -> Result<(), DeserializationError> {
+        let mut reader = std::io::repeat(0b101);
+        let mut adapter = ReadAdapter::new(&mut reader);
+        assert!(adapter.has_more_bytes());
+        assert_eq!(adapter.check_eor(8), Ok(()));
+        assert_eq!(adapter.peek_u8(), Ok(0b101));
+        assert_eq!(adapter.read_u8(), Ok(0b101));
+        assert_eq!(adapter.read_slice(0), Ok([].as_slice()));
+        assert_eq!(adapter.read_slice(4), Ok([0b101, 0b101, 0b101, 0b101].as_slice()));
+        assert_eq!(adapter.read_array(), Ok([]));
+        assert_eq!(adapter.read_array(), Ok([0b101, 0b101]));
+        Ok(())
+    }
+
+    #[test]
+    fn read_adapter_exact() {
+        const VALUE: usize = 2048;
+        let mut reader = Cursor::new(VALUE.to_le_bytes());
+        let mut adapter = ReadAdapter::new(&mut reader);
+        assert_eq!(usize::from_le_bytes(adapter.read_array().unwrap()), VALUE);
+        assert!(!adapter.has_more_bytes());
+        assert_eq!(adapter.peek_u8(), Err(DeserializationError::UnexpectedEOF));
+        assert_eq!(adapter.read_u8(), Err(DeserializationError::UnexpectedEOF));
+    }
+
+    #[test]
+    fn read_adapter_roundtrip() {
+        const VALUE: usize = 2048;
+
+        // Write VALUE to storage
+        let mut cursor = Cursor::new([0; core::mem::size_of::<usize>()]);
+        cursor.write_usize(VALUE);
+
+        // Read VALUE from storage
+        cursor.set_position(0);
+        let mut adapter = ReadAdapter::new(&mut cursor);
+
+        assert_eq!(adapter.read_usize(), Ok(VALUE));
     }
 }

--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Serializable;
-use crate::collections::*;
 
 // BYTE WRITER TRAIT
 // ================================================================================================
@@ -114,7 +113,7 @@ pub trait ByteWriter: Sized {
 // BYTE WRITER IMPLEMENTATIONS
 // ================================================================================================
 
-impl ByteWriter for Vec<u8> {
+impl ByteWriter for alloc::vec::Vec<u8> {
     fn write_u8(&mut self, value: u8) {
         self.push(value);
     }

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -14,6 +14,9 @@ use super::DeserializationError;
 mod byte_reader;
 pub use byte_reader::{ByteReader, SliceReader};
 
+#[cfg(feature = "std")]
+pub use byte_reader::ReadAdapter;
+
 mod byte_writer;
 pub use byte_writer::ByteWriter;
 

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -3,8 +3,13 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+    vec::Vec,
+};
+
 use super::DeserializationError;
-use crate::collections::*;
 
 mod byte_reader;
 pub use byte_reader::{ByteReader, SliceReader};

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -196,6 +196,15 @@ impl<T: Serializable, const C: usize> Serializable for [T; C] {
     }
 }
 
+impl<T: Serializable> Serializable for [T] {
+    fn write_into<W: ?Sized + ByteWriter>(&self, target: &mut W) {
+        target.write_usize(self.len());
+        for element in self.iter() {
+            element.write_into(target);
+        }
+    }
+}
+
 impl<T: Serializable> Serializable for Vec<T> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_usize(self.len());
@@ -214,6 +223,13 @@ impl<T: Serializable> Serializable for BTreeSet<T> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_usize(self.len());
         target.write_many(self);
+    }
+}
+
+impl Serializable for str {
+    fn write_into<W: ?Sized + ByteWriter>(&self, target: &mut W) {
+        target.write_usize(self.len());
+        target.write_many(self.as_bytes());
     }
 }
 

--- a/utils/core/src/string.rs
+++ b/utils/core/src/string.rs
@@ -4,13 +4,5 @@
 // LICENSE file in the root directory of this source tree.
 
 //! Feature-based re-export of common string components.
-//!
-//! When `std` feature is enabled, this module exports string components from the Rust standard
-//! library. When `alloc` feature is enabled, same components are provided without relying on the
-//! Rust standard library.
 
-#[cfg(not(feature = "std"))]
 pub use alloc::string::{String, ToString};
-
-#[cfg(feature = "std")]
-pub use std::string::{String, ToString};

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -3,7 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use super::{collections::*, ByteReader, ByteWriter, Serializable, SliceReader};
+use super::{ByteReader, ByteWriter, Serializable, SliceReader};
+use alloc::vec::Vec;
 use proptest::prelude::{any, proptest};
 
 // VECTOR UTILS TESTS
@@ -139,7 +140,7 @@ fn write_serializable_batch() {
     assert_eq!(64, target.len());
 
     let batch2 = [5u128, 6, 7, 8];
-    target.write_many(&batch2);
+    target.write_many(batch2);
     assert_eq!(128, target.len());
 
     let mut reader = SliceReader::new(&target);
@@ -157,7 +158,7 @@ fn write_serializable_array_batch() {
     assert_eq!(64, target.len());
 
     let batch2 = [[5u128, 6], [7, 8]];
-    target.write_many(&batch2);
+    target.write_many(batch2);
     assert_eq!(128, target.len());
 
     let mut reader = SliceReader::new(&target);

--- a/verifier/src/channel.rs
+++ b/verifier/src/channel.rs
@@ -8,10 +8,10 @@ use air::{
     proof::{Queries, StarkProof, Table},
     Air, EvaluationFrame,
 };
+use alloc::{string::ToString, vec::Vec};
 use crypto::{BatchMerkleProof, ElementHasher, MerkleTree};
 use fri::VerifierChannel as FriVerifierChannel;
 use math::{FieldElement, StarkField};
-use utils::{collections::*, string::*};
 
 // VERIFIER CHANNEL
 // ================================================================================================

--- a/verifier/src/composer.rs
+++ b/verifier/src/composer.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use air::{proof::Table, Air, DeepCompositionCoefficients, EvaluationFrame};
+use alloc::vec::Vec;
 use math::{batch_inversion, FieldElement};
-use utils::collections::*;
 
 // DEEP COMPOSER
 // ================================================================================================

--- a/verifier/src/errors.rs
+++ b/verifier/src/errors.rs
@@ -5,8 +5,8 @@
 
 //! Contains common error types for prover and verifier.
 
+use alloc::string::String;
 use core::fmt;
-use utils::string::*;
 
 // VERIFIER ERROR
 // ================================================================================================

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -4,8 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use air::{Air, AuxTraceRandElements, ConstraintCompositionCoefficients, EvaluationFrame};
+use alloc::vec::Vec;
 use math::{polynom, FieldElement};
-use utils::collections::*;
 
 // CONSTRAINT EVALUATION
 // ================================================================================================

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -26,9 +26,8 @@
 //! need to be in tens of thousands. And even for hundreds of thousands of asserted values, the
 //! verification time should not exceed 50 ms.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 
@@ -45,9 +44,14 @@ use math::{
     FieldElement, ToElements,
 };
 
+#[deprecated(
+    since = "0.8.2",
+    note = "You should prefer the types from libstd/liballoc instead"
+)]
+#[allow(deprecated)]
+pub use utils::collections::*;
 pub use utils::{
-    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-    SliceReader,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 pub use crypto;

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -346,7 +346,7 @@
 //!     type TraceLde<E: FieldElement<BaseField = Self::BaseField>> = DefaultTraceLde<E, Self::HashFn>;
 //!     type ConstraintEvaluator<'a, E: FieldElement<BaseField = Self::BaseField>> =
 //!         DefaultConstraintEvaluator<'a, Self::Air, E>;
-//!     
+//!
 //!     // Our public inputs consist of the first and last value in the execution trace.
 //!     fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
 //!         let last_step = trace.length() - 1;
@@ -367,7 +367,7 @@
 //!         domain: &StarkDomain<Self::BaseField>,
 //!     ) -> (Self::TraceLde<E>, TracePolyTable<E>) {
 //!         DefaultTraceLde::new(trace_info, main_trace, domain)
-//!     }    
+//!     }
 //!
 //!     fn new_evaluator<'a, E: FieldElement<BaseField = Self::BaseField>>(
 //!         &self,
@@ -507,7 +507,7 @@
 //! #    ) -> (Self::TraceLde<E>, TracePolyTable<E>) {
 //! #        DefaultTraceLde::new(trace_info, main_trace, domain)
 //! #    }
-//! #  
+//! #
 //! #    fn new_evaluator<'a, E: FieldElement<BaseField = Self::BaseField>>(
 //! #        &self,
 //! #        air: &'a Self::Air,
@@ -578,7 +578,7 @@
 //! * [Low Degree Testing](https://medium.com/starkware/low-degree-testing-f7614f5172db)
 //! * [A Framework for Efficient STARKs](https://medium.com/starkware/a-framework-for-efficient-starks-19608ba06fbe)
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 pub use prover::{
     crypto, iterators, math, matrix, Air, AirContext, Assertion, AuxTraceRandElements,


### PR DESCRIPTION
This PR contains two main changes:

1. Implement `ByteReader`/`ByteWriter` for any implementation of `std::io::Read` or `std::io::Write`, and remove the `Sized` bound on the traits, so as to support a wider array of implementations. NOTE: This is technically a breaking change for downstream crates that have their own implementations of `Serializable` and `Deserializable`, as they will need to add the `?Sized` bound to a couple of the trait methods which were overly restrictive. I don't know how problematic that is, but actually has the effect of making those traits easier to work with, so it should be a net positive. The caveat is that it probably requires a minor version bump as a result to signal the change.
2. Tweak how the `winterfell` crates are built, so that they are no-std by default, and are extended with additional features when the `std` feature is enabled, as is the recommended practice for such crates. This also comes with a deprecation of the `boxed`, `collections`, and `strings` modules (but not removal yet), as they are entirely redundant with `liballoc`.

As mentioned above, the `boxed`, `collections`, and `strings` modules of `winter-utils` are redundant. It seems the only reason they exist was due to a misunderstanding on how to set up a crate with no-std support. As part of the changes related to point 2 above, I have marked those modules as deprecated, with a helpful message informing downstream users how to address the deprecation, and updated all of the crates in the `winterfell` workspace to make use of `alloc` directly.

While many files are touched here, it's typically one or two lines per module to update the `use` statements, so should be trivial to skim through. However, I've broken up all the changes into relevant commits to make each easier to review independently. While in theory this could have been two separate PRs, I'm in a bit of a time crunch, so only had time to put this together as a single PR - hopefully that is acceptable, and that the extra work I put in to document each change in its individual commit makes up for the inconvenience.