### PR TITLE
Parallelize Lagrange constraints evaluation

### DIFF
--- a/air/src/air/logup_gkr/lagrange/boundary.rs
+++ b/air/src/air/logup_gkr/lagrange/boundary.rs
@@ -48,7 +48,7 @@ where
     /// `frame` is the evaluation frame of the Lagrange kernel column `c`, starting at `c(x)` for
     /// some `x`
     pub fn evaluate_numerator_at(&self, frame: &LagrangeKernelEvaluationFrame<E>) -> E {
-        let trace_value = frame.inner()[0];
+        let trace_value = frame[0];
         let constraint_evaluation = trace_value - self.assertion_value;
 
         constraint_evaluation * self.composition_coefficient

--- a/air/src/air/logup_gkr/lagrange/boundary.rs
+++ b/air/src/air/logup_gkr/lagrange/boundary.rs
@@ -31,27 +31,28 @@ where
         }
     }
 
+    /// Returns the constraint composition coefficient for this boundary constraint.
+    pub fn constraint_composition_coefficient(&self) -> E {
+        self.composition_coefficient
+    }
+
     /// Returns the evaluation of the boundary constraint at `x`, multiplied by the composition
     /// coefficient.
     ///
     /// `frame` is the evaluation frame of the Lagrange kernel column `c`, starting at `c(x)`
     pub fn evaluate_at(&self, x: E, frame: &LagrangeKernelEvaluationFrame<E>) -> E {
-        let numerator = self.evaluate_numerator_at(frame);
+        let numerator = self.evaluate_numerator_at(frame) * self.composition_coefficient;
         let denominator = self.evaluate_denominator_at(x);
 
         numerator / denominator
     }
 
-    /// Returns the evaluation of the boundary constraint numerator, multiplied by the composition
-    /// coefficient.
+    /// Returns the evaluation of the boundary constraint numerator.
     ///
     /// `frame` is the evaluation frame of the Lagrange kernel column `c`, starting at `c(x)` for
     /// some `x`
     pub fn evaluate_numerator_at(&self, frame: &LagrangeKernelEvaluationFrame<E>) -> E {
-        let trace_value = frame[0];
-        let constraint_evaluation = trace_value - self.assertion_value;
-
-        constraint_evaluation * self.composition_coefficient
+        frame[0] - self.assertion_value
     }
 
     /// Returns the evaluation of the boundary constraint denominator at point `x`.

--- a/air/src/air/logup_gkr/lagrange/frame.rs
+++ b/air/src/air/logup_gkr/lagrange/frame.rs
@@ -29,10 +29,14 @@ impl<E: FieldElement> LagrangeKernelEvaluationFrame<E> {
         Self { frame }
     }
 
+    pub fn inner_mut(&mut self) -> &mut [E] {
+        &mut self.frame
+    }
+
     /// Constructs an empty Lagrange kernel evaluation frame from the raw column polynomial
     /// evaluations. The frame can subsequently be filled using [`Self::frame_mut`].
