### PR TITLE
Implement `core::error::Error` for all error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.2 (TBD)
+- Implement `core::error::Error` for error types (#341).
+
 ## 0.10.1 (2024-10-30)
 - Fixed partition hashing and add logging to aux trace building (#338).
 

--- a/air/src/errors.rs
+++ b/air/src/errors.rs
@@ -42,3 +42,5 @@ impl fmt::Display for AssertionError {
         }
     }
 }
+
+impl core::error::Error for AssertionError {}

--- a/crypto/src/errors.rs
+++ b/crypto/src/errors.rs
@@ -61,6 +61,8 @@ impl fmt::Display for MerkleTreeError {
     }
 }
 
+impl core::error::Error for MerkleTreeError {}
+
 // RANDOM COIN ERROR
 // ================================================================================================
 
@@ -89,3 +91,5 @@ impl fmt::Display for RandomCoinError {
         }
     }
 }
+
+impl core::error::Error for RandomCoinError {}

--- a/fri/src/errors.rs
+++ b/fri/src/errors.rs
@@ -73,3 +73,5 @@ impl fmt::Display for VerifierError {
         }
     }
 }
+
+impl core::error::Error for VerifierError {}

--- a/prover/src/errors.rs
+++ b/prover/src/errors.rs
@@ -39,3 +39,5 @@ impl fmt::Display for ProverError {
         }
     }
 }
+
+impl core::error::Error for ProverError {}

--- a/utils/core/src/errors.rs
+++ b/utils/core/src/errors.rs
@@ -32,3 +32,5 @@ impl fmt::Display for DeserializationError {
         }
     }
 }
+
+impl core::error::Error for DeserializationError {}

--- a/utils/core/src/serde/mod.rs
+++ b/utils/core/src/serde/mod.rs
@@ -344,7 +344,7 @@ impl Serializable for str {
     }
 
     fn get_size_hint(&self) -> usize {
-        self.len().get_size_hint() + self.as_bytes().len()
+        self.len().get_size_hint() + self.len()
     }
 }
 
@@ -355,7 +355,7 @@ impl Serializable for String {
     }
 
     fn get_size_hint(&self) -> usize {
-        self.len().get_size_hint() + self.as_bytes().len()
+        self.len().get_size_hint() + self.len()
     }
 }
 

--- a/verifier/src/errors.rs
+++ b/verifier/src/errors.rs
@@ -99,3 +99,5 @@ impl fmt::Display for VerifierError {
         }
     }
 }
+
+impl core::error::Error for VerifierError {}


### PR DESCRIPTION
Implements `core::error::Error` for all error types in a non-breaking way, which is why this targets `main`.

The motivation is to be able to wrap these errors in `Box<dyn Error>` and use them as `source` errors which requires the trait to be implemented. 

Also fixes a clippy lint introduced in a recent rust nightly version replacing `string.as_bytes().len()` with `string.len()`.