### PR TITLE
Absorb OOD evaluations only once into the transcript

### DIFF
--- a/air/src/proof/mod.rs
+++ b/air/src/proof/mod.rs
@@ -25,7 +25,7 @@ mod queries;
 pub use queries::Queries;
 
 mod ood_frame;
-pub use ood_frame::{OodFrame, QuotientOodFrame, TraceOodFrame};
+pub use ood_frame::{merge_ood_evaluations, OodFrame, QuotientOodFrame, TraceOodFrame};
 
 mod security;
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -397,10 +397,8 @@ pub trait Prover {
             // evaluate trace and constraint polynomials at the OOD point z and gz, where g is
             // the generator of the trace domain. and send the results to the verifier
             let ood_trace_states = trace_polys.get_ood_frame(z);
-            channel.send_ood_trace_states(&ood_trace_states);
-
             let ood_evaluations = composition_poly.get_ood_frame(z);
-            channel.send_ood_constraint_evaluations(&ood_evaluations);
+            channel.send_ood_evaluations(&ood_trace_states, &ood_evaluations);
 
             // draw random coefficients to use during DEEP polynomial composition, and use them to
             // initialize the DEEP composition polynomial


### PR DESCRIPTION
Merges the OOD evaluations of the trace and constraints composition polynomials into one vector which is absorbed into the transcript in one-go.