### PR TITLE
fix: re-add unintentionally removed re-exported liballoc macros

### DIFF
--- a/utils/core/src/collections.rs
+++ b/utils/core/src/collections.rs
@@ -6,4 +6,4 @@
 //! Feature-based re-export of common collection components.
 
 pub use alloc::collections::{btree_map, btree_set, BTreeMap, BTreeSet};
-pub use alloc::vec::{self as vec, Vec};
+pub use alloc::{vec, vec::Vec};

--- a/utils/core/src/string.rs
+++ b/utils/core/src/string.rs
@@ -5,4 +5,7 @@
 
 //! Feature-based re-export of common string components.
 
-pub use alloc::string::{String, ToString};
+pub use alloc::{
+    format,
+    string::{String, ToString},
+};


### PR DESCRIPTION
With the changes in #262, the re-exports of `vec!` and `format!` macros was unintentionally removed. This is required for backwards compatibility until the deprecated `boxed`, `collections`, and `string` modules are removed.

/cc @irakliyk 