### PR TITLE
Optimize `bind_least_significant_variable`

### DIFF
--- a/sumcheck/benches/bind_variable.rs
+++ b/sumcheck/benches/bind_variable.rs
@@ -66,8 +66,14 @@ fn bind_least_significant_variable_serial<E: FieldElement>(
     let num_evals = evaluations.len() >> 1;
 
     for i in 0..num_evals {
-        evaluations[i] = evaluations[i << 1]
-            + round_challenge * (evaluations[(i << 1) + 1] - evaluations[i << 1]);
+        // SAFETY: This loops over [0, evaluations.len()/2). The largest value for `i` is
+        // `(evaluations.len() / 2) - 1`. Hence, the largest value for `(i<<1)` is
+        // `evaluations.len() - 2`, and largest value for `(i<<1) + 1` is `evaluations.len() - 1`.
+        let evaluations_2i = unsafe { *evaluations.get_unchecked(i << 1) };
+        let evaluations_2i_plus_1 = unsafe { *evaluations.get_unchecked((i << 1) + 1) };
+
+        evaluations[i] =
+            evaluations_2i + round_challenge * (evaluations_2i_plus_1 - evaluations_2i);
     }
     evaluations.truncate(num_evals);
 }

--- a/sumcheck/benches/bind_variable.rs
+++ b/sumcheck/benches/bind_variable.rs
@@ -16,8 +16,7 @@ const POLY_SIZE: [usize; 2] = [1 << 18, 1 << 20];
 
 fn bind_variable(c: &mut Criterion) {
     let mut group = c.benchmark_group("bind variable ");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(10));
+    group.measurement_time(Duration::from_secs(15));
 
     for &poly_size in POLY_SIZE.iter() {
         group.bench_function(BenchmarkId::new("", poly_size), |b| {

--- a/sumcheck/src/multilinear.rs
+++ b/sumcheck/src/multilinear.rs
@@ -79,7 +79,8 @@ impl<E: FieldElement> MultiLinearPoly<E> {
                 // `(evaluations.len() / 2) - 1`. Hence, the largest value for `(i<<1)` is
                 // `evaluations.len() - 2`, and largest value for `(i<<1) + 1` is `evaluations.len() - 1`.
                 let evaluations_2i = unsafe { *self.evaluations.get_unchecked(i << 1) };
-                let evaluations_2i_plus_1 = unsafe { *self.evaluations.get_unchecked((i << 1) + 1) };
+                let evaluations_2i_plus_1 =
+                    unsafe { *self.evaluations.get_unchecked((i << 1) + 1) };
 
                 self.evaluations[i] =
                     evaluations_2i + round_challenge * (evaluations_2i_plus_1 - evaluations_2i);
@@ -91,8 +92,14 @@ impl<E: FieldElement> MultiLinearPoly<E> {
         {
             let mut result = unsafe { utils::uninit_vector(num_evals) };
             result.par_iter_mut().enumerate().for_each(|(i, ev)| {
-                *ev = self.evaluations[i << 1]
-                    + round_challenge * (self.evaluations[(i << 1) + 1] - self.evaluations[i << 1])
+                // SAFETY: This loops over [0, evaluations.len()/2). The largest value for `i` is
+                // `(evaluations.len() / 2) - 1`. Hence, the largest value for `(i<<1)` is
+                // `evaluations.len() - 2`, and largest value for `(i<<1) + 1` is `evaluations.len() - 1`.
+                let evaluations_2i = unsafe { *self.evaluations.get_unchecked(i << 1) };
+                let evaluations_2i_plus_1 =
+                    unsafe { *self.evaluations.get_unchecked((i << 1) + 1) };
+
+                *ev = evaluations_2i + round_challenge * (evaluations_2i_plus_1 - evaluations_2i);
             });
             self.evaluations = result
         }

--- a/sumcheck/src/multilinear.rs
+++ b/sumcheck/src/multilinear.rs
@@ -70,6 +70,7 @@ impl<E: FieldElement> MultiLinearPoly<E> {
     /// Computes $f(r_0, y_1, ..., y_{{\nu} - 1})$ using the linear interpolation formula
     /// $(1 - r_0) * f(0, y_1, ..., y_{{\nu} - 1}) + r_0 * f(1, y_1, ..., y_{{\nu} - 1})$ and assigns
     /// the resulting multi-linear, defined over a domain of half the size, to `self`.
+    #[inline(always)]
     pub fn bind_least_significant_variable(&mut self, round_challenge: E) {
         let num_evals = self.evaluations.len() >> 1;
         #[cfg(not(feature = "concurrent"))]


### PR DESCRIPTION
This PR removes the slide bound checks in `MultiLinearPoly::bind_least_significant_variable`.

In the serial case, we see a 7-9% improvement in the `bind-variable` benchmark, and sum-check performance improvement by 2.5-3.5%. Parallel performance doesn't change, presumably since the algorithm is bounded by the threading overhead rather than the time each threads spends looping over its chunk.

The LogUp-GKR benchmark also didn't change, since `bind_least_significant_variable` was not a bottleneck. However I see this PR as a proof of concept, and will apply similar bound checks removal in any hot loop I find in a subsequent PR.

Below are the serial bind-variable and sum-check benchmark results:

```
bind variable //262144  time:   [219.29 µs 225.73 µs 231.25 µs]
                        change: [-9.5833% -6.9170% -3.6918%] (p = 0.00 < 0.05)
                        Performance has improved.
bind variable //1048576 time:   [877.21 µs 907.05 µs 923.14 µs]
                        change: [-12.616% -8.9228% -4.7734%] (p = 0.00 < 0.05)
                        Performance has improved.

Sum-check prover high degree//18
                        time:   [26.296 ms 26.391 ms 26.504 ms]
                        change: [-3.3216% -2.7946% -2.2863%] (p = 0.00 < 0.05)
                        Performance has improved.
Sum-check prover high degree//20
                        time:   [100.89 ms 101.80 ms 102.65 ms]
                        change: [-3.6253% -2.6530% -1.6493%] (p = 0.00 < 0.05)
                        Performance has improved.

Sum-check prover plain//18
                        time:   [8.1104 ms 8.1457 ms 8.2036 ms]
                        change: [-4.6356% -3.6520% -2.6455%] (p = 0.00 < 0.05)
                        Performance has improved.
Sum-check prover plain//20
                        time:   [32.213 ms 32.604 ms 32.995 ms]
                        change: [-3.9200% -2.2554% -0.5909%] (p = 0.03 < 0.05)
                        Change within noise threshold.
```