### PR TITLE
Reduce degree of sum-check round polynomials

### DIFF
--- a/prover/src/logup_gkr/prover.rs
+++ b/prover/src/logup_gkr/prover.rs
@@ -205,13 +205,14 @@ fn prove_intermediate_layers<
     // reduced in terms of the input layer separately in `prove_final_circuit_layer`.
     for inner_layer in circuit.layers().into_iter().skip(1).rev().skip(1) {
         // construct the Lagrange kernel evaluated at the previous GKR round randomness
-        let mut eq_mle = EqFunction::ml_at(evaluation_point.into());
+        let mut eq_mle = EqFunction::ml_at(evaluation_point.clone().into());
 
         let (numerators, denominators) = inner_layer.into_numerators_denominators();
 
         // run the sumcheck protocol
         let proof = sum_check_prove_num_rounds_degree_3(
             claimed_evaluation,
+            &evaluation_point,
             numerators,
             denominators,
             &mut eq_mle,
@@ -260,6 +261,7 @@ fn sum_check_prove_num_rounds_degree_3<
     H: ElementHasher<BaseField = E::BaseField>,
 >(
     claim: (E, E),
+    evaluation_point: &[E],
     p: MultiLinearPoly<E>,
     q: MultiLinearPoly<E>,
     eq: &mut MultiLinearPoly<E>,
@@ -270,7 +272,7 @@ fn sum_check_prove_num_rounds_degree_3<
     let r_batch = transcript.draw().map_err(|_| GkrProverError::FailedToGenerateChallenge)?;
     let claim = claim.0 + claim.1 * r_batch;
 
-    let proof = sumcheck_prove_plain(claim, r_batch, p, q, eq, transcript)?;
+    let proof = sumcheck_prove_plain(claim, evaluation_point, r_batch, p, q, eq, transcript)?;
 
     Ok(proof)
 }

--- a/sumcheck/benches/sum_check_plain.rs
+++ b/sumcheck/benches/sum_check_plain.rs
@@ -27,7 +27,7 @@ fn sum_check_plain(c: &mut Criterion) {
                         DefaultRandomCoin::<Blake3_192<BaseElement>>::new(&[BaseElement::ZERO; 4]);
                     (setup_sum_check::<BaseElement>(log_poly_size), transcript)
                 },
-                |((claim, r_batch, p, q, eq), transcript)| {
+                |((claim, evaluation_point, r_batch, p, q, eq), transcript)| {
                     let mut eq = eq;
                     let mut transcript = transcript;
                     sumcheck_prove_plain(claim, r_batch, p, q, &mut eq, &mut transcript)
@@ -42,7 +42,7 @@ fn sum_check_plain(c: &mut Criterion) {
 #[allow(clippy::type_complexity)]
 fn setup_sum_check<E: FieldElement>(
     log_size: usize,
-) -> (E, E, MultiLinearPoly<E>, MultiLinearPoly<E>, MultiLinearPoly<E>) {
+) -> (E, Vec<E>, E, MultiLinearPoly<E>, MultiLinearPoly<E>, MultiLinearPoly<E>) {
     let n = 1 << (log_size + 1);
     let p: Vec<E> = rand_vector(n);
     let q: Vec<E> = rand_vector(n);
@@ -52,12 +52,13 @@ fn setup_sum_check<E: FieldElement>(
     let rand_pt = rand_vector(log_size);
     let r_batch: E = rand_value();
     let claim: E = rand_value();
+    let evaluation_point = rand_vector(log_size);
 
     let p = MultiLinearPoly::from_evaluations(p);
     let q = MultiLinearPoly::from_evaluations(q);
     let eq = MultiLinearPoly::from_evaluations(EqFunction::new(rand_pt.into()).evaluations());
 
-    (claim, r_batch, p, q, eq)
+    (claim, evaluation_point, r_batch, p, q, eq)
 }
 
 criterion_group!(group, sum_check_plain);

--- a/sumcheck/benches/sum_check_plain.rs
+++ b/sumcheck/benches/sum_check_plain.rs
@@ -30,7 +30,15 @@ fn sum_check_plain(c: &mut Criterion) {
                 |((claim, evaluation_point, r_batch, p, q, eq), transcript)| {
                     let mut eq = eq;
                     let mut transcript = transcript;
-                    sumcheck_prove_plain(claim, r_batch, p, q, &mut eq, &mut transcript)
+                    sumcheck_prove_plain(
+                        claim,
+                        &evaluation_point,
+                        r_batch,
+                        p,
+                        q,
+                        &mut eq,
+                        &mut transcript,
+                    )
                 },
                 BatchSize::SmallInput,
             )

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -23,7 +23,7 @@ mod verifier;
 pub use verifier::*;
 
 mod univariate;
-pub use univariate::{CompressedUnivariatePoly, CompressedUnivariatePolyEvals};
+pub use univariate::CompressedUnivariatePoly;
 
 mod multilinear;
 pub use multilinear::{inner_product, EqFunction, MultiLinearPoly};

--- a/sumcheck/src/prover/high_degree.rs
+++ b/sumcheck/src/prover/high_degree.rs
@@ -206,8 +206,8 @@ use crate::{
 /// $$
 ///
 /// As the prover computes $v_{i+1}^{'}(X)$ in evaluation form and hence also $v_{i+1}(X)$, this
-/// means that due to the degrees being off by $1$, the prover uses we can use the linear factor
-/// in order to obtain an extra evaluation point in order to be able to interpolate $v_{i+1}(X)$.
+/// means that due to the degrees being off by $1$, the prover uses the linear factor in order to
+/// obtain an additional evaluation point in order to be able to interpolate $v_{i+1}(X)$.
 /// More precisely, we can get a root of $$v_{i+1}(X) = 0$$ by solving $$Eq\left( \alpha_i ; X \right) = 0$$
 /// The latter equation has as solution $$\mathsf{r} = \frac{1 - \alpha}{1 - 2\cdot\alpha}$$
 /// which is, except with negligible probability, an evaluation point not in the original
@@ -287,13 +287,13 @@ pub fn sum_check_prove_higher_degree<
     let mut scaling_up_factor = E::ONE;
     // this will hold `Eq((\alpha_{0}, \cdots, \alpha_{i}); (0, \cdots, 0))` for all `i`
     let scaling_down_factors = compute_scaling_down_factors(evaluation_point_nu);
-    // this `\alpha_i`
-    let mut alpha = evaluation_point_nu[0];
+    // this is `\alpha_i` above
+    let mut alpha_i = evaluation_point_nu[0];
     let scaling_down_factor = scaling_down_factors[0];
     let round_poly_coefs = to_coefficients(
         &mut round_poly_evals,
         current_round_claim.claim,
-        alpha,
+        alpha_i,
         scaling_down_factor,
         scaling_up_factor,
     );
@@ -308,9 +308,9 @@ pub fn sum_check_prove_higher_degree<
             coin.draw().map_err(|_| SumCheckProverError::FailedToGenerateChallenge)?;
 
         // update `scaling_up_factor`
-        alpha = evaluation_point_nu[evaluation_point_nu.len() - mls[0].num_variables()];
+        alpha_i = evaluation_point_nu[evaluation_point_nu.len() - mls[0].num_variables()];
         scaling_up_factor *=
-            round_challenge * alpha + (E::ONE - round_challenge) * (E::ONE - alpha);
+            round_challenge * alpha_i + (E::ONE - round_challenge) * (E::ONE - alpha_i);
 
         // compute the new reduced round claim
         let new_round_claim =
@@ -339,13 +339,12 @@ pub fn sum_check_prove_higher_degree<
         // update the claim
         current_round_claim = new_round_claim;
 
-        let alpha = evaluation_point_nu[i];
-        let scaling_down_factor = scaling_down_factors[i];
+        let alpha_i = evaluation_point_nu[i];
         let round_poly_coefs = to_coefficients(
             &mut round_poly_evals,
             current_round_claim.claim,
-            alpha,
-            scaling_down_factor,
+            alpha_i,
+            scaling_down_factors[i],
             scaling_up_factor,
         );
 
@@ -480,7 +479,7 @@ fn sumcheck_round<E: FieldElement>(
                     r_sum_check,
                 );
 
-                // compute the evaluations at 2, ..., d_max points
+                // compute the evaluations at `2, ..., d_max - 1` points
                 for i in 0..num_mls {
                     deltas[i] = evals_one[i] - evals_zero[i];
                     evals_x[i] = evals_one[i];
@@ -590,7 +589,7 @@ fn sumcheck_round<E: FieldElement>(
                     r_sum_check,
                 );
 
-                // compute the evaluations at 2, ..., d_max points
+                // compute the evaluations at `2, ..., d_max - 1` points
                 for i in 0..num_mls {
                     deltas[i] = evals_one[i] - evals_zero[i];
                     evals_x[i] = evals_one[i];

--- a/sumcheck/src/prover/high_degree.rs
+++ b/sumcheck/src/prover/high_degree.rs
@@ -537,12 +537,11 @@ fn sumcheck_round<E: FieldElement>(
                     vec![E::ZERO; num_periodic],
                     vec![E::ZERO; num_periodic],
                     vec![E::ZERO; num_periodic],
-                    vec![E::ZERO; evaluator.max_degree() - 1],
                     vec![E::ZERO; evaluator.get_num_fractions()],
                     vec![E::ZERO; evaluator.get_num_fractions()],
                     vec![E::ZERO; num_mls],
                     vec![E::ZERO; num_periodic],
-                    vec![E::ZERO; evaluator.max_degree()],
+                    vec![E::ZERO; evaluator.max_degree() - 1],
                 )
             },
             |(

--- a/sumcheck/src/prover/high_degree.rs
+++ b/sumcheck/src/prover/high_degree.rs
@@ -448,7 +448,7 @@ fn sumcheck_round<E: FieldElement>(
         let mut denominators = vec![E::ZERO; evaluator.get_num_fractions()];
         (0..1 << num_rounds)
             .map(|i| {
-                let mut poly_evals = vec![E::ZERO; evaluator.max_degree()];
+                let mut poly_evals = vec![E::ZERO; evaluator.max_degree() - 1];
 
                 for (j, ml) in mls.iter().enumerate() {
                     evals_zero[j] = ml.evaluations()[2 * i];
@@ -518,7 +518,7 @@ fn sumcheck_round<E: FieldElement>(
 
                 poly_evals
             })
-            .fold(vec![E::ZERO; evaluator.max_degree()], |mut acc, poly_eval| {
+            .fold(vec![E::ZERO; evaluator.max_degree() - 1], |mut acc, poly_eval| {
                 acc.iter_mut().zip(poly_eval.iter()).for_each(|(a, b)| {
                     *a += *b;
                 });
@@ -538,6 +538,7 @@ fn sumcheck_round<E: FieldElement>(
                     vec![E::ZERO; num_periodic],
                     vec![E::ZERO; num_periodic],
                     vec![E::ZERO; num_periodic],
+                    vec![E::ZERO; evaluator.max_degree() - 1],
                     vec![E::ZERO; evaluator.get_num_fractions()],
                     vec![E::ZERO; evaluator.get_num_fractions()],
                     vec![E::ZERO; num_mls],
@@ -642,7 +643,7 @@ fn sumcheck_round<E: FieldElement>(
         )
         .map(|(.., poly_evals)| poly_evals)
         .reduce(
-            || vec![E::ZERO; evaluator.max_degree()],
+            || vec![E::ZERO; evaluator.max_degree() - 1],
             |mut acc, poly_eval| {
                 acc.iter_mut().zip(poly_eval.iter()).for_each(|(a, b)| {
                     *a += *b;

--- a/sumcheck/src/prover/mod.rs
+++ b/sumcheck/src/prover/mod.rs
@@ -4,10 +4,55 @@
 // LICENSE file in the root directory of this source tree.
 
 mod high_degree;
+use alloc::vec::Vec;
+
 pub use high_degree::sum_check_prove_higher_degree;
 
 mod plain;
+use math::{batch_inversion, FieldElement};
 pub use plain::sumcheck_prove_plain;
 
 mod error;
 pub use error::SumCheckProverError;
+
+use crate::{univariate::interpolate_equidistant_points, CompressedUnivariatePoly};
+
+fn compute_weight<E: FieldElement>(alpha: E, x: E) -> E {
+    x * alpha + (E::ONE - x) * (E::ONE - alpha)
+}
+
+fn to_coefficients<E: FieldElement>(
+    round_poly_evals: &mut [E],
+    claim: E,
+    alpha: E,
+    scaling_down_factor: E,
+    scaling_up_factor: E,
+) -> CompressedUnivariatePoly<E> {
+    let a = scaling_down_factor;
+    round_poly_evals.iter_mut().for_each(|e| *e *= scaling_up_factor);
+
+    let mut round_poly_evaluations = vec![];
+    round_poly_evaluations.push(round_poly_evals[0] * compute_weight(alpha, E::ZERO) * a);
+    round_poly_evaluations.push(claim - round_poly_evaluations[0]);
+
+    for (x, eval) in round_poly_evals.iter().skip(1).enumerate() {
+        round_poly_evaluations.push(*eval * compute_weight(alpha, E::from(x as u32 + 2)) * a)
+    }
+
+    let root = (E::ONE - alpha) / (E::ONE - alpha.double());
+
+    let round_poly_coefs_alt = interpolate_equidistant_points(&round_poly_evaluations, root);
+
+    round_poly_coefs_alt
+}
+
+fn compute_scaling_down_factors<E: FieldElement>(gkr_point: &[E]) -> Vec<E> {
+    let cumulative_product: Vec<E> = gkr_point
+        .iter()
+        .scan(E::ONE, |acc, &x| {
+            *acc = *acc * (E::ONE - x);
+            Some(*acc)
+        })
+        .collect();
+    batch_inversion(&cumulative_product)
+}

--- a/sumcheck/src/prover/mod.rs
+++ b/sumcheck/src/prover/mod.rs
@@ -15,7 +15,7 @@ pub use plain::sumcheck_prove_plain;
 mod error;
 pub use error::SumCheckProverError;
 
-use crate::{univariate::interpolate_equidistant_points, CompressedUnivariatePoly};
+use crate::CompressedUnivariatePoly;
 
 /// Takes the evaluation of the polynomial $v_{i+1}^{'}(X)$ defined by
 ///
@@ -23,7 +23,7 @@ use crate::{univariate::interpolate_equidistant_points, CompressedUnivariatePoly
 /// \left( x_{i+1}, \cdots x_{\nu - 1}   \right) \right)
 /// C\left(  r_0, \cdots, r_{i-1}, X, x_{i+1}, \cdots x_{\nu - 1}   \right)$$
 ///
-/// and computes the interpolation of the $v_{i+1}(X)$ defined by
+/// and computes the interpolation of the $v_{i+1}(X)$ polynomial defined by
 ///
 /// $$
 /// v_{i+1}(X) = v_{i+1}^{'}(X) \frac{Eq\left( \left(\alpha_0, \cdots, \alpha_{i - 1} \right);
@@ -52,7 +52,7 @@ fn to_coefficients<E: FieldElement>(
 
     let root = (E::ONE - alpha) / (E::ONE - alpha.double());
 
-    interpolate_equidistant_points(&round_poly_evaluations, root)
+    CompressedUnivariatePoly::interpolate_equidistant_points(&round_poly_evaluations, root)
 }
 
 /// Computes

--- a/sumcheck/src/prover/mod.rs
+++ b/sumcheck/src/prover/mod.rs
@@ -17,10 +17,21 @@ pub use error::SumCheckProverError;
 
 use crate::{univariate::interpolate_equidistant_points, CompressedUnivariatePoly};
 
-fn compute_weight<E: FieldElement>(alpha: E, x: E) -> E {
-    x * alpha + (E::ONE - x) * (E::ONE - alpha)
-}
-
+/// Takes the evaluation of the polynomial $v_{i+1}^{'}(X)$ defined by
+///
+/// $$v_{i+1}^{'}(X) =  \sum_{x} Eq\left( \left( \alpha_{i+1}, \cdots \alpha_{\nu - 1} \right);
+/// \left( x_{i+1}, \cdots x_{\nu - 1}   \right) \right)
+/// C\left(  r_0, \cdots, r_{i-1}, X, x_{i+1}, \cdots x_{\nu - 1}   \right)$$
+///
+/// and computes the interpolation of the $v_{i+1}(X)$ defined by
+///
+/// $$
+/// v_{i+1}(X) = v_{i+1}^{'}(X) \frac{Eq\left( \left(\alpha_0, \cdots, \alpha_{i - 1} \right);
+/// \left( r_0, \cdots, r_{i-1} \right) \right)}{Eq\left( \left( \alpha_{0}, \cdots, \alpha_{i} \right);
+/// \left(0, \cdots, 0\right) \right)} \cdot  Eq\left( \alpha_i ; X \right)
+/// $$
+///
+/// The function returns a `CompressedUnivariatePoly` instead of the full list of coefficients.
 fn to_coefficients<E: FieldElement>(
     round_poly_evals: &mut [E],
     claim: E,
@@ -31,7 +42,7 @@ fn to_coefficients<E: FieldElement>(
     let a = scaling_down_factor;
     round_poly_evals.iter_mut().for_each(|e| *e *= scaling_up_factor);
 
-    let mut round_poly_evaluations = vec![];
+    let mut round_poly_evaluations = Vec::with_capacity(round_poly_evals.len() + 1);
     round_poly_evaluations.push(round_poly_evals[0] * compute_weight(alpha, E::ZERO) * a);
     round_poly_evaluations.push(claim - round_poly_evaluations[0]);
 
@@ -41,18 +52,29 @@ fn to_coefficients<E: FieldElement>(
 
     let root = (E::ONE - alpha) / (E::ONE - alpha.double());
 
-    let round_poly_coefs_alt = interpolate_equidistant_points(&round_poly_evaluations, root);
-
-    round_poly_coefs_alt
+    interpolate_equidistant_points(&round_poly_evaluations, root)
 }
 
+/// Computes
+///
+/// $$
+/// Eq\left( \left( \alpha_{0}, \cdots, \alpha_{i} \right);
+/// \left(0, \cdots, 0\right) \right)
+/// $$
+///
+/// given $(\alpha_0, \cdots, \alpha_{\nu - 1})$ for all $i$ in $0, \cdots, \nu - 1$.
 fn compute_scaling_down_factors<E: FieldElement>(gkr_point: &[E]) -> Vec<E> {
     let cumulative_product: Vec<E> = gkr_point
         .iter()
         .scan(E::ONE, |acc, &x| {
-            *acc = *acc * (E::ONE - x);
+            *acc *= E::ONE - x;
             Some(*acc)
         })
         .collect();
     batch_inversion(&cumulative_product)
+}
+
+/// Computes $EQ(x; \alpha)$.
+fn compute_weight<E: FieldElement>(alpha: E, x: E) -> E {
+    x * alpha + (E::ONE - x) * (E::ONE - alpha)
 }

--- a/sumcheck/src/prover/plain.rs
+++ b/sumcheck/src/prover/plain.rs
@@ -100,8 +100,8 @@ use crate::{comb_func, FinalOpeningClaim, MultiLinearPoly, RoundProof, SumCheckP
 /// $$
 ///
 /// As the prover computes $v_{i+1}^{'}(X)$ in evaluation form and hence also $v_{i+1}(X)$, this
-/// means that due to the degrees being off by $1$, the prover uses we can use the linear factor
-/// in order to obtain an extra evaluation point in order to be able to interpolate $v_{i+1}(X)$.
+/// means that due to the degrees being off by $1$, the prover uses the linear factor in order to
+/// obtain an additional evaluation point in order to be able to interpolate $v_{i+1}(X)$.
 /// More precisely, we can get a root of $$v_{i+1}(X) = 0$$ by solving $$Eq\left( \alpha_i ; X \right) = 0$$
 /// The latter equation has as solution $$\mathsf{r} = \frac{1 - \alpha}{1 - 2\cdot\alpha}$$
 /// which is, except with negligible probability, an evaluation point not in the original
@@ -161,25 +161,25 @@ pub fn sumcheck_prove_plain<E: FieldElement, H: ElementHasher<BaseField = E::Bas
     let scaling_down_factors = compute_scaling_down_factors(gkr_point);
     let mut scaling_up_factor = E::ONE;
 
-    for l in 0..num_rounds {
+    for i in 0..num_rounds {
         let len = p0.num_evaluations() / 2;
 
         #[cfg(not(feature = "concurrent"))]
         let (round_poly_eval_at_0, round_poly_eval_at_2) =
-            (0..len).fold((E::ZERO, E::ZERO), |(acc_point_0, acc_point_2), i| {
-                let j = i << (l + 1);
+            (0..len).fold((E::ZERO, E::ZERO), |(acc_point_0, acc_point_2), k| {
+                let j = k << (i + 1);
                 let round_poly_eval_at_0 =
-                    comb_func(p0[2 * i], p1[2 * i], q0[2 * i], q1[2 * i], eq[j], r_batch);
+                    comb_func(p0[2 * k], p1[2 * k], q0[2 * k], q1[2 * k], eq[j], r_batch);
 
-                let p0_delta = p0[2 * i + 1] - p0[2 * i];
-                let p1_delta = p1[2 * i + 1] - p1[2 * i];
-                let q0_delta = q0[2 * i + 1] - q0[2 * i];
-                let q1_delta = q1[2 * i + 1] - q1[2 * i];
+                let p0_delta = p0[2 * k + 1] - p0[2 * k];
+                let p1_delta = p1[2 * k + 1] - p1[2 * k];
+                let q0_delta = q0[2 * k + 1] - q0[2 * k];
+                let q1_delta = q1[2 * k + 1] - q1[2 * k];
 
-                let p0_eval_at_x = p0[2 * i + 1] + p0_delta;
-                let p1_eval_at_x = p1[2 * i + 1] + p1_delta;
-                let q0_eval_at_x = q0[2 * i + 1] + q0_delta;
-                let q1_eval_at_x = q1[2 * i + 1] + q1_delta;
+                let p0_eval_at_x = p0[2 * k + 1] + p0_delta;
+                let p1_eval_at_x = p1[2 * k + 1] + p1_delta;
+                let q0_eval_at_x = q0[2 * k + 1] + q0_delta;
+                let q1_eval_at_x = q1[2 * k + 1] + q1_delta;
                 let round_poly_eval_at_2 = comb_func(
                     p0_eval_at_x,
                     p1_eval_at_x,
@@ -197,20 +197,20 @@ pub fn sumcheck_prove_plain<E: FieldElement, H: ElementHasher<BaseField = E::Bas
             .into_par_iter()
             .fold(
                 || (E::ZERO, E::ZERO),
-                |(a, b), i| {
-                    let j = i << (l + 1);
+                |(a, b), k| {
+                    let j = k << (i + 1);
                     let round_poly_eval_at_0 =
-                        comb_func(p0[2 * i], p1[2 * i], q0[2 * i], q1[2 * i], eq[j], r_batch);
+                        comb_func(p0[2 * k], p1[2 * k], q0[2 * k], q1[2 * k], eq[j], r_batch);
 
-                    let p0_delta = p0[2 * i + 1] - p0[2 * i];
-                    let p1_delta = p1[2 * i + 1] - p1[2 * i];
-                    let q0_delta = q0[2 * i + 1] - q0[2 * i];
-                    let q1_delta = q1[2 * i + 1] - q1[2 * i];
+                    let p0_delta = p0[2 * k + 1] - p0[2 * k];
+                    let p1_delta = p1[2 * k + 1] - p1[2 * k];
+                    let q0_delta = q0[2 * k + 1] - q0[2 * k];
+                    let q1_delta = q1[2 * k + 1] - q1[2 * k];
 
-                    let p0_eval_at_x = p0[2 * i + 1] + p0_delta;
-                    let p1_eval_at_x = p1[2 * i + 1] + p1_delta;
-                    let q0_eval_at_x = q0[2 * i + 1] + q0_delta;
-                    let q1_eval_at_x = q1[2 * i + 1] + q1_delta;
+                    let p0_eval_at_x = p0[2 * k + 1] + p0_delta;
+                    let p1_eval_at_x = p1[2 * k + 1] + p1_delta;
+                    let q0_eval_at_x = q0[2 * k + 1] + q0_delta;
+                    let q1_eval_at_x = q1[2 * k + 1] + q1_delta;
                     let round_poly_eval_at_2 = comb_func(
                         p0_eval_at_x,
                         p1_eval_at_x,
@@ -225,14 +225,12 @@ pub fn sumcheck_prove_plain<E: FieldElement, H: ElementHasher<BaseField = E::Bas
             )
             .reduce(|| (E::ZERO, E::ZERO), |(a0, b0), (a1, b1)| (a0 + a1, b0 + b1));
 
-        let alpha = gkr_point[l];
-        let scaling_down_factor = scaling_down_factors[l];
-
+        let alpha_i = gkr_point[i];
         let compressed_round_poly = to_coefficients(
             &mut [round_poly_eval_at_0, round_poly_eval_at_2],
             claim,
-            alpha,
-            scaling_down_factor,
+            alpha_i,
+            scaling_down_factors[i],
             scaling_up_factor,
         );
 
@@ -253,7 +251,7 @@ pub fn sumcheck_prove_plain<E: FieldElement, H: ElementHasher<BaseField = E::Bas
 
         // update the scaling up factor
         scaling_up_factor *=
-            round_challenge * alpha + (E::ONE - round_challenge) * (E::ONE - alpha);
+            round_challenge * alpha_i + (E::ONE - round_challenge) * (E::ONE - alpha_i);
 
         // compute the new reduced round claim
         claim = compressed_round_poly.evaluate_using_claim(&claim, &round_challenge);


### PR DESCRIPTION
Implements the optimization in Section 3.3 [here](https://eprint.iacr.org/2024/108).
Benchmarks show about 20% improvement in sum-check proving times.