### PR TITLE
use number of partitions for buffer allocation instead of partition size

### DIFF
--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -383,7 +383,11 @@ impl PartitionOptions {
             self.min_partition_size as usize,
         );
 
-        base_elements_per_partition.div(E::EXTENSION_DEGREE)
+        base_elements_per_partition.div_ceil(E::EXTENSION_DEGREE)
+    }
+
+    pub fn num_partitons(&self) -> usize {
+        self.num_partitions as usize
     }
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -555,11 +555,8 @@ pub trait Prover {
             log_domain_size = domain_size.ilog2()
         )
         .in_scope(|| {
-            let commitment = composed_evaluations.commit_to_rows::<Self::HashFn, Self::VC>(
-                self.options()
-                    .partition_options()
-                    .partition_size::<E>(num_constraint_composition_columns),
-            );
+            let commitment = composed_evaluations
+                .commit_to_rows::<Self::HashFn, Self::VC>(self.options().partition_options());
             ConstraintCommitment::new(composed_evaluations, commitment)
         });
 

--- a/prover/src/trace/trace_lde/default/mod.rs
+++ b/prover/src/trace/trace_lde/default/mod.rs
@@ -71,7 +71,7 @@ where
             build_trace_commitment::<E, E::BaseField, H, V>(
                 main_trace,
                 domain,
-                partition_options.partition_size::<E::BaseField>(main_trace.num_cols()),
+                partition_options,
             );
 
         let trace_poly_table = TracePolyTable::new(main_segment_polys);


### PR DESCRIPTION
Buffer allocation was too big when using partition size. Only "num partition" values would be filled, leaving everything else as 0.
This Changes the size to number of partitions.