### PR TITLE
fix: replace ProofOptions panics with proper error handling

### DIFF
--- a/air/src/errors.rs
+++ b/air/src/errors.rs
@@ -44,3 +44,94 @@ impl fmt::Display for AssertionError {
 }
 
 impl core::error::Error for AssertionError {}
+
+// PROOF OPTIONS ERROR
+// ================================================================================================
+/// Represents an error returned during proof options validation.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProofOptionsError {
+    /// This error occurs when the number of queries is zero.
+    NumQueriesTooSmall,
+    /// This error occurs when the number of queries is greater than the maximum allowed.
+    NumQueriesTooLarge(usize, usize),
+    /// This error occurs when the blowup factor is not a power of two.
+    BlowupFactorNotPowerOfTwo(usize),
+    /// This error occurs when the blowup factor is smaller than the minimum allowed.
+    BlowupFactorTooSmall(usize, usize),
+    /// This error occurs when the blowup factor is greater than the maximum allowed.
+    BlowupFactorTooLarge(usize, usize),
+    /// This error occurs when the grinding factor is greater than the maximum allowed.
+    GrindingFactorTooLarge(u32, u32),
+    /// This error occurs when the FRI folding factor is not a power of two.
+    FriFoldingFactorNotPowerOfTwo(usize),
+    /// This error occurs when the FRI folding factor is smaller than the minimum allowed.
+    FriFoldingFactorTooSmall(usize, usize),
+    /// This error occurs when the FRI folding factor is greater than the maximum allowed.
+    FriFoldingFactorTooLarge(usize, usize),
+    /// This error occurs when the FRI remainder max degree is not one less than a power of two.
+    FriRemainderDegreeInvalid(usize),
+    /// This error occurs when the FRI remainder max degree is greater than the maximum allowed.
+    FriRemainderDegreeTooLarge(usize, usize),
+    /// This error occurs when the number of partitions is zero.
+    PartitionCountTooSmall,
+    /// This error occurs when the number of partitions is greater than the maximum allowed.
+    PartitionCountTooLarge(usize, usize),
+    /// This error occurs when the hash rate is zero.
+    HashRateTooSmall,
+    /// This error occurs when the hash rate is greater than the maximum allowed.
+    HashRateTooLarge(usize, usize),
+}
+
+impl fmt::Display for ProofOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NumQueriesTooSmall => {
+                write!(f, "number of queries must be greater than 0")
+            },
+            Self::NumQueriesTooLarge(value, max) => {
+                write!(f, "number of queries cannot be greater than {max}, but was {value}")
+            },
+            Self::BlowupFactorNotPowerOfTwo(value) => {
+                write!(f, "blowup factor must be a power of 2, but was {value}")
+            },
+            Self::BlowupFactorTooSmall(value, min) => {
+                write!(f, "blowup factor cannot be smaller than {min}, but was {value}")
+            },
+            Self::BlowupFactorTooLarge(value, max) => {
+                write!(f, "blowup factor cannot be greater than {max}, but was {value}")
+            },
+            Self::GrindingFactorTooLarge(value, max) => {
+                write!(f, "grinding factor cannot be greater than {max}, but was {value}")
+            },
+            Self::FriFoldingFactorNotPowerOfTwo(value) => {
+                write!(f, "FRI folding factor must be a power of 2, but was {value}")
+            },
+            Self::FriFoldingFactorTooSmall(value, min) => {
+                write!(f, "FRI folding factor cannot be smaller than {min}, but was {value}")
+            },
+            Self::FriFoldingFactorTooLarge(value, max) => {
+                write!(f, "FRI folding factor cannot be greater than {max}, but was {value}")
+            },
+            Self::FriRemainderDegreeInvalid(value) => {
+                write!(f, "FRI polynomial remainder degree must be one less than a power of two, but was {value}")
+            },
+            Self::FriRemainderDegreeTooLarge(value, max) => {
+                write!(f, "FRI polynomial remainder degree cannot be greater than {max}, but was {value}")
+            },
+            Self::PartitionCountTooSmall => {
+                write!(f, "number of partitions must be greater than 0")
+            },
+            Self::PartitionCountTooLarge(value, max) => {
+                write!(f, "number of partitions cannot be greater than {max}, but was {value}")
+            },
+            Self::HashRateTooSmall => {
+                write!(f, "hash rate must be greater than 0")
+            },
+            Self::HashRateTooLarge(value, max) => {
+                write!(f, "hash rate cannot be greater than {max}, but was {value}")
+            },
+        }
+    }
+}
+
+impl core::error::Error for ProofOptionsError {}

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -35,7 +35,7 @@ extern crate alloc;
 pub mod proof;
 
 mod errors;
-pub use errors::AssertionError;
+pub use errors::{AssertionError, ProofOptionsError};
 
 mod options;
 pub use options::{BatchingMethod, FieldExtension, PartitionOptions, ProofOptions};


### PR DESCRIPTION
Fixed TODO in ProofOptions::new() by implementing proper error handling instead of panicking on invalid parameters.

**Changes:**
- Add ProofOptionsError enum for descriptive validation errors  
- Add ProofOptions::try_new() method that returns Result<ProofOptions, ProofOptionsError>
- Add ProofOptions::try_with_partitions() for safe partition validation
- Deprecate old methods while maintaining backward compatibility
- Add comprehensive test coverage for all validation scenarios