### PR TITLE
feat(utils): Implement `get_size_hint` for default impls

### DIFF
--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -385,6 +385,10 @@ impl Serializable for BaseElement {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_bytes(&self.0.to_le_bytes());
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
 }
 
 impl Deserializable for BaseElement {

--- a/math/src/field/f62/mod.rs
+++ b/math/src/field/f62/mod.rs
@@ -512,6 +512,10 @@ impl Serializable for BaseElement {
         // convert from Montgomery representation into canonical representation
         target.write_bytes(&self.as_int().to_le_bytes());
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.as_int().get_size_hint()
+    }
 }
 
 impl Deserializable for BaseElement {

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -663,6 +663,10 @@ impl Serializable for BaseElement {
         // convert from Montgomery representation into canonical representation
         target.write_bytes(&self.as_int().to_le_bytes());
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.as_int().get_size_hint()
+    }
 }
 
 impl Deserializable for BaseElement {

--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -75,9 +75,9 @@ pub trait ByteWriter: Sized {
     /// # Panics
     /// Panics if the value could not be written into `self`.
     fn write_usize(&mut self, value: usize) {
-        let length = usize_encoded_len(value);
         // convert the value into a u64 so that we always get 8 bytes from to_le_bytes() call
         let value = value as u64;
+        let length = usize_encoded_len(value);
 
         // 9-byte special case
         if length == 9 {
@@ -142,8 +142,8 @@ impl ByteWriter for alloc::vec::Vec<u8> {
 // ================================================================================================
 
 /// Returns the length of the usize value in vint64 encoding.
-pub(super) fn usize_encoded_len(value: usize) -> usize {
-    let zeros = (value as u64).leading_zeros() as usize;
+pub(super) fn usize_encoded_len(value: u64) -> usize {
+    let zeros = value.leading_zeros() as usize;
     let len = zeros.saturating_sub(1) / 7;
     9 - core::cmp::min(len, 8)
 }

--- a/utils/core/src/serde/byte_writer.rs
+++ b/utils/core/src/serde/byte_writer.rs
@@ -75,9 +75,9 @@ pub trait ByteWriter: Sized {
     /// # Panics
     /// Panics if the value could not be written into `self`.
     fn write_usize(&mut self, value: usize) {
+        let length = usize_encoded_len(value);
         // convert the value into a u64 so that we always get 8 bytes from to_le_bytes() call
         let value = value as u64;
-        let length = encoded_len(value);
 
         // 9-byte special case
         if length == 9 {
@@ -141,9 +141,9 @@ impl ByteWriter for alloc::vec::Vec<u8> {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Returns the length of the value in vint64 encoding.
-fn encoded_len(value: u64) -> usize {
-    let zeros = value.leading_zeros() as usize;
+/// Returns the length of the usize value in vint64 encoding.
+pub(super) fn usize_encoded_len(value: usize) -> usize {
+    let zeros = (value as u64).leading_zeros() as usize;
     let len = zeros.saturating_sub(1) / 7;
     9 - core::cmp::min(len, 8)
 }

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -241,7 +241,7 @@ impl Serializable for usize {
     }
 
     fn get_size_hint(&self) -> usize {
-        byte_writer::usize_encoded_len(*self)
+        byte_writer::usize_encoded_len(*self as u64)
     }
 }
 

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -4,6 +4,10 @@
 // LICENSE file in the root directory of this source tree.
 
 use alloc::vec::Vec;
+use std::{
+    borrow::ToOwned,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use proptest::prelude::{any, proptest};
 
@@ -144,6 +148,94 @@ fn write_serializable_array_batch() {
     for i in 1u128..9 {
         assert_eq!(i, reader.read_u128().unwrap());
     }
+}
+
+// SIZE HINT
+// ================================================================================================
+
+fn size_hint_matches_serialized_len<S: Serializable>(value: S) {
+    let mut target = Vec::new();
+    let size_hint = value.get_size_hint();
+    target.write(value);
+    assert_eq!(target.len(), size_hint);
+}
+
+fn size_hint_matches_serialized_len_unsized<S: Serializable + ?Sized>(value: &S) {
+    let mut target = Vec::new();
+    let size_hint = value.get_size_hint();
+    value.write_into(&mut target);
+    assert_eq!(target.len(), size_hint);
+}
+
+#[test]
+fn size_hint_primitive_integers() {
+    size_hint_matches_serialized_len(0u8);
+    size_hint_matches_serialized_len(0u16);
+    size_hint_matches_serialized_len(0u32);
+    size_hint_matches_serialized_len(0u64);
+    size_hint_matches_serialized_len(0u128);
+    size_hint_matches_serialized_len(0usize);
+    size_hint_matches_serialized_len(u32::MAX as usize);
+    size_hint_matches_serialized_len(u64::MAX as usize);
+}
+
+#[test]
+fn size_hint_tuples() {
+    size_hint_matches_serialized_len((0u8,));
+    size_hint_matches_serialized_len((0u8, 0u16));
+    size_hint_matches_serialized_len((0u8, 0u16, 200u32));
+    size_hint_matches_serialized_len((0u8, 0u16, 200u32, 300u64));
+    size_hint_matches_serialized_len((0u8, 0u16, 200u32, 300u64));
+}
+
+#[test]
+fn size_hint_arrays_and_slices() {
+    size_hint_matches_serialized_len::<[u8; 0]>([]);
+    size_hint_matches_serialized_len([3u8; 1]);
+    size_hint_matches_serialized_len([50u32; 5]);
+
+    size_hint_matches_serialized_len_unsized::<[u8]>(&[]);
+    size_hint_matches_serialized_len_unsized::<[u8]>(&[0]);
+    size_hint_matches_serialized_len_unsized::<[u8]>(&[0, 1, 2, 3]);
+}
+
+#[test]
+fn size_hint_vector() {
+    size_hint_matches_serialized_len::<Vec<u8>>(vec![]);
+    size_hint_matches_serialized_len(vec![3u8; 1]);
+    size_hint_matches_serialized_len(vec![50u32; 5]);
+}
+
+#[test]
+fn size_hint_option() {
+    size_hint_matches_serialized_len(Option::<u16>::None);
+    size_hint_matches_serialized_len(Some(3u64));
+}
+
+#[test]
+fn size_hint_string() {
+    size_hint_matches_serialized_len("".to_owned());
+    size_hint_matches_serialized_len("test_string".to_owned());
+
+    size_hint_matches_serialized_len_unsized::<str>("");
+    size_hint_matches_serialized_len_unsized::<str>("test_str");
+}
+
+#[test]
+fn size_hint_btree() {
+    size_hint_matches_serialized_len(BTreeMap::<alloc::string::String, u64>::new());
+
+    let mut map = BTreeMap::new();
+    map.insert("key".to_owned(), "value".to_owned());
+    map.insert("key2".to_owned(), "value2".to_owned());
+    size_hint_matches_serialized_len(map);
+
+    size_hint_matches_serialized_len(BTreeSet::<alloc::string::String>::new());
+
+    let mut set = BTreeSet::new();
+    set.insert("value".to_owned());
+    set.insert("value2".to_owned());
+    size_hint_matches_serialized_len(set);
 }
 
 // UTILS - RANDOMIZED - UINT SERIALIZATION AND DESERIALIZATION

--- a/utils/core/src/tests.rs
+++ b/utils/core/src/tests.rs
@@ -3,10 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use alloc::vec::Vec;
-use std::{
+use alloc::{
     borrow::ToOwned,
     collections::{BTreeMap, BTreeSet},
+    vec::Vec,
 };
 
 use proptest::prelude::{any, proptest};


### PR DESCRIPTION
Implements `get_size_hint` for the types that are implemented by default.

Currently, crates that call `u8.get_size_hint()` get the default value of 0 which makes it harder to implement `get_size_hint` for custom types, since they cannot simply call `get_size_hint` on the contained types recursively. This PR fixes that.

This change is non-breaking.

See also https://github.com/0xPolygonMiden/miden-base/pull/895#pullrequestreview-2326556758 for more context.