### PR TITLE
Update options.rs

### DIFF
--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -292,9 +292,9 @@ impl Serializable for ProofOptions {
         target.write(self.field_extension);
         target.write_u8(self.fri_folding_factor);
         target.write_u8(self.fri_remainder_max_degree);
+        target.write(self.batching_deep);
         target.write_u8(self.partition_options.num_partitions);
         target.write_u8(self.partition_options.hash_rate);
-        target.write(self.batching_deep);
     }
 }
 


### PR DESCRIPTION
Fixed a bug in the serializer. It was writing the batching_deep variable in the wrong place, compared to the deserializer. Tested and seems to work.