### PR TITLE
fix: incorrect read_slice impl for ReadAdapter

### DIFF
--- a/air/src/proof/ood_frame.rs
+++ b/air/src/proof/ood_frame.rs
@@ -230,9 +230,11 @@ impl Deserializable for OodFrame {
 // ================================================================================================
 
 /// Stores the trace evaluations at `z` and `gz`, where `z` is a random Field element in
-/// `current_row` and `next_row`, respectively. If the Air contains a Lagrange kernel auxiliary
-/// column, then that column interpolated polynomial will be evaluated at `z`, `gz`, `g^2 z`, ...
-/// `g^(2^(v-1)) z`, where `v == log(trace_len)`, and stored in `lagrange_kernel_frame`.
+/// `current_row` and `next_row`, respectively.
+///
+/// If the Air contains a Lagrange kernel auxiliary column, then that column interpolated polynomial
+/// will be evaluated at `z`, `gz`, `g^2 z`, ... `g^(2^(v-1)) z`, where `v == log(trace_len)`, and
+/// stored in `lagrange_kernel_frame`.
 pub struct TraceOodFrame<E: FieldElement> {
     current_row: Vec<E>,
     next_row: Vec<E>,

--- a/crypto/src/merkle/concurrent.rs
+++ b/crypto/src/merkle/concurrent.rs
@@ -18,9 +18,11 @@ pub const MIN_CONCURRENT_LEAVES: usize = 1024;
 // PUBLIC FUNCTIONS
 // ================================================================================================
 
-/// Builds all internal nodes of the Merkle using all available threads and stores the
-/// results in a single vector such that root of the tree is at position 1, nodes immediately
-/// under the root is at positions 2 and 3 etc.
+/// Builds all internal nodes of the Merkle.
+///
+/// All available threads are used, and the results are stored in a single vector, such that
+/// the root of the tree is at position 1, and nodes immediately under the root are at positions
+/// 2 and 3, and so on.
 pub fn build_merkle_nodes<H: Hasher>(leaves: &[H::Digest]) -> Vec<H::Digest> {
     let n = leaves.len() / 2;
 

--- a/examples/src/utils/rescue.rs
+++ b/examples/src/utils/rescue.rs
@@ -21,10 +21,11 @@ pub const RATE_WIDTH: usize = 4;
 /// Two elements (32-bytes) are returned as digest.
 const DIGEST_SIZE: usize = 2;
 
-/// The number of rounds is set to 7 to provide 128-bit security level with 40% security margin;
-/// computed using algorithm 7 from <https://eprint.iacr.org/2020/1143.pdf>
-/// security margin here differs from Rescue Prime specification which suggests 50% security
-/// margin (and would require 8 rounds) primarily to make AIR a bit simpler.
+/// The number of rounds is set to 7 to provide 128-bit security level with 40% security margin.
+///
+/// Computed using algorithm 7 from <https://eprint.iacr.org/2020/1143.pdf>, the security margin
+/// here differs from Rescue Prime specification which suggests 50% security margin (and would
+/// require 8 rounds) primarily to make AIR a bit simpler.
 pub const NUM_ROUNDS: usize = 7;
 
 /// Minimum cycle length required to describe Rescue permutation.

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -5,10 +5,12 @@
 
 //! An implementation of a 64-bit STARK-friendly prime field with modulus $2^{64} - 2^{32} + 1$
 //! using Montgomery representation.
+//!
 //! Our implementation follows <https://eprint.iacr.org/2022/274.pdf> and is constant-time.
 //!
 //! This field supports very fast modular arithmetic and has a number of other attractive
 //! properties, including:
+//!
 //! * Multiplication of two 32-bit values does not overflow field modulus.
 //! * Field arithmetic in this field can be implemented using a few 32-bit addition, subtractions,
 //!   and shifts.


### PR DESCRIPTION
This commit fixes a bug that is present in the implementation of `ByteReader::read_slice` for ReadAdapter. Specifically, it does not consume any input, so calling `read_slice` and then attempting to read the next value in the input, will read the same bytes again. The documented behavior of this function is that any of the `read_*` methods consume the corresponding amount of input.

To catch this, and to prevent future regressions, a new test was added that serializes some data to a file using one approach, and deserializes it using the ReadAdapter. This ensures that we don't accidentally make choices in the writer that aren't matched by the reader, and vice versa.

Closes #308