### PR TITLE
Remove un-needed vector utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.0 (2024-05-09)
+- [BREAKING] removed `group_vector_elements()` utility function (TBD).
+
 ## 0.8.4 (2024-03-18) - `utils/core` crate only
 * Re-added unintentionally removed re-exported liballoc macros (#263).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.9.0 (2024-05-09)
 - [BREAKING] removed `group_vector_elements()` utility function (TBD).
+- [BREAKING] removed `FieldElement::zeroed_vector()` function (TBD).
 
 ## 0.8.4 (2024-03-18) - `utils/core` crate only
 * Re-added unintentionally removed re-exported liballoc macros (#263).

--- a/air/src/air/lagrange/transition.rs
+++ b/air/src/air/lagrange/transition.rs
@@ -110,7 +110,7 @@ impl<E: FieldElement> LagrangeKernelTransitionConstraints<E> {
     // HELPERS
     // ---------------------------------------------------------------------------------------------
 
-    /// Evaluates the transition constraints' numerators over the specificed Lagrange kernel
+    /// Evaluates the transition constraints' numerators over the specified Lagrange kernel
     /// evaluation frame.
     fn evaluate_numerators<F>(
         &self,
@@ -122,7 +122,7 @@ impl<E: FieldElement> LagrangeKernelTransitionConstraints<E> {
         E: ExtensionOf<F>,
     {
         let log2_trace_len = lagrange_kernel_column_frame.num_rows() - 1;
-        let mut transition_evals = E::zeroed_vector(log2_trace_len);
+        let mut transition_evals = vec![E::ZERO; log2_trace_len];
 
         let c = lagrange_kernel_column_frame.inner();
         let v = c.len() - 1;

--- a/air/src/air/transition/frame.rs
+++ b/air/src/air/transition/frame.rs
@@ -31,8 +31,8 @@ impl<E: FieldElement> EvaluationFrame<E> {
     pub fn new(num_columns: usize) -> Self {
         assert!(num_columns > 0, "number of columns must be greater than zero");
         EvaluationFrame {
-            current: E::zeroed_vector(num_columns),
-            next: E::zeroed_vector(num_columns),
+            current: vec![E::ZERO; num_columns],
+            next: vec![E::ZERO; num_columns],
         }
     }
 

--- a/examples/src/rescue/rescue.rs
+++ b/examples/src/rescue/rescue.rs
@@ -19,7 +19,7 @@ const CYCLE_LENGTH: usize = 16;
 /// Implementation of Rescue hash function with a 4 element state and 14 rounds. Accepts a
 /// 2-element input, and returns a 2-element digest.
 pub fn hash(value: [BaseElement; 2], result: &mut [BaseElement]) {
-    let mut state = BaseElement::zeroed_vector(STATE_WIDTH);
+    let mut state = [BaseElement::ZERO; STATE_WIDTH];
     state[..2].copy_from_slice(&value);
     for i in 0..NUM_ROUNDS {
         apply_round(&mut state, i);

--- a/fri/benches/folding.rs
+++ b/fri/benches/folding.rs
@@ -6,7 +6,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use math::{fields::f128::BaseElement, get_power_series, polynom, StarkField};
 use rand_utils::{rand_value, rand_vector};
-use utils::group_vector_elements;
+use utils::group_slice_elements;
 use winter_fri::folding;
 
 static BATCH_SIZES: [usize; 3] = [65536, 131072, 262144];
@@ -42,7 +42,7 @@ criterion_main!(quartic_group);
 
 fn build_coordinate_batches(batch_size: usize) -> (Vec<[BaseElement; 4]>, Vec<[BaseElement; 4]>) {
     let r = BaseElement::get_root_of_unity(batch_size.ilog2());
-    let xs = group_vector_elements(get_power_series(r, batch_size));
-    let ys = group_vector_elements(rand_vector::<BaseElement>(batch_size));
+    let xs = group_slice_elements(&get_power_series(r, batch_size)).to_vec();
+    let ys = group_slice_elements(&rand_vector::<BaseElement>(batch_size)).to_vec();
     (xs, ys)
 }

--- a/fri/src/verifier/channel.rs
+++ b/fri/src/verifier/channel.rs
@@ -7,7 +7,7 @@ use crate::{FriProof, VerifierError};
 use alloc::vec::Vec;
 use crypto::{BatchMerkleProof, ElementHasher, Hasher, MerkleTree};
 use math::FieldElement;
-use utils::{group_vector_elements, DeserializationError};
+use utils::{group_slice_elements, DeserializationError};
 
 // VERIFIER CHANNEL TRAIT
 // ================================================================================================
@@ -88,7 +88,7 @@ pub trait VerifierChannel<E: FieldElement> {
         // TODO: make sure layer queries hash into leaves of layer proof
 
         let layer_queries = self.take_next_fri_layer_queries();
-        Ok(group_vector_elements(layer_queries))
+        Ok(group_slice_elements(&layer_queries).to_vec())
     }
 
     /// Returns FRI remainder polynomial read from this channel.

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -4,10 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::string::{String, ToString};
 use core::{
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -43,22 +40,6 @@ impl<B: ExtensibleField<3>> CubeExtension<B> {
     /// Returns true if the base field specified by B type parameter supports cubic extensions.
     pub fn is_supported() -> bool {
         <B as ExtensibleField<3>>::is_supported()
-    }
-
-    /// Converts a vector of base elements into a vector of elements in a cubic extension field
-    /// by fusing three adjacent base elements together. The output vector is one-third the length
-    /// of the source vector.
-    fn base_to_cubic_vector(source: Vec<B>) -> Vec<Self> {
-        debug_assert!(
-            source.len() % Self::EXTENSION_DEGREE == 0,
-            "source vector length must be divisible by three, but was {}",
-            source.len()
-        );
-        let mut v = core::mem::ManuallyDrop::new(source);
-        let p = v.as_mut_ptr();
-        let len = v.len() / Self::EXTENSION_DEGREE;
-        let cap = v.capacity() / Self::EXTENSION_DEGREE;
-        unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
     }
 
     /// Returns an array of base field elements comprising this extension field element.
@@ -181,16 +162,6 @@ impl<B: ExtensibleField<3>> FieldElement for CubeExtension<B> {
         }
 
         Ok(slice::from_raw_parts(p as *const Self, len))
-    }
-
-    // UTILITIES
-    // --------------------------------------------------------------------------------------------
-
-    fn zeroed_vector(n: usize) -> Vec<Self> {
-        // get three times the number of base elements and re-interpret them as cubic field
-        // elements
-        let result = B::zeroed_vector(n * Self::EXTENSION_DEGREE);
-        Self::base_to_cubic_vector(result)
     }
 }
 
@@ -439,18 +410,6 @@ mod tests {
 
         let expected = CubeExtension(r1.0 - r2.0, r1.1 - r2.1, r1.2 - r2.2);
         assert_eq!(expected, r1 - r2);
-    }
-
-    // INITIALIZATION
-    // --------------------------------------------------------------------------------------------
-
-    #[test]
-    fn zeroed_vector() {
-        let result = CubeExtension::<BaseElement>::zeroed_vector(4);
-        assert_eq!(4, result.len());
-        for element in result.into_iter() {
-            assert_eq!(CubeExtension::<BaseElement>::ZERO, element);
-        }
     }
 
     // SERIALIZATION / DESERIALIZATION

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -4,10 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::string::{String, ToString};
 use core::{
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -43,22 +40,6 @@ impl<B: ExtensibleField<2>> QuadExtension<B> {
     /// Returns true if the base field specified by B type parameter supports quadratic extensions.
     pub fn is_supported() -> bool {
         <B as ExtensibleField<2>>::is_supported()
-    }
-
-    /// Converts a vector of base elements into a vector of elements in a quadratic extension
-    /// field by fusing two adjacent base elements together. The output vector is half the length
-    /// of the source vector.
-    fn base_to_quad_vector(source: Vec<B>) -> Vec<Self> {
-        debug_assert!(
-            source.len() % Self::EXTENSION_DEGREE == 0,
-            "source vector length must be divisible by two, but was {}",
-            source.len()
-        );
-        let mut v = core::mem::ManuallyDrop::new(source);
-        let p = v.as_mut_ptr();
-        let len = v.len() / Self::EXTENSION_DEGREE;
-        let cap = v.capacity() / Self::EXTENSION_DEGREE;
-        unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
     }
 
     /// Returns an array of base field elements comprising this extension field element.
@@ -177,15 +158,6 @@ impl<B: ExtensibleField<2>> FieldElement for QuadExtension<B> {
         }
 
         Ok(slice::from_raw_parts(p as *const Self, len))
-    }
-
-    // UTILITIES
-    // --------------------------------------------------------------------------------------------
-
-    fn zeroed_vector(n: usize) -> Vec<Self> {
-        // get twice the number of base elements, and re-interpret them as quad field elements
-        let result = B::zeroed_vector(n * Self::EXTENSION_DEGREE);
-        Self::base_to_quad_vector(result)
     }
 }
 
@@ -431,18 +403,6 @@ mod tests {
 
         let expected = QuadExtension(r1.0 - r2.0, r1.1 - r2.1);
         assert_eq!(expected, r1 - r2);
-    }
-
-    // INITIALIZATION
-    // --------------------------------------------------------------------------------------------
-
-    #[test]
-    fn zeroed_vector() {
-        let result = QuadExtension::<BaseElement>::zeroed_vector(4);
-        assert_eq!(4, result.len());
-        for element in result.into_iter() {
-            assert_eq!(QuadExtension::<BaseElement>::ZERO, element);
-        }
     }
 
     // SERIALIZATION / DESERIALIZATION

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -136,25 +136,6 @@ impl FieldElement for BaseElement {
 
         Ok(slice::from_raw_parts(p as *const Self, len))
     }
-
-    // UTILITIES
-    // --------------------------------------------------------------------------------------------
-
-    fn zeroed_vector(n: usize) -> Vec<Self> {
-        // this uses a specialized vector initialization code which requests zero-filled memory
-        // from the OS; unfortunately, this works only for built-in types and we can't use
-        // Self::ZERO here as much less efficient initialization procedure will be invoked.
-        // We also use u128 to make sure the memory is aligned correctly for our element size.
-        debug_assert_eq!(Self::ELEMENT_BYTES, mem::size_of::<u128>());
-        let result = vec![0u128; n];
-
-        // translate a zero-filled vector of u128s into a vector of base field elements
-        let mut v = core::mem::ManuallyDrop::new(result);
-        let p = v.as_mut_ptr();
-        let len = v.len();
-        let cap = v.capacity();
-        unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
-    }
 }
 
 impl StarkField for BaseElement {

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -225,18 +225,6 @@ fn read_elements_from() {
     }
 }
 
-// INITIALIZATION
-// ================================================================================================
-
-#[test]
-fn zeroed_vector() {
-    let result = BaseElement::zeroed_vector(4);
-    assert_eq!(4, result.len());
-    for element in result.into_iter() {
-        assert_eq!(BaseElement::ZERO, element);
-    }
-}
-
 // HELPER FUNCTIONS
 // ================================================================================================
 

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -173,24 +173,6 @@ impl FieldElement for BaseElement {
 
         Ok(slice::from_raw_parts(p as *const Self, len))
     }
-
-    // UTILITIES
-    // --------------------------------------------------------------------------------------------
-
-    fn zeroed_vector(n: usize) -> Vec<Self> {
-        // this uses a specialized vector initialization code which requests zero-filled memory
-        // from the OS; unfortunately, this works only for built-in types and we can't use
-        // Self::ZERO here as much less efficient initialization procedure will be invoked.
-        // We also use u64 to make sure the memory is aligned correctly for our element size.
-        let result = vec![0u64; n];
-
-        // translate a zero-filled vector of u64s into a vector of base field elements
-        let mut v = core::mem::ManuallyDrop::new(result);
-        let p = v.as_mut_ptr();
-        let len = v.len();
-        let cap = v.capacity();
-        unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
-    }
 }
 
 impl StarkField for BaseElement {

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -276,18 +276,6 @@ fn bytes_as_elements() {
     assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
 }
 
-// INITIALIZATION
-// ------------------------------------------------------------------------------------------------
-
-#[test]
-fn zeroed_vector() {
-    let result = BaseElement::zeroed_vector(4);
-    assert_eq!(4, result.len());
-    for element in result.into_iter() {
-        assert_eq!(BaseElement::ZERO, element);
-    }
-}
-
 // RANDOMIZED TESTS
 // ================================================================================================
 

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -232,24 +232,6 @@ impl FieldElement for BaseElement {
 
         Ok(slice::from_raw_parts(p as *const Self, len))
     }
-
-    // UTILITIES
-    // --------------------------------------------------------------------------------------------
-
-    fn zeroed_vector(n: usize) -> Vec<Self> {
-        // this uses a specialized vector initialization code which requests zero-filled memory
-        // from the OS; unfortunately, this works only for built-in types and we can't use
-        // Self::ZERO here as much less efficient initialization procedure will be invoked.
-        // We also use u64 to make sure the memory is aligned correctly for our element size.
-        let result = vec![0u64; n];
-
-        // translate a zero-filled vector of u64s into a vector of base field elements
-        let mut v = core::mem::ManuallyDrop::new(result);
-        let p = v.as_mut_ptr();
-        let len = v.len();
-        let cap = v.capacity();
-        unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
-    }
 }
 
 impl StarkField for BaseElement {

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -213,18 +213,6 @@ fn bytes_as_elements() {
     assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
 }
 
-// INITIALIZATION
-// ------------------------------------------------------------------------------------------------
-
-#[test]
-fn zeroed_vector() {
-    let result = BaseElement::zeroed_vector(4);
-    assert_eq!(4, result.len());
-    for element in result.into_iter() {
-        assert_eq!(BaseElement::ZERO, element);
-    }
-}
-
 // QUADRATIC EXTENSION
 // ------------------------------------------------------------------------------------------------
 #[test]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -207,16 +207,6 @@ pub trait FieldElement:
     /// This function is unsafe because it does not check whether underlying bytes represent valid
     /// field elements according to their internal representation.
     unsafe fn bytes_as_elements(bytes: &[u8]) -> Result<&[Self], DeserializationError>;
-
-    // UTILITIES
-    // --------------------------------------------------------------------------------------------
-
-    /// Returns a vector of length `n` initialized with all ZERO elements.
-    ///
-    /// Specialized implementations of this function may be faster than the generic implementation.
-    fn zeroed_vector(n: usize) -> Vec<Self> {
-        vec![Self::ZERO; n]
-    }
 }
 
 // STARK FIELD

--- a/math/src/polynom/mod.rs
+++ b/math/src/polynom/mod.rs
@@ -120,7 +120,7 @@ where
     let denominators: Vec<E> = numerators.iter().zip(xs).map(|(e, &x)| eval(e, x)).collect();
     let denominators = batch_inversion(&denominators);
 
-    let mut result = E::zeroed_vector(xs.len());
+    let mut result = vec![E::ZERO; xs.len()];
     for i in 0..xs.len() {
         let y_slice = ys[i] * denominators[i];
         for (j, res) in result.iter_mut().enumerate() {
@@ -320,7 +320,7 @@ where
     E: FieldElement,
 {
     let result_len = a.len() + b.len() - 1;
-    let mut result = E::zeroed_vector(result_len);
+    let mut result = vec![E::ZERO; result_len];
     for i in 0..a.len() {
         for j in 0..b.len() {
             let s = a[i] * b[j];
@@ -409,7 +409,7 @@ where
         assert!(b[0] != E::ZERO, "cannot divide polynomial by zero");
     }
 
-    let mut result = E::zeroed_vector(apos - bpos + 1);
+    let mut result = vec![E::ZERO; apos - bpos + 1];
     for i in (0..result.len()).rev() {
         let quot = a[apos] / b[bpos];
         result[i] = quot;

--- a/prover/src/composer/mod.rs
+++ b/prover/src/composer/mod.rs
@@ -89,8 +89,8 @@ impl<E: FieldElement> DeepCompositionPoly<E> {
         let next_z = self.z * g;
 
         // combine trace polynomials into 2 composition polynomials T'(x) and T''(x)
-        let mut t1_composition = E::zeroed_vector(trace_length);
-        let mut t2_composition = E::zeroed_vector(trace_length);
+        let mut t1_composition = vec![E::ZERO; trace_length];
+        let mut t2_composition = vec![E::ZERO; trace_length];
 
         // index of a trace polynomial; we declare it here so that we can maintain index continuity
         // across all trace segments

--- a/prover/src/constraints/evaluation_table.rs
+++ b/prover/src/constraints/evaluation_table.rs
@@ -163,7 +163,7 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
     /// combines the results into a single column.
     pub fn combine(self) -> Vec<E> {
         // allocate memory for the combined polynomial
-        let mut combined_poly = E::zeroed_vector(self.num_rows());
+        let mut combined_poly = vec![E::ZERO; self.num_rows()];
 
         // iterate over all columns of the constraint evaluation table, divide each column
         // by the evaluations of its corresponding divisor, and add all resulting evaluations

--- a/prover/src/matrix/segments.rs
+++ b/prover/src/matrix/segments.rs
@@ -7,7 +7,7 @@ use super::ColMatrix;
 use alloc::vec::Vec;
 use core::ops::Deref;
 use math::{fft::fft_inputs::FftInputs, FieldElement, StarkField};
-use utils::{group_vector_elements, uninit_vector};
+use utils::uninit_vector;
 
 #[cfg(feature = "concurrent")]
 use utils::iterators::*;
@@ -69,7 +69,7 @@ impl<B: StarkField, const N: usize> Segment<B, N> {
         } else {
             // but if some columns in the segment will remain unfilled, we allocate memory initialized
             // to zeros to make sure we don't end up with memory with undefined values
-            group_vector_elements(B::zeroed_vector(N * domain_size))
+            vec![[B::ZERO; N]; domain_size]
         };
 
         Self::new_with_buffer(data, polys, poly_offset, offsets, twiddles)

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -7,29 +7,6 @@ use super::{ByteReader, ByteWriter, Serializable, SliceReader};
 use alloc::vec::Vec;
 use proptest::prelude::{any, proptest};
 
-// VECTOR UTILS TESTS
-// ================================================================================================
-
-#[test]
-fn group_vector_elements() {
-    let n = 16;
-    let a = (0..n).map(|v| v as u64).collect::<Vec<_>>();
-
-    let b = super::group_vector_elements::<u64, 4>(a.clone());
-    for i in 0..b.len() {
-        for j in 0..4 {
-            assert_eq!(a[i * 4 + j], b[i][j]);
-        }
-    }
-
-    let b = super::group_vector_elements::<u64, 2>(a.clone());
-    for i in 0..b.len() {
-        for j in 0..2 {
-            assert_eq!(a[i * 2 + j], b[i][j]);
-        }
-    }
-}
-
 // SLICE READER TESTS
 // ================================================================================================
 

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -40,11 +40,11 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
         .collect::<Vec<_>>();
 
     // evaluate transition constraints for the main trace segment
-    let mut t_evaluations1 = E::zeroed_vector(t_constraints.num_main_constraints());
+    let mut t_evaluations1 = vec![E::ZERO; t_constraints.num_main_constraints()];
     air.evaluate_transition(main_trace_frame, &periodic_values, &mut t_evaluations1);
 
     // evaluate transition constraints for the auxiliary trace segment (if any)
-    let mut t_evaluations2 = E::zeroed_vector(t_constraints.num_aux_constraints());
+    let mut t_evaluations2 = vec![E::ZERO; t_constraints.num_aux_constraints()];
     if let Some(aux_trace_frame) = aux_trace_frame {
         let aux_rand_elements =
             aux_rand_elements.expect("expected aux rand elements to be present");


### PR DESCRIPTION
This PR addresses https://github.com/facebook/winterfell/issues/277 and in the process removes `group_vector_elements()` and `FieldElement::zeroed_vector()` functions.

After doing some benchmarking, it seems like the impact of removing these functions is negligible (or maybe even non-existent).