### PR TITLE
Parallelize Lagrange constraints evaluation

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -16,6 +16,10 @@ rust-version = "1.78"
 bench = false
 
 [[bench]]
+name = "logup_gkr"
+harness = false
+
+[[bench]]
 name = "row_matrix"
 harness = false
 

--- a/prover/benches/logup_gkr.rs
+++ b/prover/benches/logup_gkr.rs
@@ -20,16 +20,16 @@ use winter_prover::{
     DefaultConstraintEvaluator, DefaultTraceLde, Prover, StarkDomain, Trace, TracePolyTable,
 };
 
-const TRACE_LENS: [usize; 3] = [2_usize.pow(16), 2_usize.pow(18), 2_usize.pow(20)];
+const TRACE_LENS: [usize; 2] = [2_usize.pow(20), 2_usize.pow(21)];
 const AUX_TRACE_WIDTH: usize = 2;
 
 fn prove_with_lagrange_kernel(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Lagrange kernel column");
+    let mut group = c.benchmark_group("prove with Lagrange kernel column");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(20));
 
     for &trace_len in TRACE_LENS.iter() {
-        group.bench_function(BenchmarkId::new("prover", trace_len), |b| {
+        group.bench_function(BenchmarkId::new("", trace_len), |b| {
             let trace = LogUpGkrSimple::new(trace_len, AUX_TRACE_WIDTH);
             let prover = LogUpGkrSimpleProver::new(AUX_TRACE_WIDTH);
 

--- a/prover/benches/logup_gkr.rs
+++ b/prover/benches/logup_gkr.rs
@@ -1,0 +1,351 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::{marker::PhantomData, time::Duration, vec::Vec};
+
+use air::{
+    Air, AirContext, Assertion, AuxRandElements, ConstraintCompositionCoefficients,
+    EvaluationFrame, FieldExtension, LogUpGkrEvaluator, LogUpGkrOracle, ProofOptions, TraceInfo,
+    TransitionConstraintDegree,
+};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use crypto::MerkleTree;
+use math::StarkField;
+use winter_prover::{
+    crypto::{hashers::Blake3_256, DefaultRandomCoin},
+    math::{fields::f64::BaseElement, ExtensionOf, FieldElement},
+    matrix::ColMatrix,
+    DefaultConstraintEvaluator, DefaultTraceLde, Prover, StarkDomain, Trace, TracePolyTable,
+};
+
+const TRACE_LENS: [usize; 3] = [2_usize.pow(16), 2_usize.pow(18), 2_usize.pow(20)];
+const AUX_TRACE_WIDTH: usize = 2;
+
+fn prove_with_lagrange_kernel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Lagrange kernel column");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(20));
+
+    for &trace_len in TRACE_LENS.iter() {
+        group.bench_function(BenchmarkId::new("prover", trace_len), |b| {
+            let trace = LogUpGkrSimple::new(trace_len, AUX_TRACE_WIDTH);
+            let prover = LogUpGkrSimpleProver::new(AUX_TRACE_WIDTH);
+
+            b.iter_batched(
+                || trace.clone(),
+                |trace| prover.prove(trace).unwrap(),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+criterion_group!(lagrange_kernel_group, prove_with_lagrange_kernel);
+criterion_main!(lagrange_kernel_group);
+
+// LogUpGkrSimple
+// =================================================================================================
+
+#[derive(Clone, Debug)]
+struct LogUpGkrSimple {
+    // dummy main trace
+    main_trace: ColMatrix<BaseElement>,
+    info: TraceInfo,
+}
+
+impl LogUpGkrSimple {
+    fn new(trace_len: usize, aux_segment_width: usize) -> Self {
+        assert!(trace_len < u32::MAX.try_into().unwrap());
+
+        let table: Vec<BaseElement> =
+            (0..trace_len).map(|idx| BaseElement::from(idx as u32)).collect();
+        let mut multiplicity: Vec<BaseElement> =
+            (0..trace_len).map(|_idx| BaseElement::ZERO).collect();
+        multiplicity[0] = BaseElement::new(3 * trace_len as u64 - 3 * 4);
+        multiplicity[1] = BaseElement::new(3 * 4);
+
+        let mut values_0: Vec<BaseElement> = (0..trace_len).map(|_idx| BaseElement::ZERO).collect();
+
+        for i in 0..4 {
+            values_0[i + 4] = BaseElement::ONE;
+        }
+
+        let mut values_1: Vec<BaseElement> = (0..trace_len).map(|_idx| BaseElement::ZERO).collect();
+
+        for i in 0..4 {
+            values_1[i + 4] = BaseElement::ONE;
+        }
+
+        let mut values_2: Vec<BaseElement> = (0..trace_len).map(|_idx| BaseElement::ZERO).collect();
+
+        for i in 0..4 {
+            values_2[i + 4] = BaseElement::ONE;
+        }
+
+        Self {
+            main_trace: ColMatrix::new(vec![table, multiplicity, values_0, values_1, values_2]),
+            info: TraceInfo::new_multi_segment(5, aux_segment_width, 0, trace_len, vec![], true),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.main_trace.num_rows()
+    }
+}
+
+impl Trace for LogUpGkrSimple {
+    type BaseField = BaseElement;
+
+    fn info(&self) -> &TraceInfo {
+        &self.info
+    }
+
+    fn main_segment(&self) -> &ColMatrix<Self::BaseField> {
+        &self.main_trace
+    }
+
+    fn read_main_frame(&self, row_idx: usize, frame: &mut EvaluationFrame<Self::BaseField>) {
+        let next_row_idx = row_idx + 1;
+        self.main_trace.read_row_into(row_idx, frame.current_mut());
+        self.main_trace.read_row_into(next_row_idx % self.len(), frame.next_mut());
+    }
+}
+
+// AIR
+// =================================================================================================
+
+struct LogUpGkrSimpleAir {
+    context: AirContext<BaseElement, ()>,
+}
+
+impl Air for LogUpGkrSimpleAir {
+    type BaseField = BaseElement;
+    type PublicInputs = ();
+
+    fn new(trace_info: TraceInfo, _pub_inputs: Self::PublicInputs, options: ProofOptions) -> Self {
+        Self {
+            context: AirContext::new_multi_segment(
+                trace_info,
+                _pub_inputs,
+                vec![TransitionConstraintDegree::new(1)],
+                vec![],
+                1,
+                0,
+                options,
+            ),
+        }
+    }
+
+    fn context(&self) -> &AirContext<Self::BaseField, ()> {
+        &self.context
+    }
+
+    fn evaluate_transition<E: math::FieldElement<BaseField = Self::BaseField>>(
+        &self,
+        frame: &EvaluationFrame<E>,
+        _periodic_values: &[E],
+        result: &mut [E],
+    ) {
+        let current = frame.current()[0];
+        let next = frame.next()[0];
+
+        // increments by 1
+        result[0] = next - current - E::ONE;
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
+        vec![Assertion::single(0, 0, BaseElement::ZERO)]
+    }
+
+    fn evaluate_aux_transition<F, E>(
+        &self,
+        _main_frame: &EvaluationFrame<F>,
+        _aux_frame: &EvaluationFrame<E>,
+        _periodic_values: &[F],
+        _aux_rand_elements: &AuxRandElements<E>,
+        _result: &mut [E],
+    ) where
+        F: FieldElement<BaseField = Self::BaseField>,
+        E: FieldElement<BaseField = Self::BaseField> + ExtensionOf<F>,
+    {
+        // do nothing
+    }
+
+    fn get_aux_assertions<E: FieldElement<BaseField = Self::BaseField>>(
+        &self,
+        _aux_rand_elements: &AuxRandElements<E>,
+    ) -> Vec<Assertion<E>> {
+        vec![]
+    }
+
+    fn get_logup_gkr_evaluator(
+        &self,
+    ) -> impl LogUpGkrEvaluator<BaseField = Self::BaseField, PublicInputs = Self::PublicInputs>
+    {
+        PlainLogUpGkrEval::new()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct PlainLogUpGkrEval<B: FieldElement + StarkField> {
+    oracles: Vec<LogUpGkrOracle>,
+    _field: PhantomData<B>,
+}
+
+impl<B: FieldElement + StarkField> PlainLogUpGkrEval<B> {
+    pub fn new() -> Self {
+        let committed_0 = LogUpGkrOracle::CurrentRow(0);
+        let committed_1 = LogUpGkrOracle::CurrentRow(1);
+        let committed_2 = LogUpGkrOracle::CurrentRow(2);
+        let committed_3 = LogUpGkrOracle::CurrentRow(3);
+        let committed_4 = LogUpGkrOracle::CurrentRow(4);
+        let oracles = vec![committed_0, committed_1, committed_2, committed_3, committed_4];
+        Self { oracles, _field: PhantomData }
+    }
+}
+
+impl LogUpGkrEvaluator for PlainLogUpGkrEval<BaseElement> {
+    type BaseField = BaseElement;
+
+    type PublicInputs = ();
+
+    fn get_oracles(&self) -> &[LogUpGkrOracle] {
+        &self.oracles
+    }
+
+    fn get_num_rand_values(&self) -> usize {
+        1
+    }
+
+    fn get_num_fractions(&self) -> usize {
+        4
+    }
+
+    fn max_degree(&self) -> usize {
+        3
+    }
+
+    fn build_query<E>(&self, frame: &EvaluationFrame<E>, query: &mut [E])
+    where
+        E: FieldElement<BaseField = Self::BaseField>,
+    {
+        query.iter_mut().zip(frame.current().iter()).for_each(|(q, f)| *q = *f)
+    }
+
+    fn evaluate_query<F, E>(
+        &self,
+        query: &[F],
+        _periodic_values: &[F],
+        rand_values: &[E],
+        numerator: &mut [E],
+        denominator: &mut [E],
+    ) where
+        F: FieldElement<BaseField = Self::BaseField>,
+        E: FieldElement<BaseField = Self::BaseField> + ExtensionOf<F>,
+    {
+        assert_eq!(numerator.len(), 4);
+        assert_eq!(denominator.len(), 4);
+        assert_eq!(query.len(), 5);
+        numerator[0] = E::from(query[1]);
+        numerator[1] = E::ONE;
+        numerator[2] = E::ONE;
+        numerator[3] = E::ONE;
+
+        denominator[0] = rand_values[0] - E::from(query[0]);
+        denominator[1] = -(rand_values[0] - E::from(query[2]));
+        denominator[2] = -(rand_values[0] - E::from(query[3]));
+        denominator[3] = -(rand_values[0] - E::from(query[4]));
+    }
+
+    fn compute_claim<E>(&self, _inputs: &Self::PublicInputs, _rand_values: &[E]) -> E
+    where
+        E: FieldElement<BaseField = Self::BaseField>,
+    {
+        E::ZERO
+    }
+}
+// Prover
+// ================================================================================================
+
+struct LogUpGkrSimpleProver {
+    aux_trace_width: usize,
+    options: ProofOptions,
+}
+
+impl LogUpGkrSimpleProver {
+    fn new(aux_trace_width: usize) -> Self {
+        Self {
+            aux_trace_width,
+            options: ProofOptions::new(1, 8, 0, FieldExtension::Quadratic, 2, 1),
+        }
+    }
+}
+
+impl Prover for LogUpGkrSimpleProver {
+    type BaseField = BaseElement;
+    type Air = LogUpGkrSimpleAir;
+    type Trace = LogUpGkrSimple;
+    type HashFn = Blake3_256<BaseElement>;
+    type VC = MerkleTree<Blake3_256<BaseElement>>;
+    type RandomCoin = DefaultRandomCoin<Self::HashFn>;
+    type TraceLde<E: FieldElement<BaseField = BaseElement>> =
+        DefaultTraceLde<E, Self::HashFn, Self::VC>;
+    type ConstraintEvaluator<'a, E: FieldElement<BaseField = BaseElement>> =
+        DefaultConstraintEvaluator<'a, LogUpGkrSimpleAir, E>;
+
+    fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+
+    fn new_trace_lde<E>(
+        &self,
+        trace_info: &TraceInfo,
+        main_trace: &ColMatrix<Self::BaseField>,
+        domain: &StarkDomain<Self::BaseField>,
+    ) -> (Self::TraceLde<E>, TracePolyTable<E>)
+    where
+        E: math::FieldElement<BaseField = Self::BaseField>,
+    {
+        DefaultTraceLde::new(trace_info, main_trace, domain)
+    }
+
+    fn new_evaluator<'a, E>(
+        &self,
+        air: &'a Self::Air,
+        aux_rand_elements: Option<AuxRandElements<E>>,
+        composition_coefficients: ConstraintCompositionCoefficients<E>,
+    ) -> Self::ConstraintEvaluator<'a, E>
+    where
+        E: math::FieldElement<BaseField = Self::BaseField>,
+    {
+        DefaultConstraintEvaluator::new(air, aux_rand_elements, composition_coefficients)
+    }
+
+    fn build_aux_trace<E>(&self, main_trace: &Self::Trace, _aux_rand_elements: &[E]) -> ColMatrix<E>
+    where
+        E: FieldElement<BaseField = Self::BaseField>,
+    {
+        let main_trace = main_trace.main_segment();
+
+        let mut columns = Vec::new();
+
+        let rand_summed = E::from(777_u32);
+        for _ in 0..self.aux_trace_width {
+            // building a dummy auxiliary column
+            let column = main_trace
+                .get_column(0)
+                .iter()
+                .map(|row_val| rand_summed.mul_base(*row_val))
+                .collect();
+
+            columns.push(column);
+        }
+
+        ColMatrix::new(columns)
+    }
+}

--- a/prover/src/constraints/evaluator/logup_gkr.rs
+++ b/prover/src/constraints/evaluator/logup_gkr.rs
@@ -82,7 +82,7 @@ where
         let mean = c / E::from(E::BaseField::from(trace.trace_info().length() as u32));
 
         #[cfg(feature = "concurrent")]
-        let _ = combined_evaluations_acc
+        combined_evaluations_acc
             .par_iter_mut()
             .enumerate()
             .fold(

--- a/sumcheck/Cargo.toml
+++ b/sumcheck/Cargo.toml
@@ -23,12 +23,10 @@ harness = false
 [[bench]]
 name = "eq_function"
 harness = false
-required-features = ["concurrent"]
 
 [[bench]]
 name = "bind_variable"
 harness = false
-required-features = ["concurrent"]
 
 [features]
 concurrent = ["utils/concurrent", "dep:rayon", "std"]

--- a/sumcheck/benches/bind_variable.rs
+++ b/sumcheck/benches/bind_variable.rs
@@ -6,29 +6,29 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use math::{fields::f64::BaseElement, FieldElement};
+use math::fields::f64::BaseElement;
 use rand_utils::{rand_value, rand_vector};
 #[cfg(feature = "concurrent")]
 pub use rayon::prelude::*;
+use winter_sumcheck::MultiLinearPoly;
 
 const POLY_SIZE: [usize; 2] = [1 << 18, 1 << 20];
 
-fn bind_variable_serial(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Bind variable evaluations");
+fn bind_variable(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bind variable ");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(10));
 
     for &poly_size in POLY_SIZE.iter() {
-        group.bench_function(BenchmarkId::new("serial", poly_size), |b| {
+        group.bench_function(BenchmarkId::new("", poly_size), |b| {
             b.iter_batched(
                 || {
                     let random_challenge: BaseElement = rand_value();
-                    let poly_evals: Vec<BaseElement> = rand_vector(poly_size);
-                    (random_challenge, poly_evals)
+                    let poly = MultiLinearPoly::from_evaluations(rand_vector(poly_size));
+                    (random_challenge, poly)
                 },
-                |(random_challenge, poly_evals)| {
-                    let mut poly_evals = poly_evals;
-                    bind_least_significant_variable_serial(&mut poly_evals, random_challenge)
+                |(random_challenge, mut poly)| {
+                    poly.bind_least_significant_variable(random_challenge)
                 },
                 BatchSize::SmallInput,
             )
@@ -36,55 +36,5 @@ fn bind_variable_serial(c: &mut Criterion) {
     }
 }
 
-fn bind_variable_parallel(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Bind variable function evaluations");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(10));
-
-    for &poly_size in POLY_SIZE.iter() {
-        group.bench_function(BenchmarkId::new("parallel", poly_size), |b| {
-            b.iter_batched(
-                || {
-                    let random_challenge: BaseElement = rand_value();
-                    let poly_evals: Vec<BaseElement> = rand_vector(poly_size);
-                    (random_challenge, poly_evals)
-                },
-                |(random_challenge, poly_evals)| {
-                    let mut poly_evals = poly_evals;
-                    bind_least_significant_variable_parallel(&mut poly_evals, random_challenge)
-                },
-                BatchSize::SmallInput,
-            )
-        });
-    }
-}
-
-fn bind_least_significant_variable_serial<E: FieldElement>(
-    evaluations: &mut Vec<E>,
-    round_challenge: E,
-) {
-    let num_evals = evaluations.len() >> 1;
-
-    for i in 0..num_evals {
-        evaluations[i] = evaluations[i << 1]
-            + round_challenge * (evaluations[(i << 1) + 1] - evaluations[i << 1]);
-    }
-    evaluations.truncate(num_evals);
-}
-
-fn bind_least_significant_variable_parallel<E: FieldElement>(
-    evaluations: &mut Vec<E>,
-    round_challenge: E,
-) {
-    let num_evals = evaluations.len() >> 1;
-
-    let mut result = unsafe { utils::uninit_vector(num_evals) };
-    result.par_iter_mut().enumerate().for_each(|(i, ev)| {
-        *ev = evaluations[i << 1]
-            + round_challenge * (evaluations[(i << 1) + 1] - evaluations[i << 1])
-    });
-    *evaluations = result
-}
-
-criterion_group!(group, bind_variable_serial, bind_variable_parallel);
+criterion_group!(group, bind_variable);
 criterion_main!(group);

--- a/sumcheck/benches/eq_function.rs
+++ b/sumcheck/benches/eq_function.rs
@@ -6,91 +6,32 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use math::{fields::f64::BaseElement, FieldElement};
+use math::fields::f64::BaseElement;
 use rand_utils::rand_vector;
 #[cfg(feature = "concurrent")]
 pub use rayon::prelude::*;
+use winter_sumcheck::EqFunction;
 
 const LOG_POLY_SIZE: [usize; 2] = [18, 20];
 
-fn evaluate_eq_serial(c: &mut Criterion) {
+fn evaluate_eq(c: &mut Criterion) {
     let mut group = c.benchmark_group("EQ function evaluations");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(10));
 
     for &log_poly_size in LOG_POLY_SIZE.iter() {
-        group.bench_function(BenchmarkId::new("serial", log_poly_size), |b| {
+        group.bench_function(BenchmarkId::new("", log_poly_size), |b| {
             b.iter_batched(
                 || {
                     let randomness: Vec<BaseElement> = rand_vector(log_poly_size);
-                    randomness
+                    EqFunction::new(randomness.into())
                 },
-                |rand| eq_evaluations(&rand),
+                |eq_function| eq_function.evaluations(),
                 BatchSize::SmallInput,
             )
         });
     }
 }
 
-fn evaluate_eq_parallel(c: &mut Criterion) {
-    let mut group = c.benchmark_group("EQ function evaluations");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(10));
-
-    for &log_poly_size in LOG_POLY_SIZE.iter() {
-        group.bench_function(BenchmarkId::new("parallel", log_poly_size), |b| {
-            b.iter_batched(
-                || {
-                    let randomness: Vec<BaseElement> = rand_vector(log_poly_size);
-                    randomness
-                },
-                |rand| eq_evaluations_par(&rand),
-                BatchSize::SmallInput,
-            )
-        });
-    }
-}
-
-fn eq_evaluations<E: FieldElement>(query: &[E]) -> Vec<E> {
-    let n = 1 << query.len();
-    let mut evals = unsafe { utils::uninit_vector(n) };
-
-    let mut size = 1;
-    evals[0] = E::ONE;
-    for r_i in query.iter() {
-        let (left_evals, right_evals) = evals.split_at_mut(size);
-        left_evals.iter_mut().zip(right_evals.iter_mut()).for_each(|(left, right)| {
-            let factor = *left;
-            *right = factor * *r_i;
-            *left -= *right;
-        });
-
-        size *= 2;
-    }
-    evals
-}
-
-fn eq_evaluations_par<E: FieldElement>(query: &[E]) -> Vec<E> {
-    let n = 1 << query.len();
-    let mut evals = unsafe { utils::uninit_vector(n) };
-
-    let mut size = 1;
-    evals[0] = E::ONE;
-    for r_i in query.iter() {
-        let (left_evals, right_evals) = evals.split_at_mut(size);
-        left_evals
-            .par_iter_mut()
-            .zip(right_evals.par_iter_mut())
-            .for_each(|(left, right)| {
-                let factor = *left;
-                *right = factor * *r_i;
-                *left -= *right;
-            });
-
-        size <<= 1;
-    }
-    evals
-}
-
-criterion_group!(group, evaluate_eq_serial, evaluate_eq_parallel);
+criterion_group!(group, evaluate_eq);
 criterion_main!(group);


### PR DESCRIPTION
Improves Lagrange constraints evaluation. This improves the end-to-end LogUp-GKR benchmark by 17-18% on my machine.