### PR TITLE
Fix GKR-LogUp API

### DIFF
--- a/air/src/air/aux.rs
+++ b/air/src/air/aux.rs
@@ -27,8 +27,8 @@ impl<E> AuxRandElements<E> {
 
     /// Creates a new [`AuxRandElements`], where the auxiliary trace contains columns needed when
     /// using GKR to accelerate LogUp (i.e. a Lagrange kernel column and the "s" column).
-    pub fn new_with_gkr(rand_elements: Vec<E>, gkr: Option<GkrRandElements<E>>) -> Self {
-        Self { rand_elements, gkr }
+    pub fn new_with_gkr(rand_elements: Vec<E>, gkr: GkrRandElements<E>) -> Self {
+        Self { rand_elements, gkr: Some(gkr) }
     }
 
     /// Returns the random elements needed to build all columns other than the two GKR-related ones.

--- a/air/src/air/aux.rs
+++ b/air/src/air/aux.rs
@@ -50,11 +50,11 @@ impl<E> AuxRandElements<E> {
 }
 
 /// Holds all the random elements needed when using GKR to accelerate LogUp.
-/// 
+///
 /// This consists of two sets of random values:
 /// 1. The Lagrange kernel random elements (expanded on in [`LagrangeKernelRandElements`]), and
 /// 2. The "openings combining randomness".
-/// 
+///
 /// After the verifying the LogUp-GKR circuit, the verifier is left with unproven claims provided
 /// nondeterministically by the prover about the evaluations of the MLE of the main trace columns at
 /// the Lagrange kernel random elements. Those claims are (linearly) combined into one using the
@@ -68,7 +68,7 @@ pub struct GkrRandElements<E> {
 impl<E> GkrRandElements<E> {
     /// Constructs a new [`GkrRandElements`] from [`LagrangeKernelRandElements`], and the openings
     /// combining randomness.
-    /// 
+    ///
     /// See [`GkrRandElements`] for a more detailed description.
     pub fn new(
         lagrange: LagrangeKernelRandElements<E>,

--- a/air/src/air/aux.rs
+++ b/air/src/air/aux.rs
@@ -50,6 +50,15 @@ impl<E> AuxRandElements<E> {
 }
 
 /// Holds all the random elements needed when using GKR to accelerate LogUp.
+/// 
+/// This consists of two sets of random values:
+/// 1. The Lagrange kernel random elements (expanded on in [`LagrangeKernelRandElements`]), and
+/// 2. The "openings combining randomness".
+/// 
+/// After the verifying the LogUp-GKR circuit, the verifier is left with unproven claims provided
+/// nondeterministically by the prover about the evaluations of the MLE of the main trace columns at
+/// the Lagrange kernel random elements. Those claims are (linearly) combined into one using the
+/// openings combining randomness.
 #[derive(Clone, Debug)]
 pub struct GkrRandElements<E> {
     lagrange: LagrangeKernelRandElements<E>,
@@ -57,6 +66,10 @@ pub struct GkrRandElements<E> {
 }
 
 impl<E> GkrRandElements<E> {
+    /// Constructs a new [`GkrRandElements`] from [`LagrangeKernelRandElements`], and the openings
+    /// combining randomness.
+    /// 
+    /// See [`GkrRandElements`] for a more detailed description.
     pub fn new(
         lagrange: LagrangeKernelRandElements<E>,
         openings_combining_randomness: Vec<E>,
@@ -70,8 +83,6 @@ impl<E> GkrRandElements<E> {
     }
 
     /// Returns the random values used to linearly combine the openings returned from the GKR proof.
-    ///
-    /// These correspond to the lambdas in our documentation.
     pub fn openings_combining_randomness(&self) -> &[E] {
         &self.openings_combining_randomness
     }

--- a/air/src/air/lagrange/mod.rs
+++ b/air/src/air/lagrange/mod.rs
@@ -46,7 +46,7 @@ impl<E: FieldElement> LagrangeKernelConstraints<E> {
 }
 
 /// Holds the randomly generated elements needed to build the Lagrange kernel auxiliary column.
-/// 
+///
 /// The Lagrange kernel consists of evaluating the function $eq(x, r)$, where $x$ is the binary
 /// decomposition of the row index, and $r$ is some random point. The "Lagrange kernel random
 /// elements" refer to this (multidimensional) point $r$.

--- a/air/src/air/lagrange/mod.rs
+++ b/air/src/air/lagrange/mod.rs
@@ -46,6 +46,10 @@ impl<E: FieldElement> LagrangeKernelConstraints<E> {
 }
 
 /// Holds the randomly generated elements needed to build the Lagrange kernel auxiliary column.
+/// 
+/// The Lagrange kernel consists of evaluating the function $eq(x, r)$, where $x$ is the binary
+/// decomposition of the row index, and $r$ is some random point. The "Lagrange kernel random
+/// elements" refer to this (multidimensional) point $r$.
 #[derive(Debug, Clone, Default)]
 pub struct LagrangeKernelRandElements<E> {
     elements: Vec<E>,

--- a/air/src/air/lagrange/mod.rs
+++ b/air/src/air/lagrange/mod.rs
@@ -46,7 +46,7 @@ impl<E: FieldElement> LagrangeKernelConstraints<E> {
 }
 
 /// Holds the randomly generated elements needed to build the Lagrange kernel auxiliary column.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LagrangeKernelRandElements<E> {
     elements: Vec<E>,
 }

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -11,7 +11,7 @@ use math::{fft, ExtensibleField, ExtensionOf, FieldElement, StarkField, ToElemen
 use crate::ProofOptions;
 
 mod aux;
-pub use aux::{AuxRandElements, GkrVerifier};
+pub use aux::{AuxRandElements, GkrRandElements, GkrVerifier};
 
 mod trace_info;
 pub use trace_info::TraceInfo;
@@ -309,7 +309,7 @@ pub trait Air: Send + Sync {
     /// Returns the [`GkrVerifier`] to be used to verify the GKR proof.
     ///
     /// Leave unimplemented if the `Air` doesn't use a GKR proof.
-    fn get_auxiliary_proof_verifier<E: FieldElement<BaseField = Self::BaseField>>(
+    fn get_gkr_proof_verifier<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
     ) -> Self::GkrVerifier {
         unimplemented!("`get_auxiliary_proof_verifier()` must be implemented when the proof contains a GKR proof");

--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -269,7 +269,7 @@ pub trait Air: Send + Sync {
         main_frame: &EvaluationFrame<F>,
         aux_frame: &EvaluationFrame<E>,
         periodic_values: &[F],
-        aux_rand_elements: &[E],
+        aux_rand_elements: &AuxRandElements<E>,
         result: &mut [E],
     ) where
         F: FieldElement<BaseField = Self::BaseField>,
@@ -298,7 +298,7 @@ pub trait Air: Send + Sync {
     #[allow(unused_variables)]
     fn get_aux_assertions<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
-        aux_rand_elements: &[E],
+        aux_rand_elements: &AuxRandElements<E>,
     ) -> Vec<Assertion<E>> {
         Vec::new()
     }
@@ -422,7 +422,7 @@ pub trait Air: Send + Sync {
     /// combination of boundary constraints during constraint merging.
     fn get_boundary_constraints<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
-        aux_rand_elements: Option<&[E]>,
+        aux_rand_elements: Option<&AuxRandElements<E>>,
         composition_coefficients: &[E],
     ) -> BoundaryConstraints<E> {
         BoundaryConstraints::new(

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -44,7 +44,7 @@ mod air;
 pub use air::{
     Air, AirContext, Assertion, AuxRandElements, BoundaryConstraint, BoundaryConstraintGroup,
     BoundaryConstraints, ConstraintCompositionCoefficients, ConstraintDivisor,
-    DeepCompositionCoefficients, EvaluationFrame, GkrVerifier,
+    DeepCompositionCoefficients, EvaluationFrame, GkrRandElements, GkrVerifier,
     LagrangeConstraintsCompositionCoefficients, LagrangeKernelBoundaryConstraint,
     LagrangeKernelConstraints, LagrangeKernelEvaluationFrame, LagrangeKernelRandElements,
     LagrangeKernelTransitionConstraints, TraceInfo, TransitionConstraintDegree,

--- a/examples/src/rescue_raps/air.rs
+++ b/examples/src/rescue_raps/air.rs
@@ -5,7 +5,7 @@
 
 use core_utils::flatten_slice_elements;
 use winterfell::{
-    math::ToElements, Air, AirContext, Assertion, EvaluationFrame, TraceInfo,
+    math::ToElements, Air, AirContext, Assertion, AuxRandElements, EvaluationFrame, TraceInfo,
     TransitionConstraintDegree,
 };
 
@@ -162,7 +162,7 @@ impl Air for RescueRapsAir {
         main_frame: &EvaluationFrame<F>,
         aux_frame: &EvaluationFrame<E>,
         periodic_values: &[F],
-        aux_rand_elements: &[E],
+        aux_rand_elements: &AuxRandElements<E>,
         result: &mut [E],
     ) where
         F: FieldElement<BaseField = Self::BaseField>,
@@ -173,6 +173,8 @@ impl Air for RescueRapsAir {
 
         let aux_current = aux_frame.current();
         let aux_next = aux_frame.next();
+
+        let aux_rand_elements = aux_rand_elements.rand_elements();
 
         let absorption_flag = periodic_values[1];
 
@@ -233,7 +235,7 @@ impl Air for RescueRapsAir {
         ]
     }
 
-    fn get_aux_assertions<E>(&self, _aux_rand_elements: &[E]) -> Vec<Assertion<E>>
+    fn get_aux_assertions<E>(&self, _aux_rand_elements: &AuxRandElements<E>) -> Vec<Assertion<E>>
     where
         E: FieldElement<BaseField = Self::BaseField>,
     {

--- a/prover/benches/lagrange_kernel.rs
+++ b/prover/benches/lagrange_kernel.rs
@@ -144,7 +144,7 @@ impl Air for LagrangeKernelAir {
         _main_frame: &EvaluationFrame<F>,
         _aux_frame: &EvaluationFrame<E>,
         _periodic_values: &[F],
-        _aux_rand_elements: &[E],
+        _aux_rand_elements: &AuxRandElements<E>,
         _result: &mut [E],
     ) where
         F: FieldElement<BaseField = Self::BaseField>,
@@ -155,7 +155,7 @@ impl Air for LagrangeKernelAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
-        _aux_rand_elements: &[E],
+        _aux_rand_elements: &AuxRandElements<E>,
     ) -> Vec<Assertion<E>> {
         vec![Assertion::single(1, 0, E::ZERO)]
     }

--- a/prover/src/constraints/evaluator/boundary.rs
+++ b/prover/src/constraints/evaluator/boundary.rs
@@ -5,7 +5,7 @@
 
 use alloc::{collections::BTreeMap, vec::Vec};
 
-use air::{Air, ConstraintDivisor};
+use air::{Air, AuxRandElements, ConstraintDivisor};
 use math::{fft, ExtensionOf, FieldElement};
 
 use super::StarkDomain;
@@ -35,7 +35,7 @@ impl<E: FieldElement> BoundaryConstraints<E> {
     /// by an instance of AIR for a specific computation.
     pub fn new<A: Air<BaseField = E::BaseField>>(
         air: &A,
-        aux_rand_elements: Option<&[E]>,
+        aux_rand_elements: Option<&AuxRandElements<E>>,
         composition_coefficients: &[E],
     ) -> Self {
         // get constraints from the AIR instance

--- a/prover/src/constraints/evaluator/default.rs
+++ b/prover/src/constraints/evaluator/default.rs
@@ -154,9 +154,7 @@ where
         // constraint evaluations.
         let boundary_constraints = BoundaryConstraints::new(
             air,
-            aux_rand_elements
-                .as_ref()
-                .map(|aux_rand_elements| aux_rand_elements.rand_elements()),
+            aux_rand_elements.as_ref(),
             &composition_coefficients.boundary,
         );
 
@@ -378,8 +376,7 @@ where
             periodic_values,
             self.aux_rand_elements
                 .as_ref()
-                .expect("expected aux rand elements to be present")
-                .rand_elements(),
+                .expect("expected aux rand elements to be present"),
             evaluations,
         );
 

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -127,7 +127,7 @@ pub trait Trace: Sized {
             let aux_trace = &aux_trace_with_metadata.aux_trace;
             let aux_rand_elements = &aux_trace_with_metadata.aux_rand_elements;
 
-            for assertion in air.get_aux_assertions(aux_rand_elements.rand_elements()) {
+            for assertion in air.get_aux_assertions(aux_rand_elements) {
                 // get the matrix and verify the assertion against it
                 assertion.apply(self.length(), |step, value| {
                     assert!(
@@ -209,7 +209,7 @@ pub trait Trace: Sized {
                     &main_frame,
                     aux_frame,
                     &periodic_values,
-                    aux_rand_elements.rand_elements(),
+                    aux_rand_elements,
                     &mut aux_evaluations,
                 );
                 for (i, &evaluation) in aux_evaluations.iter().enumerate() {

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -196,7 +196,7 @@ impl<T: Serializable, const C: usize> Serializable for [T; C] {
 }
 
 impl<T: Serializable> Serializable for [T] {
-    fn write_into<W: ?Sized + ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_usize(self.len());
         for element in self.iter() {
             element.write_into(target);
@@ -226,7 +226,7 @@ impl<T: Serializable> Serializable for BTreeSet<T> {
 }
 
 impl Serializable for str {
-    fn write_into<W: ?Sized + ByteWriter>(&self, target: &mut W) {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_usize(self.len());
         target.write_many(self.as_bytes());
     }

--- a/verifier/src/evaluator.rs
+++ b/verifier/src/evaluator.rs
@@ -54,7 +54,7 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
             main_trace_frame,
             aux_trace_frame,
             &periodic_values,
-            aux_rand_elements.rand_elements(),
+            aux_rand_elements,
             &mut t_evaluations2,
         );
     }
@@ -67,10 +67,8 @@ pub fn evaluate_constraints<A: Air, E: FieldElement<BaseField = A::BaseField>>(
     // 2 ----- evaluate boundary constraints ------------------------------------------------------
 
     // get boundary constraints grouped by common divisor from the AIR
-    let b_constraints = air.get_boundary_constraints(
-        aux_rand_elements.as_ref().map(|eles| eles.rand_elements()),
-        &composition_coefficients.boundary,
-    );
+    let b_constraints =
+        air.get_boundary_constraints(aux_rand_elements, &composition_coefficients.boundary);
 
     // iterate over boundary constraint groups for the main trace segment (each group has a
     // distinct divisor), evaluate constraints in each group and add their combination to the

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -178,8 +178,8 @@ where
                 Deserializable::read_from_bytes(gkr_proof_serialized)
                     .map_err(|err| VerifierError::ProofDeserializationError(err.to_string()))?
             };
-            let lagrange_rand_elements = air
-                .get_auxiliary_proof_verifier::<E>()
+            let gkr_rand_elements = air
+                .get_gkr_proof_verifier::<E>()
                 .verify::<E, _>(gkr_proof, &mut public_coin)
                 .map_err(|err| VerifierError::GkrProofVerificationFailed(err.to_string()))?;
 
@@ -189,7 +189,7 @@ where
 
             public_coin.reseed(trace_commitments[AUX_TRACE_IDX]);
 
-            Some(AuxRandElements::new_with_lagrange(rand_elements, Some(lagrange_rand_elements)))
+            Some(AuxRandElements::new_with_gkr(rand_elements, Some(gkr_rand_elements)))
         } else {
             let rand_elements = air.get_aux_rand_elements(&mut public_coin).expect(
                 "failed to generate the random elements needed to build the auxiliary trace",

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -189,7 +189,7 @@ where
 
             public_coin.reseed(trace_commitments[AUX_TRACE_IDX]);
 
-            Some(AuxRandElements::new_with_gkr(rand_elements, Some(gkr_rand_elements)))
+            Some(AuxRandElements::new_with_gkr(rand_elements, gkr_rand_elements))
         } else {
             let rand_elements = air.get_aux_rand_elements(&mut public_coin).expect(
                 "failed to generate the random elements needed to build the auxiliary trace",

--- a/winterfell/src/tests.rs
+++ b/winterfell/src/tests.rs
@@ -5,7 +5,7 @@
 
 use std::{vec, vec::Vec};
 
-use air::LagrangeKernelRandElements;
+use air::{GkrRandElements, LagrangeKernelRandElements};
 use prover::{
     crypto::{hashers::Blake3_256, DefaultRandomCoin, RandomCoin},
     math::{fields::f64::BaseElement, ExtensionOf, FieldElement},
@@ -96,7 +96,7 @@ impl GkrVerifier for DummyGkrVerifier {
         &self,
         gkr_proof: usize,
         public_coin: &mut impl RandomCoin<BaseField = E::BaseField, Hasher = Hasher>,
-    ) -> Result<LagrangeKernelRandElements<E>, Self::Error>
+    ) -> Result<GkrRandElements<E>, Self::Error>
     where
         E: FieldElement,
         Hasher: crypto::ElementHasher<BaseField = E::BaseField>,
@@ -111,7 +111,7 @@ impl GkrVerifier for DummyGkrVerifier {
             LagrangeKernelRandElements::new(rand_elements)
         };
 
-        Ok(lagrange_kernel_rand_elements)
+        Ok(GkrRandElements::new(lagrange_kernel_rand_elements, Vec::new()))
     }
 }
 
@@ -184,7 +184,7 @@ impl Air for LagrangeKernelComplexAir {
         vec![Assertion::single(0, 0, E::ZERO)]
     }
 
-    fn get_auxiliary_proof_verifier<E: FieldElement<BaseField = Self::BaseField>>(
+    fn get_gkr_proof_verifier<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
     ) -> Self::GkrVerifier {
         DummyGkrVerifier
@@ -253,22 +253,22 @@ impl Prover for LagrangeComplexProver {
         &self,
         main_trace: &Self::Trace,
         public_coin: &mut Self::RandomCoin,
-    ) -> (ProverGkrProof<Self>, LagrangeKernelRandElements<E>)
+    ) -> (ProverGkrProof<Self>, GkrRandElements<E>)
     where
         E: FieldElement<BaseField = Self::BaseField>,
     {
         let main_trace = main_trace.main_segment();
         let log_trace_len = main_trace.num_rows().ilog2() as usize;
-        let lagrange_kernel_rand_elements: Vec<E> = {
+        let lagrange_kernel_rand_elements = {
             let mut rand_elements = Vec::with_capacity(log_trace_len);
             for _ in 0..log_trace_len {
                 rand_elements.push(public_coin.draw().unwrap());
             }
 
-            rand_elements
+            LagrangeKernelRandElements::new(rand_elements)
         };
 
-        (log_trace_len, LagrangeKernelRandElements::new(lagrange_kernel_rand_elements))
+        (log_trace_len, GkrRandElements::new(lagrange_kernel_rand_elements, Vec::new()))
     }
 
     fn build_aux_trace<E>(

--- a/winterfell/src/tests.rs
+++ b/winterfell/src/tests.rs
@@ -168,7 +168,7 @@ impl Air for LagrangeKernelComplexAir {
         _main_frame: &EvaluationFrame<F>,
         _aux_frame: &EvaluationFrame<E>,
         _periodic_values: &[F],
-        _aux_rand_elements: &[E],
+        _aux_rand_elements: &AuxRandElements<E>,
         _result: &mut [E],
     ) where
         F: FieldElement<BaseField = Self::BaseField>,
@@ -179,7 +179,7 @@ impl Air for LagrangeKernelComplexAir {
 
     fn get_aux_assertions<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
-        _aux_rand_elements: &[E],
+        _aux_rand_elements: &AuxRandElements<E>,
     ) -> Vec<Assertion<E>> {
         vec![Assertion::single(0, 0, E::ZERO)]
     }


### PR DESCRIPTION
Closes #286 

I opted to expand the scope of the current `Air::evaluate_aux_transition()` and `Air::get_aux_assertions()` instead of creating new methods (as suggested in the issue), since it ended up being much cleaner.