### PR TITLE
CI: check msrv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,114 +1,64 @@
 name: CI
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, repoened, synchronize]
 
 jobs:
-  check:
-    name: Check with ${{matrix.features}}
+  light-checks:
+    name: Ligth checks
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable]
-        os: [ubuntu]
-        features: [--all-features, --no-default-features]
     steps:
       - uses: actions/checkout@main
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
-          override: true
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets ${{matrix.features}}
+      - name: Clippy
+        run: |
+          rustup update --no-self-update nightly
+          rustup +nightly component add clippy
+          cargo +nightly clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings
+
+      - name: Rustfmt
+        run: |
+          rustup +nightly component add rustfmt
+          cargo +nightly fmt --all --check
+
+  check:
+    name: Check all features and all targets against the MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Perform checks
+        run: |
+          rustup update --no-self-update stable
+          cargo +stable install cargo-hack --locked
+          RUSTFLAGS=-Dwarnings cargo +stable hack --no-private --feature-powerset --keep-going check --rust-version --workspace --all-targets --verbose
 
   test:
     name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         toolchain: [stable, nightly]
-        os: [ubuntu]
     steps:
       - uses: actions/checkout@main
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
-          override: true
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - name: Install minimal nightly with clippy
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: clippy
-          override: true
-
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -D clippy::all -D warnings
-        env:
-          # Seems necessary until https://github.com/rust-lang/rust/pull/115819 is merged.
-          CARGO_INCREMENTAL: 0
-
-  rustfmt:
-    name: rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - name: Install minimal nightly with rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt
-          override: true
-
-      - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Run test
+        run: |
+          rustup update --no-self-update ${{ matrix.toolchain }}
+          cargo +${{ matrix.toolchain }} test
 
   no-std:
-    name: no-std
+    name: Build for no-std
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         toolchain: [stable, nightly]
-        target:
-          - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@main
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
-          override: true
-      - run: rustup target add wasm32-unknown-unknown
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --no-default-features --target ${{ matrix.target }}
+      - name: Build for no-std
+        run: |
+          rustup update --no-self-update ${{ matrix.toolchain }}
+          rustup +${{ matrix.toolchain }} target add wasm32-unknown-unknown
+          cargo +${{ matrix.toolchain }} build --verbose --no-default-features --target wasm32-unknown-unknown

--- a/prover/benches/lagrange_kernel.rs
+++ b/prover/benches/lagrange_kernel.rs
@@ -238,7 +238,6 @@ impl Prover for LagrangeProver {
         DefaultConstraintEvaluator<'a, LagrangeKernelAir, E>;
 
     fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
-        ()
     }
 
     fn options(&self) -> &ProofOptions {

--- a/prover/src/trace/trace_lde/default/tests.rs
+++ b/prover/src/trace/trace_lde/default/tests.rs
@@ -26,7 +26,7 @@ fn extend_trace_table() {
 
     // build the trace polynomials, extended trace, and commitment using the default TraceLde impl
     let (trace_lde, trace_polys) =
-        DefaultTraceLde::<BaseElement, Blake3>::new(&trace.info(), trace.main_segment(), &domain);
+        DefaultTraceLde::<BaseElement, Blake3>::new(trace.info(), trace.main_segment(), &domain);
 
     // check the width and length of the extended trace
     assert_eq!(2, trace_lde.main_segment_width());
@@ -73,7 +73,7 @@ fn commit_trace_table() {
 
     // build the trace polynomials, extended trace, and commitment using the default TraceLde impl
     let (trace_lde, _) =
-        DefaultTraceLde::<BaseElement, Blake3>::new(&trace.info(), trace.main_segment(), &domain);
+        DefaultTraceLde::<BaseElement, Blake3>::new(trace.info(), trace.main_segment(), &domain);
 
     // build Merkle tree from trace rows
     let mut hashed_states = Vec::new();

--- a/utils/core/src/serde/byte_reader.rs
+++ b/utils/core/src/serde/byte_reader.rs
@@ -3,16 +3,15 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use super::{Deserializable, DeserializationError};
+use alloc::{string::String, vec::Vec};
+
+#[cfg(feature = "std")]
+use alloc::string::ToString;
 #[cfg(feature = "std")]
 use core::cell::{Ref, RefCell};
 #[cfg(feature = "std")]
 use std::io::BufRead;
-
-use super::{Deserializable, DeserializationError};
 
 // BYTE READER TRAIT
 // ================================================================================================

--- a/winterfell/src/tests.rs
+++ b/winterfell/src/tests.rs
@@ -201,7 +201,6 @@ impl Prover for LagrangeSimpleProver {
         DefaultConstraintEvaluator<'a, LagrangeKernelSimpleAir, E>;
 
     fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
-        ()
     }
 
     fn options(&self) -> &ProofOptions {
@@ -445,7 +444,6 @@ impl Prover for LagrangeComplexProver {
         DefaultConstraintEvaluator<'a, LagrangeKernelComplexAir, E>;
 
     fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
-        ()
     }
 
     fn options(&self) -> &ProofOptions {


### PR DESCRIPTION
- [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) is no longer maintained and it is now an archived project
- there is no official action for rust, but now the GH action image include rustup natively, so the changes bellow uses rustup directly (this is the strategy from projects like [`rust-analyzer`](https://github.com/rust-lang/rust-analyzer/blob/99718d0c8bc5aadd993acdcabc1778fc7b5cc572/.github/workflows/ci.yaml#L63-L67))
- the main change here is adding the `cargo-hack` tool. Using that tool mainly because it is recommended in the [cargo book](https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version)
    - This is basically a wrapper around `cargo check`, which checks every combination of features. It is fast enough that it should be done before the tests.
    - It runs using the compiler with the `rust-version`, which checks the setting is correct (it doesn't guarantee it is the lowest MSRV, but it does check that the setting is a valid MSRV)
- This fixes a typo in the CI trigger condition, it was `repoened`. Now it just uses the default which are [ref](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request):

> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened