### PR TITLE
Minor: Documentation of the default prover/verifier example causes issue in rust analyser

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ impl Air for WorkAir {
         result: &mut [E],
     ) {
         // First, we'll read the current state, and use it to compute the expected next state
-        let current_state = &frame.current()[0];
+        let current_state = frame.current()[0];
         let next_state = current_state.exp(3u32.into()) + E::from(42u32);
 
         // Then, we'll subtract the expected next state from the actual next state; this will

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -223,7 +223,7 @@
 //!         result: &mut [E],
 //!     ) {
 //!         // First, we'll read the current state, and use it to compute the expected next state
-//!         let current_state = &frame.current()[0];
+//!         let current_state = frame.current()[0];
 //!         let next_state = current_state.exp(3u32.into()) + E::from(42u32);
 //!
 //!         // Then, we'll subtract the expected next state from the actual next state; this will


### PR DESCRIPTION
PR fixes a minor issue in the documentation of the default prover/verifier example - note the cargo build is independent of this problem. 

The [prover example](https://docs.rs/winterfell/latest/winterfell/) causes rust analyser (vs code) to flag an error - requiring a ref to be added here `E::from(42u32)` - adding the ref causes the analyser to flag another error asking for the ref to be removed.

```
let current_state = &frame.current()[0];
let next_state = current_state.exp(3u32.into()) + E::from(42u32); 
```

Removing the ref in the first line solves the problem.