-    pub fn new_empty() -> Self {
-        Self { frame: Vec::new() }
+    pub fn new_empty(size: usize) -> Self {
+        Self { frame: vec![E::ZERO; size] }
     }
 
     /// Constructs the frame from the Lagrange kernel column trace polynomial coefficients for an

--- a/air/src/air/logup_gkr/lagrange/frame.rs
+++ b/air/src/air/logup_gkr/lagrange/frame.rs
@@ -26,13 +26,13 @@ impl<E: FieldElement> LagrangeKernelEvaluationFrame<E> {
     // --------------------------------------------------------------------------------------------
 
     /// Constructs a Lagrange kernel evaluation frame from the raw column polynomial evaluations.
-    pub fn new(frame: Vec<E>) -> Self {
+    pub fn with_values(frame: Vec<E>) -> Self {
         Self { frame }
     }
 
     /// Constructs an empty Lagrange kernel evaluation frame from the raw column polynomial
     /// evaluations. The frame can subsequently be filled using [`Self::frame_mut`].
-    pub fn new_empty(trace_len: usize) -> Self {
+    pub fn new(trace_len: usize) -> Self {
         let frame_length = trace_len.ilog2() as usize + 1;
         Self { frame: vec![E::ZERO; frame_length] }
     }

--- a/air/src/air/logup_gkr/lagrange/frame.rs
+++ b/air/src/air/logup_gkr/lagrange/frame.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use alloc::vec::Vec;
+use core::ops::{Index, IndexMut};
 
 use math::{polynom, FieldElement, StarkField};
 
@@ -29,14 +30,11 @@ impl<E: FieldElement> LagrangeKernelEvaluationFrame<E> {
         Self { frame }
     }
 
-    pub fn inner_mut(&mut self) -> &mut [E] {
-        &mut self.frame
-    }
-
     /// Constructs an empty Lagrange kernel evaluation frame from the raw column polynomial
     /// evaluations. The frame can subsequently be filled using [`Self::frame_mut`].
-    pub fn new_empty(size: usize) -> Self {
-        Self { frame: vec![E::ZERO; size] }
+    pub fn new_empty(trace_len: usize) -> Self {
+        let frame_length = trace_len.ilog2() as usize + 1;
+        Self { frame: vec![E::ZERO; frame_length] }
     }
 
     /// Constructs the frame from the Lagrange kernel column trace polynomial coefficients for an
@@ -65,14 +63,6 @@ impl<E: FieldElement> LagrangeKernelEvaluationFrame<E> {
         Self { frame }
     }
 
-    // MUTATORS
-    // --------------------------------------------------------------------------------------------
-
-    /// Returns a mutable reference to the inner frame.
-    pub fn frame_mut(&mut self) -> &mut Vec<E> {
-        &mut self.frame
-    }
-
     // ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -86,5 +76,19 @@ impl<E: FieldElement> LagrangeKernelEvaluationFrame<E> {
     /// This is equal to `log(trace_length) + 1`.
     pub fn num_rows(&self) -> usize {
         self.frame.len()
+    }
+}
+
+impl<E: FieldElement> Index<usize> for LagrangeKernelEvaluationFrame<E> {
+    type Output = E;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.frame[index]
+    }
+}
+
+impl<E: FieldElement> IndexMut<usize> for LagrangeKernelEvaluationFrame<E> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.frame[index]
     }
 }

--- a/air/src/air/logup_gkr/lagrange/transition.rs
+++ b/air/src/air/logup_gkr/lagrange/transition.rs
@@ -54,8 +54,8 @@ impl<E: FieldElement> LagrangeKernelTransitionConstraints<E> {
         F: FieldElement<BaseField = E::BaseField>,
         E: ExtensionOf<F>,
     {
-        let c = lagrange_kernel_column_frame.inner();
-        let v = c.len() - 1;
+        let c = lagrange_kernel_column_frame;
+        let v = c.num_rows() - 1;
         let r = lagrange_kernel_rand_elements;
         let k = constraint_idx + 1;
 
@@ -124,8 +124,8 @@ impl<E: FieldElement> LagrangeKernelTransitionConstraints<E> {
         let log2_trace_len = lagrange_kernel_column_frame.num_rows() - 1;
         let mut transition_evals = vec![E::ZERO; log2_trace_len];
 
-        let c = lagrange_kernel_column_frame.inner();
-        let v = c.len() - 1;
+        let c = lagrange_kernel_column_frame;
+        let v = c.num_rows() - 1;
         let r = lagrange_kernel_rand_elements;
 
         for k in 1..v + 1 {

--- a/air/src/air/logup_gkr/lagrange/transition.rs
+++ b/air/src/air/logup_gkr/lagrange/transition.rs
@@ -43,6 +43,11 @@ impl<E: FieldElement> LagrangeKernelTransitionConstraints<E> {
         }
     }
 
+    /// Returns the constraint composition coefficients for the Lagrange kernel transition constraints.
+    pub fn lagrange_constraint_coefficients(&self) -> &[E] {
+        &self.lagrange_constraint_coefficients
+    }
+
     /// Evaluates the numerator of the `constraint_idx`th transition constraint.
     pub fn evaluate_ith_numerator<F>(
         &self,
@@ -59,9 +64,7 @@ impl<E: FieldElement> LagrangeKernelTransitionConstraints<E> {
         let r = lagrange_kernel_rand_elements;
         let k = constraint_idx + 1;
 
-        let eval = (r[v - k] * c[0]) - ((E::ONE - r[v - k]) * c[v - k + 1]);
-
-        self.lagrange_constraint_coefficients[constraint_idx].mul_base(eval)
+        (r[v - k] * c[0]) - ((E::ONE - r[v - k]) * c[v - k + 1])
     }
 
     /// Evaluates the divisor of the `constraint_idx`th transition constraint.

--- a/air/src/proof/ood_frame.rs
+++ b/air/src/proof/ood_frame.rs
@@ -131,7 +131,7 @@ impl OodFrame {
         let lagrange_kernel_frame = if lagrange_kernel_frame_size > 0 {
             let lagrange_kernel_trace = reader.read_many(lagrange_kernel_frame_size)?;
 
-            Some(LagrangeKernelEvaluationFrame::new(lagrange_kernel_trace))
+            Some(LagrangeKernelEvaluationFrame::with_values(lagrange_kernel_trace))
         } else {
             None
         };

--- a/prover/benches/logup_gkr.rs
+++ b/prover/benches/logup_gkr.rs
@@ -20,7 +20,7 @@ use winter_prover::{
     DefaultTraceLde, LogUpGkrConstraintEvaluator, Prover, StarkDomain, Trace, TracePolyTable,
 };
 
-const TRACE_LENS: [usize; 2] = [2_usize.pow(18), 2_usize.pow(19)];
+const TRACE_LENS: [usize; 2] = [2_usize.pow(18), 2_usize.pow(20)];
 const AUX_TRACE_WIDTH: usize = 2;
 
 /// Simple end-to-end benchmark for LogUp-GKR.

--- a/prover/benches/logup_gkr.rs
+++ b/prover/benches/logup_gkr.rs
@@ -17,10 +17,10 @@ use winter_prover::{
     crypto::{hashers::Blake3_256, DefaultRandomCoin},
     math::{fields::f64::BaseElement, ExtensionOf, FieldElement},
     matrix::ColMatrix,
-    DefaultConstraintEvaluator, DefaultTraceLde, Prover, StarkDomain, Trace, TracePolyTable,
+    DefaultTraceLde, LogUpGkrConstraintEvaluator, Prover, StarkDomain, Trace, TracePolyTable,
 };
 
-const TRACE_LENS: [usize; 2] = [2_usize.pow(20), 2_usize.pow(21)];
+const TRACE_LENS: [usize; 2] = [2_usize.pow(18), 2_usize.pow(19)];
 const AUX_TRACE_WIDTH: usize = 2;
 
 /// Simple end-to-end benchmark for LogUp-GKR.
@@ -310,7 +310,7 @@ impl Prover for LogUpGkrSimpleProver {
     type TraceLde<E: FieldElement<BaseField = BaseElement>> =
         DefaultTraceLde<E, Self::HashFn, Self::VC>;
     type ConstraintEvaluator<'a, E: FieldElement<BaseField = BaseElement>> =
-        DefaultConstraintEvaluator<'a, LogUpGkrSimpleAir, E>;
+        LogUpGkrConstraintEvaluator<'a, LogUpGkrSimpleAir, E>;
 
     fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
     }
@@ -340,7 +340,7 @@ impl Prover for LogUpGkrSimpleProver {
     where
         E: math::FieldElement<BaseField = Self::BaseField>,
     {
-        DefaultConstraintEvaluator::new(air, aux_rand_elements, composition_coefficients)
+        LogUpGkrConstraintEvaluator::new(air, aux_rand_elements.unwrap(), composition_coefficients)
     }
 
     fn build_aux_trace<E>(&self, main_trace: &Self::Trace, _aux_rand_elements: &[E]) -> ColMatrix<E>

--- a/prover/src/constraints/evaluation_table.rs
+++ b/prover/src/constraints/evaluation_table.rs
@@ -48,7 +48,7 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
         divisors: Vec<ConstraintDivisor<E::BaseField>>,
         logup_gkr_enabled: bool,
     ) -> Self {
-        let num_columns = divisors.len() +  2 * logup_gkr_enabled as usize;
+        let num_columns = divisors.len() + logup_gkr_enabled as usize;
         let num_rows = domain.ce_domain_size();
         ConstraintEvaluationTable {
             evaluations: uninit_matrix(num_columns, num_rows),
@@ -67,7 +67,7 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
         transition_constraints: &TransitionConstraints<E>,
         logup_gkr_enabled: bool,
     ) -> Self {
-        let num_columns = divisors.len() + 2 * logup_gkr_enabled as usize;
+        let num_columns = divisors.len() + logup_gkr_enabled as usize;
         let num_rows = domain.ce_domain_size();
         let num_tm_columns = transition_constraints.num_main_constraints();
         let num_ta_columns = transition_constraints.num_aux_constraints();
@@ -164,16 +164,15 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
     /// combines the results into a single column.
     pub fn combine(self) -> Vec<E> {
         // allocate memory for the combined polynomial
-        let mut combined_poly = vec![E::ZERO; self.num_rows()];
+        let mut combined_poly = unsafe { uninit_vector(self.num_rows()) };
 
-        // when LogUp-GKR is enabled, the last two columns contain the constraint evaluations of
-        // the Lagrange kernel column and s-column. These evaluations were already divided by
+        // when LogUp-GKR is enabled, the last column contains the constraint evaluations of
+        // the Lagrange kernel column and the s-column. These evaluations were already divided by
         // their respective divisors, and hence we just have to add them to `combined_poly`.
-        let offset = self.evaluations.len() - self.divisors.len();
-        if offset > 0 {
-            iter_mut!(combined_poly).enumerate().for_each(|(i, row)| {
-                *row = self.evaluations[offset][i] + self.evaluations[offset + 1][i]
-            });
+        if self.evaluations.len() != self.divisors.len() {
+            iter_mut!(combined_poly)
+                .enumerate()
+                .for_each(|(i, row)| *row = self.evaluations[self.divisors.len()][i]);
         }
 
         // iterate over all columns of the constraint evaluation table, divide each column

--- a/prover/src/constraints/evaluation_table.rs
+++ b/prover/src/constraints/evaluation_table.rs
@@ -46,8 +46,9 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
     pub fn new(
         domain: &'a StarkDomain<E::BaseField>,
         divisors: Vec<ConstraintDivisor<E::BaseField>>,
+        logup_gkr_enabled: bool,
     ) -> Self {
-        let num_columns = divisors.len();
+        let num_columns = divisors.len() +  2 * logup_gkr_enabled as usize;
         let num_rows = domain.ce_domain_size();
         ConstraintEvaluationTable {
             evaluations: uninit_matrix(num_columns, num_rows),
@@ -64,8 +65,9 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
         domain: &'a StarkDomain<E::BaseField>,
         divisors: Vec<ConstraintDivisor<E::BaseField>>,
         transition_constraints: &TransitionConstraints<E>,
+        logup_gkr_enabled: bool,
     ) -> Self {
-        let num_columns = divisors.len();
+        let num_columns = divisors.len() + 2 * logup_gkr_enabled as usize;
         let num_rows = domain.ce_domain_size();
         let num_tm_columns = transition_constraints.num_main_constraints();
         let num_ta_columns = transition_constraints.num_aux_constraints();
@@ -164,10 +166,23 @@ impl<'a, E: FieldElement> ConstraintEvaluationTable<'a, E> {
         // allocate memory for the combined polynomial
         let mut combined_poly = vec![E::ZERO; self.num_rows()];
 
+        // when LogUp-GKR is enabled, the last two columns contain the constraint evaluations of
+        // the Lagrange kernel column and s-column. These evaluations were already divided by
+        // their respective divisors, and hence we just have to add them to `combined_poly`.
+        let offset = self.evaluations.len() - self.divisors.len();
+        if offset > 0 {
+            iter_mut!(combined_poly).enumerate().for_each(|(i, row)| {
+                *row = self.evaluations[offset][i] + self.evaluations[offset + 1][i]
+            });
+        }
+
         // iterate over all columns of the constraint evaluation table, divide each column
         // by the evaluations of its corresponding divisor, and add all resulting evaluations
-        // together into a single vector
-        for (column, divisor) in self.evaluations.into_iter().zip(self.divisors.iter()) {
+        // together into a single vector. When LogUp-GKR is enabled, we skip the last two columns
+        // of the evaluation table as these were already handled above.
+        for (column, divisor) in
+            self.evaluations.into_iter().take(self.divisors.len()).zip(self.divisors.iter())
+        {
             // divide the column by the divisor and accumulate the result into combined_poly
             acc_column(column, divisor, self.domain, &mut combined_poly);
         }

--- a/prover/src/constraints/evaluator/default.rs
+++ b/prover/src/constraints/evaluator/default.rs
@@ -139,7 +139,7 @@ where
     ) -> Self {
         assert!(
             !air.context().logup_gkr_enabled(),
-            "evaluating LogUp-GKR constraints is not supported in DefaultConstraintEvaluator"
+            "evaluating LogUp-GKR constraints is not supported in `DefaultConstraintEvaluator`"
         );
 
         // build transition constraint groups; these will be used to compose transition constraint

--- a/prover/src/constraints/evaluator/default.rs
+++ b/prover/src/constraints/evaluator/default.rs
@@ -13,9 +13,8 @@ use utils::iter_mut;
 use utils::{iterators::*, rayon};
 
 use super::{
-    super::EvaluationTableFragment, BoundaryConstraints,
-    CompositionPolyTrace, ConstraintEvaluationTable, ConstraintEvaluator, PeriodicValueTable,
-    StarkDomain, TraceLde,
+    super::EvaluationTableFragment, BoundaryConstraints, CompositionPolyTrace,
+    ConstraintEvaluationTable, ConstraintEvaluator, PeriodicValueTable, StarkDomain, TraceLde,
 };
 
 // CONSTANTS

--- a/prover/src/constraints/evaluator/logup_gkr.rs
+++ b/prover/src/constraints/evaluator/logup_gkr.rs
@@ -82,7 +82,7 @@ where
         let mean = c / E::from(E::BaseField::from(trace.trace_info().length() as u32));
 
         #[cfg(feature = "concurrent")]
-        let _ = combined_evaluations_acc
+        combined_evaluations_acc
             .par_iter_mut()
             .enumerate()
             .fold(

--- a/prover/src/constraints/evaluator/logup_gkr.rs
+++ b/prover/src/constraints/evaluator/logup_gkr.rs
@@ -6,8 +6,8 @@
 use alloc::vec::Vec;
 
 use air::{
-    Air, GkrData, LagrangeConstraintsCompositionCoefficients,
-    LagrangeKernelConstraints, LogUpGkrEvaluator,
+    Air, GkrData, LagrangeConstraintsCompositionCoefficients, LagrangeKernelConstraints,
+    LogUpGkrEvaluator,
 };
 use math::{batch_inversion, FieldElement};
 #[cfg(feature = "concurrent")]
@@ -29,7 +29,6 @@ pub struct LogUpGkrConstraintsEvaluator<E: FieldElement> {
 impl<E> LogUpGkrConstraintsEvaluator<E>
 where
     E: FieldElement,
-    
 {
     /// Constructs a new [`LogUpGkrConstraintsEvaluator`].
     pub fn new<A: Air<BaseField = E::BaseField>>(

--- a/prover/src/constraints/evaluator/logup_gkr_evaluator.rs
+++ b/prover/src/constraints/evaluator/logup_gkr_evaluator.rs
@@ -378,8 +378,8 @@ where
                 .boundary
                 .evaluate_numerator_at(lagrange_frame);
 
-            combined_evaluations += boundary_numerator
-                .mul_base(constraints_divisors.get_lagrange_boundary_divisor_inv(step));
+            combined_evaluations +=
+                boundary_numerator * constraints_divisors.get_lagrange_boundary_multiplier(step);
         }
 
         combined_evaluations

--- a/prover/src/constraints/evaluator/mod.rs
+++ b/prover/src/constraints/evaluator/mod.rs
@@ -16,6 +16,9 @@ use boundary::BoundaryConstraints;
 
 mod logup_gkr;
 
+mod logup_gkr_evaluator;
+pub use logup_gkr_evaluator::LogUpGkrConstraintEvaluator;
+
 mod periodic_table;
 use periodic_table::PeriodicValueTable;
 

--- a/prover/src/constraints/mod.rs
+++ b/prover/src/constraints/mod.rs
@@ -6,7 +6,7 @@
 use super::{ColMatrix, ConstraintDivisor, RowMatrix, StarkDomain};
 
 mod evaluator;
-pub use evaluator::{ConstraintEvaluator, DefaultConstraintEvaluator};
+pub use evaluator::{ConstraintEvaluator, DefaultConstraintEvaluator, LogUpGkrConstraintEvaluator};
 
 mod composition_poly;
 pub use composition_poly::{CompositionPoly, CompositionPolyTrace};

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -74,7 +74,7 @@ use matrix::{ColMatrix, RowMatrix};
 mod constraints;
 pub use constraints::{
     CompositionPoly, CompositionPolyTrace, ConstraintCommitment, ConstraintEvaluator,
-    DefaultConstraintEvaluator,
+    DefaultConstraintEvaluator, LogUpGkrConstraintEvaluator
 };
 
 mod composer;

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -74,7 +74,7 @@ use matrix::{ColMatrix, RowMatrix};
 mod constraints;
 pub use constraints::{
     CompositionPoly, CompositionPolyTrace, ConstraintCommitment, ConstraintEvaluator,
-    DefaultConstraintEvaluator, LogUpGkrConstraintEvaluator
+    DefaultConstraintEvaluator, LogUpGkrConstraintEvaluator,
 };
 
 mod composer;

--- a/prover/src/logup_gkr/mod.rs
+++ b/prover/src/logup_gkr/mod.rs
@@ -4,8 +4,6 @@ use core::ops::Add;
 use air::{EvaluationFrame, GkrData, LogUpGkrEvaluator};
 use math::FieldElement;
 use sumcheck::{EqFunction, MultiLinearPoly, SumCheckProverError};
-#[cfg(feature = "concurrent")]
-pub use utils::rayon::prelude::*;
 use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use crate::Trace;

--- a/prover/src/logup_gkr/mod.rs
+++ b/prover/src/logup_gkr/mod.rs
@@ -4,6 +4,8 @@ use core::ops::Add;
 use air::{EvaluationFrame, GkrData, LogUpGkrEvaluator};
 use math::FieldElement;
 use sumcheck::{EqFunction, MultiLinearPoly, SumCheckProverError};
+#[cfg(feature = "concurrent")]
+pub use utils::rayon::prelude::*;
 use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use crate::Trace;
@@ -111,37 +113,95 @@ impl<E: FieldElement> EvaluatedCircuit<E> {
         let num_fractions = evaluator.get_num_fractions();
         let periodic_values = evaluator.build_periodic_values();
 
-        let mut input_layer_wires =
-            Vec::with_capacity(main_trace.main_segment().num_rows() * num_fractions);
-        let mut main_frame = EvaluationFrame::new(main_trace.main_segment().num_cols());
-
-        let mut query = vec![E::BaseField::ZERO; evaluator.get_oracles().len()];
-        let mut periodic_values_row = vec![E::BaseField::ZERO; periodic_values.num_columns()];
-        let mut numerators = vec![E::ZERO; num_fractions];
-        let mut denominators = vec![E::ZERO; num_fractions];
-        for i in 0..main_trace.main_segment().num_rows() {
-            let wires_from_trace_row = {
-                main_trace.read_main_frame(i, &mut main_frame);
-                periodic_values.fill_periodic_values_at(i, &mut periodic_values_row);
-                evaluator.build_query(&main_frame, &mut query);
-
-                evaluator.evaluate_query(
-                    &query,
-                    &periodic_values_row,
-                    log_up_randomness,
-                    &mut numerators,
-                    &mut denominators,
-                );
-                let input_gates_values: Vec<CircuitWire<E>> = numerators
-                    .iter()
-                    .zip(denominators.iter())
-                    .map(|(numerator, denominator)| CircuitWire::new(*numerator, *denominator))
-                    .collect();
-                input_gates_values
+        #[cfg(feature = "concurrent")]
+        let input_layer_wires = {
+            let mut input_layer_wires = unsafe {
+                utils::uninit_vector(main_trace.main_segment().num_rows() * num_fractions)
             };
+            input_layer_wires
+                .par_chunks_mut(num_fractions)
+                .enumerate()
+                .fold(
+                    || {
+                        (
+                            EvaluationFrame::new(main_trace.main_segment().num_cols()),
+                            vec![E::BaseField::ZERO; evaluator.get_oracles().len()],
+                            vec![E::BaseField::ZERO; periodic_values.num_columns()],
+                            vec![E::ZERO; num_fractions],
+                            vec![E::ZERO; num_fractions],
+                        )
+                    },
+                    |(
+                        mut main_frame,
+                        mut query,
+                        mut periodic_values_row,
+                        mut numerators,
+                        mut denominators,
+                    ),
+                     (i, acc)| {
+                        main_trace.read_main_frame(i, &mut main_frame);
+                        periodic_values.fill_periodic_values_at(i, &mut periodic_values_row);
+                        evaluator.build_query(&main_frame, &mut query);
 
-            input_layer_wires.extend(wires_from_trace_row);
-        }
+                        evaluator.evaluate_query(
+                            &query,
+                            &periodic_values_row,
+                            log_up_randomness,
+                            &mut numerators,
+                            &mut denominators,
+                        );
+
+                        acc.iter_mut().zip(numerators.iter().zip(denominators.iter())).for_each(
+                            |(a, (numerator, denominator))| {
+                                *a = CircuitWire::new(*numerator, *denominator)
+                            },
+                        );
+
+                        (main_frame, query, periodic_values_row, numerators, denominators)
+                    },
+                )
+                .map(|(..)| {})
+                .reduce(|| {}, |_, _| {});
+            input_layer_wires
+        };
+
+        #[cfg(not(feature = "concurrent"))]
+        let input_layer_wires = {
+            let mut input_layer_wires =
+                Vec::with_capacity(main_trace.main_segment().num_rows() * num_fractions);
+
+            let mut main_frame = EvaluationFrame::new(main_trace.main_segment().num_cols());
+
+            let mut query = vec![E::BaseField::ZERO; evaluator.get_oracles().len()];
+            let mut periodic_values_row = vec![E::BaseField::ZERO; periodic_values.num_columns()];
+            let mut numerators = vec![E::ZERO; num_fractions];
+            let mut denominators = vec![E::ZERO; num_fractions];
+
+            for i in 0..main_trace.main_segment().num_rows() {
+                let wires_from_trace_row = {
+                    main_trace.read_main_frame(i, &mut main_frame);
+                    periodic_values.fill_periodic_values_at(i, &mut periodic_values_row);
+                    evaluator.build_query(&main_frame, &mut query);
+
+                    evaluator.evaluate_query(
+                        &query,
+                        &periodic_values_row,
+                        log_up_randomness,
+                        &mut numerators,
+                        &mut denominators,
+                    );
+                    let input_gates_values: Vec<CircuitWire<E>> = numerators
+                        .iter()
+                        .zip(denominators.iter())
+                        .map(|(numerator, denominator)| CircuitWire::new(*numerator, *denominator))
+                        .collect();
+                    input_gates_values
+                };
+
+                input_layer_wires.extend(wires_from_trace_row);
+            }
+            input_layer_wires
+        };
 
         CircuitLayer::new(input_layer_wires)
     }

--- a/prover/src/trace/mod.rs
+++ b/prover/src/trace/mod.rs
@@ -56,7 +56,7 @@ pub struct AuxTraceWithMetadata<E: FieldElement> {
 /// implementation supports concurrent trace generation and should be sufficient in most
 /// situations. However, if functionality provided by [TraceTable] is not sufficient, uses can
 /// provide custom implementations of the [Trace] trait which better suit their needs.
-pub trait Trace: Sized {
+pub trait Trace: Sized + Sync {
     /// Base field for this execution trace.
     ///
     /// All cells of this execution trace contain values which are elements in this field.

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -195,8 +195,6 @@ where
         lagrange_kernel_aux_column_idx: usize,
         frame: &mut LagrangeKernelEvaluationFrame<E>,
     ) {
-        let frame = frame.frame_mut();
-
         let aux_segment =
             self.aux_segment_lde.as_ref().expect("expected aux segment to be present");
 

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -196,19 +196,18 @@ where
         frame: &mut LagrangeKernelEvaluationFrame<E>,
     ) {
         let frame = frame.frame_mut();
-        frame.truncate(0);
 
         let aux_segment =
             self.aux_segment_lde.as_ref().expect("expected aux segment to be present");
 
-        frame.push(aux_segment.get(lagrange_kernel_aux_column_idx, lde_step));
+        frame[0] = aux_segment.get(lagrange_kernel_aux_column_idx, lde_step);
 
         let frame_length = self.trace_info.length().ilog2() as usize + 1;
         for i in 0..frame_length - 1 {
             let shift = self.blowup() * (1 << i);
             let next_lde_step = (lde_step + shift) % self.trace_len();
 
-            frame.push(aux_segment.get(lagrange_kernel_aux_column_idx, next_lde_step));
+            frame[i + 1] = aux_segment.get(lagrange_kernel_aux_column_idx, next_lde_step);
         }
     }
 

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -594,10 +594,11 @@ pub use air::{AuxRandElements, LogUpGkrEvaluator};
 pub use prover::{
     crypto, iterators, math, matrix, Air, AirContext, Assertion, AuxTraceWithMetadata,
     BoundaryConstraint, BoundaryConstraintGroup, CompositionPolyTrace,
-    ConstraintCompositionCoefficients, ConstraintDivisor, ConstraintEvaluator, LogUpGkrConstraintEvaluator,
+    ConstraintCompositionCoefficients, ConstraintDivisor, ConstraintEvaluator,
     DeepCompositionCoefficients, DefaultConstraintEvaluator, DefaultTraceLde, EvaluationFrame,
-    FieldExtension, Proof, ProofOptions, Prover, ProverError, StarkDomain, Trace, TraceInfo,
-    TraceLde, TracePolyTable, TraceTable, TraceTableFragment, TransitionConstraintDegree,
+    FieldExtension, LogUpGkrConstraintEvaluator, Proof, ProofOptions, Prover, ProverError,
+    StarkDomain, Trace, TraceInfo, TraceLde, TracePolyTable, TraceTable, TraceTableFragment,
+    TransitionConstraintDegree,
 };
 pub use verifier::{verify, AcceptableOptions, ByteWriter, VerifierError};
 

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -594,7 +594,7 @@ pub use air::{AuxRandElements, LogUpGkrEvaluator};
 pub use prover::{
     crypto, iterators, math, matrix, Air, AirContext, Assertion, AuxTraceWithMetadata,
     BoundaryConstraint, BoundaryConstraintGroup, CompositionPolyTrace,
-    ConstraintCompositionCoefficients, ConstraintDivisor, ConstraintEvaluator,
+    ConstraintCompositionCoefficients, ConstraintDivisor, ConstraintEvaluator, LogUpGkrConstraintEvaluator,
     DeepCompositionCoefficients, DefaultConstraintEvaluator, DefaultTraceLde, EvaluationFrame,
     FieldExtension, Proof, ProofOptions, Prover, ProverError, StarkDomain, Trace, TraceInfo,
     TraceLde, TracePolyTable, TraceTable, TraceTableFragment, TransitionConstraintDegree,

--- a/winterfell/src/tests/logup_gkr_periodic.rs
+++ b/winterfell/src/tests/logup_gkr_periodic.rs
@@ -17,7 +17,7 @@ use crate::{
     crypto::{hashers::Blake3_256, DefaultRandomCoin},
     math::{fields::f64::BaseElement, ExtensionOf, FieldElement},
     matrix::ColMatrix,
-    DefaultConstraintEvaluator, DefaultTraceLde, Prover, StarkDomain, TracePolyTable,
+    DefaultTraceLde, Prover, StarkDomain, TracePolyTable,
 };
 
 #[test]
@@ -299,7 +299,7 @@ impl Prover for LogUpGkrPeriodicProver {
     type TraceLde<E: FieldElement<BaseField = BaseElement>> =
         DefaultTraceLde<E, Self::HashFn, Self::VC>;
     type ConstraintEvaluator<'a, E: FieldElement<BaseField = BaseElement>> =
-        DefaultConstraintEvaluator<'a, LogUpGkrPeriodicAir, E>;
+        LogUpGkrConstraintEvaluator<'a, LogUpGkrPeriodicAir, E>;
 
     fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
     }
@@ -329,7 +329,7 @@ impl Prover for LogUpGkrPeriodicProver {
     where
         E: math::FieldElement<BaseField = Self::BaseField>,
     {
-        DefaultConstraintEvaluator::new(air, aux_rand_elements, composition_coefficients)
+        LogUpGkrConstraintEvaluator::new(air, aux_rand_elements.unwrap(), composition_coefficients)
     }
 
     fn build_aux_trace<E>(&self, main_trace: &Self::Trace, _aux_rand_elements: &[E]) -> ColMatrix<E>

--- a/winterfell/src/tests/logup_gkr_simple.rs
+++ b/winterfell/src/tests/logup_gkr_simple.rs
@@ -17,7 +17,7 @@ use crate::{
     crypto::{hashers::Blake3_256, DefaultRandomCoin},
     math::{fields::f64::BaseElement, ExtensionOf, FieldElement},
     matrix::ColMatrix,
-    DefaultConstraintEvaluator, DefaultTraceLde, Prover, StarkDomain, TracePolyTable,
+    DefaultTraceLde, Prover, StarkDomain, TracePolyTable,
 };
 
 #[test]
@@ -285,7 +285,7 @@ impl Prover for LogUpGkrSimpleProver {
     type TraceLde<E: FieldElement<BaseField = BaseElement>> =
         DefaultTraceLde<E, Self::HashFn, Self::VC>;
     type ConstraintEvaluator<'a, E: FieldElement<BaseField = BaseElement>> =
-        DefaultConstraintEvaluator<'a, LogUpGkrSimpleAir, E>;
+        LogUpGkrConstraintEvaluator<'a, LogUpGkrSimpleAir, E>;
 
     fn get_pub_inputs(&self, _trace: &Self::Trace) -> <<Self as Prover>::Air as Air>::PublicInputs {
     }
@@ -315,7 +315,7 @@ impl Prover for LogUpGkrSimpleProver {
     where
         E: math::FieldElement<BaseField = Self::BaseField>,
     {
-        DefaultConstraintEvaluator::new(air, aux_rand_elements, composition_coefficients)
+        LogUpGkrConstraintEvaluator::new(air, aux_rand_elements.unwrap(), composition_coefficients)
     }
 
     fn build_aux_trace<E>(&self, main_trace: &Self::Trace, _aux_rand_elements: &[E]) -> ColMatrix<E>


### PR DESCRIPTION
Builds on #315 and supersedes #316 .
The PR proposes a new constraint evaluator that is specific to when LogUp-GKR is enabled.
This has also the advantage of closing #306 .