### PR TITLE
Fix typo

### DIFF
--- a/prover/README.md
+++ b/prover/README.md
@@ -9,7 +9,7 @@ To generate a proof that a computation was executed correctly, you will need to 
 1. Define *algebraic intermediate representation* (AIR) for your computation. This can be done by implementing `Air` trait (see [air crate](../air) for more info).
 2. Define an [execution trace](#Execution-trace) for your computation. This can be done by implementing `Trace` trait. Alternatively, you can use `TraceTable` struct which already implements `Trace` trait in cases when this generic implementation works for your use case.
 3. Execute your computation and record its execution trace.
-4. Define your prover(#Prover) by implementing `Prover` trait. Then execute `Prover::prove()` function passing the trace generated in the previous step into it as a parameter. The function will return a instance of `Proof`.
+4. Define your prover(#Prover) by implementing `Prover` trait. Then execute `Prover::prove()` function passing the trace generated in the previous step into it as a parameter. The function will return an instance of `Proof`.
 
 The resulting `Proof` object can be serialized and sent to a [verifier](../verifier) for verification. The size of proof depends on the specifics of a given computation, but for most computations it should be in the range between 15 KB (for very small computations) and 300 KB (for very large computations).
 


### PR DESCRIPTION
This pull request addresses a minor typo in the `prover/README.md` file:  
- Corrected the article "a" to "an" before the word "instance" to align with proper grammar rules for article usage.  

## Summary of Changes  
- Updated the following sentence:  
  > "The function will return a instance of `Proof`."  
  to:  
  > "The function will return an instance of `Proof`."

This change improves the readability and grammatical correctness of the documentation.  

## Checklist  
- [x] Grammar and spelling fixed.  
- [x] Documentation updated accordingly.  
- [x] Changes align with repository contribution guidelines.  
