### PR TITLE
fix: Proof de/serialization

### DIFF
--- a/air/src/proof/context.rs
+++ b/air/src/proof/context.rs
@@ -147,6 +147,7 @@ impl Serializable for Context {
         target.write_u8(self.field_modulus_bytes.len() as u8);
         target.write_bytes(&self.field_modulus_bytes);
         self.options.write_into(target);
+        target.write_usize(self.num_constraints);
     }
 }
 


### PR DESCRIPTION
Serialization of the `Proof` struct was failing due to a missing field in the `Context` serialization and because it was not writing the number of trace queries.